### PR TITLE
Fix slave mailbox

### DIFF
--- a/examples/slave/nuttx/xmc4800/export_nuttx_archive.sh
+++ b/examples/slave/nuttx/xmc4800/export_nuttx_archive.sh
@@ -26,7 +26,7 @@ src=~/wdc_workspace/src/KickCAT
 
 bin=xmc4800_$project
 
-nuttx_version=nuttx-export-12.5.0-RC0
+nuttx_version=nuttx-export-12.5.0
 
 rm -f ${nuttx_src}/${nuttx_version}.tar.gz
 rm -rf ${build}/${nuttx_version}

--- a/lib/master/src/Prints.cc
+++ b/lib/master/src/Prints.cc
@@ -118,8 +118,8 @@ namespace kickcat
         switch (fmmu_type)
         {
             case 0:  {return "Unused";}
-            case 1:  {return "Outputs (Slave to Master)";}
-            case 2:  {return "Inputs  (Master to Slave)";}
+            case 1:  {return "Outputs (Master to Slave)";}
+            case 2:  {return "Inputs  (Slave to Master)";}
             case 3:  {return "SyncM Status (Read Mailbox)";}
             default: {return "Unused";}
         }

--- a/lib/src/protocol.cc
+++ b/lib/src/protocol.cc
@@ -270,8 +270,8 @@ namespace kickcat
             case SyncManagerType::Unused:     {return "Unused";    }
             case SyncManagerType::MailboxOut: {return "MailboxOut";}
             case SyncManagerType::MailboxIn: {return "MailboxIn" ;}
-            case SyncManagerType::Output:     {return "Output (Slave to Master)";    }
-            case SyncManagerType::Input:      {return "Input  (Master to Slave)";     }
+            case SyncManagerType::Output:     {return "Output (Master to Slave)";    }
+            case SyncManagerType::Input:      {return "Input  (Slave to Master)";     }
             default:                          {return "unknown";   }
         }
     }

--- a/simulation/network_simulator.cc
+++ b/simulation/network_simulator.cc
@@ -37,8 +37,8 @@ int main(int argc, char* argv[])
     std::vector<nanoseconds> stats;
     stats.reserve(1000);
 
-    auto const mbx_in_cfg  = SYNC_MANAGER_MBX_IN (0, 0x1000, 128);
-    auto const mbx_out_cfg = SYNC_MANAGER_MBX_OUT(1, 0x1400, 128);
+    auto const mbx_out_cfg  = SYNC_MANAGER_MBX_OUT (0, 0x1000, 128);
+    auto const mbx_in_cfg = SYNC_MANAGER_MBX_IN(1, 0x1400, 128);
     auto& esc0 = escs.at(0);
     mailbox::response::Mailbox mbx(&esc0, mbx_in_cfg, mbx_out_cfg);
     mbx.enableCoE();


### PR DESCRIPTION
**Check SyncManager before read the mailbox:** 
The slave application didn't to read the SyncManager register to check if there is something in the mailbox. I have added this part.

**Response mailbox SyncManager inversion:**
The mailbox in and out was inverted. I have also fix the network simulator to respect this inversion. 

**Response mailbox send function:**
The response mailbox send function didn't completely "respect" the inversion. I've applied the correct direction to the whole function. 

**Debug string direction inversion:**
In few debug prints there was also an inversion of direction (Master to slave/Slave To master). Fixed it. 

**Minor nuttx script fixed:**
The nuttx repo has tagged the nuttx-export-12.5.0-RC0 to nuttx-export-12.5.0. 
I have modifed the export_nuttx_archive.sh script to match with this change