### PR TITLE
Invert upload/download error response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build_slave/
 .cproject
 .settings/
 *.orig
+.cache/*
+compile_commands.json
+.clangd

--- a/lib/src/CoE/mailbox/response.cc
+++ b/lib/src/CoE/mailbox/response.cc
@@ -106,7 +106,7 @@ namespace kickcat::mailbox::response
     {
         if (not isUploadAuthorized(entry))
         {
-            abort(CoE::SDO::abort::READ_ONLY_ACCESS);
+            abort(CoE::SDO::abort::WRITE_ONLY_ACCESS);
             return ProcessingResult::FINALIZE;
         }
 
@@ -141,7 +141,7 @@ namespace kickcat::mailbox::response
             auto& entry = object->entries.at(i);
             if (not isUploadAuthorized(&entry))
             {
-                abort(CoE::SDO::abort::READ_ONLY_ACCESS);
+                abort(CoE::SDO::abort::WRITE_ONLY_ACCESS);
                 return ProcessingResult::FINALIZE;
             }
 
@@ -162,7 +162,7 @@ namespace kickcat::mailbox::response
     {
         if (not isDownloadAuthorized(entry))
         {
-            abort(CoE::SDO::abort::WRITE_ONLY_ACCESS);
+            abort(CoE::SDO::abort::READ_ONLY_ACCESS);
             return ProcessingResult::FINALIZE;
         }
 
@@ -215,7 +215,7 @@ namespace kickcat::mailbox::response
             auto& entry = object->entries.at(subindex);
             if (not isDownloadAuthorized(&entry))
             {
-                abort(CoE::SDO::abort::WRITE_ONLY_ACCESS);
+                abort(CoE::SDO::abort::READ_ONLY_ACCESS);
                 return ProcessingResult::FINALIZE;
             }
 


### PR DESCRIPTION
The error response when failing to do an upload or download was inverted.
upload = read from slave => So when it fails, it means that the SDO is in WRITE_ONLY
download = write to slave => So when it fails, it means that the SDO is in READ_ONLY