### PR TITLE
Fix coverage artifact path

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,13 +18,12 @@ jobs:
       - name: 'Download artifact'
         uses: actions/download-artifact@v4
         with:
-          path: build/coverage_xml.xml
           pattern: coverage
 
       - name: coverage
         uses: 5monkeys/cobertura-action@master
         with:
-            path: build/coverage_xml.xml
+            path: coverage_xml.xml
             minimum_coverage: 75
             show_line: true
             show_branch: true


### PR DESCRIPTION
Following workflow refactor, coverage artifact path was wrong but it was impossible to test the whole workflow without a first PR.