### PR TITLE
Fix Download response

### DIFF
--- a/lib/src/CoE/mailbox/response.cc
+++ b/lib/src/CoE/mailbox/response.cc
@@ -200,6 +200,7 @@ namespace kickcat::mailbox::response
         std::memcpy(entry->data, payload_, size);
 
         coe_->service = CoE::Service::SDO_RESPONSE;
+        sdo_->command = CoE::SDO::response::DOWNLOAD;
         reply(std::move(data_));
 
         afterHooks(CoE::Access::WRITE, entry);
@@ -251,6 +252,7 @@ namespace kickcat::mailbox::response
         }
 
         coe_->service = CoE::Service::SDO_RESPONSE;
+        sdo_->command = CoE::SDO::response::DOWNLOAD_SEGMENTED;
         reply(std::move(data_));
         return ProcessingResult::FINALIZE;
     }

--- a/lib/src/CoE/mailbox/response.cc
+++ b/lib/src/CoE/mailbox/response.cc
@@ -131,6 +131,7 @@ namespace kickcat::mailbox::response
 
         header_->len  = sizeof(mailbox::Header) + sizeof(CoE::ServiceData) + size;
         coe_->service = CoE::Service::SDO_RESPONSE;
+        sdo_->command = CoE::SDO::response::UPLOAD;
         reply(std::move(data_));
 
         afterHooks(CoE::Access::READ, entry);
@@ -166,6 +167,7 @@ namespace kickcat::mailbox::response
 
         header_->len  = sizeof(mailbox::Header) + sizeof(CoE::ServiceData) + size;
         coe_->service = CoE::Service::SDO_RESPONSE;
+        sdo_->command = CoE::SDO::response::UPLOAD_SEGMENTED;
         reply(std::move(data_));
         return ProcessingResult::FINALIZE;
     }


### PR DESCRIPTION
In the download response the command wasn't set (for download and segmented download). 

Tested for download, not for segmented download, but I'm no worry for this last one.

Edited : I actually also add the command se in the upload and segmented upload. I suppose it was working before because the request::UPLOAD and response::UPLOAD was both equal to 2, and that the slave stack has been used to do segmented upload. 