### PR TITLE
Select specific arch nuttx file based on arch chip.

### DIFF
--- a/examples/slave/CMakeLists.txt
+++ b/examples/slave/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_subdirectory(nuttx/lan9252)
-add_subdirectory(nuttx/xmc4800)
+
+if (NUTTX_ARCH_CHIP STREQUAL "xmc4")
+    add_subdirectory(nuttx/xmc4800)
+endif()

--- a/lib/slave/CMakeLists.txt
+++ b/lib/slave/CMakeLists.txt
@@ -13,9 +13,14 @@ target_include_directories(kickcat PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include PR
 
 if (NUTTX)
   target_sources(kickcat PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/EEPROM/XMC4800EEPROM.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/driver/nuttx/src/SPI.cc
   )
+
+  if (NUTTX_ARCH_CHIP STREQUAL "xmc4")
+    target_sources(kickcat PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/EEPROM/XMC4800EEPROM.cc
+    )
+  endif()
 
   target_include_directories(kickcat PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/driver/nuttx/include PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}driver/nuttx/include/kickcat/nuttx)
 endif()


### PR DESCRIPTION
Filtering only on NuttX OS to build the slave lib is not enough. Some files are dependent on the chip arch.