### PR TITLE
Refactor Mailbox Configuration

### DIFF
--- a/examples/slave/nuttx/lan9252/main.cc
+++ b/examples/slave/nuttx/lan9252/main.cc
@@ -30,11 +30,8 @@ int main(int argc, char *argv[])
         buffer_out[i] = 0xFF;
     }
 
-    SyncManagerConfig process_data_out = SYNC_MANAGER_PI_OUT(0, 0x1000, pdo_size); // Process data out (master view), address consistent with eeprom conf.
-    SyncManagerConfig process_data_in = SYNC_MANAGER_PI_IN(1, 0x1200, pdo_size); // Process data in (master view), address consistent with eeprom conf.
-
-    esc.set_process_data_input(buffer_in, process_data_in);
-    esc.set_process_data_output(buffer_out, process_data_out);
+    esc.set_process_data_input(buffer_in);
+    esc.set_process_data_output(buffer_out);
 
     esc.init();
 

--- a/examples/slave/nuttx/lan9252/main.cc
+++ b/examples/slave/nuttx/lan9252/main.cc
@@ -33,7 +33,6 @@ int main(int argc, char *argv[])
     SyncManagerConfig process_data_out = SYNC_MANAGER_PI_OUT(0, 0x1000, pdo_size); // Process data out (master view), address consistent with eeprom conf.
     SyncManagerConfig process_data_in = SYNC_MANAGER_PI_IN(1, 0x1200, pdo_size); // Process data in (master view), address consistent with eeprom conf.
 
-    esc.set_mailbox_config({{}});
     esc.set_process_data_input(buffer_in, process_data_in);
     esc.set_process_data_output(buffer_out, process_data_out);
 

--- a/examples/slave/nuttx/xmc4800/main_foot.cc
+++ b/examples/slave/nuttx/xmc4800/main_foot.cc
@@ -61,22 +61,13 @@ int main(int, char *[])
     foot::Input input_PDO;
     foot::Output output_PDO;
 
-    uint16_t in_pdo_size = sizeof(input_PDO);
-    uint16_t out_pdo_size = sizeof(output_PDO);
-
-    auto const mbx_out_cfg = SYNC_MANAGER_MBX_OUT(0, 0x1000, 128);
-    auto const mbx_in_cfg = SYNC_MANAGER_MBX_IN(1, 0x1400, 128);
-    mailbox::response::Mailbox mbx(&esc, mbx_in_cfg, mbx_out_cfg);
-
+    mailbox::response::Mailbox mbx(&esc, 1024);
     auto dictionary = CoE::createOD();
     mbx.enableCoE(std::move(dictionary));
 
-    SyncManagerConfig process_data_out = SYNC_MANAGER_PI_OUT(2, 0x1600, out_pdo_size); // Process data out (master view), address consistent with eeprom conf.
-    SyncManagerConfig process_data_in = SYNC_MANAGER_PI_IN(3, 0x1800, in_pdo_size);    // Process data in (master view), address consistent with eeprom conf.
-
     esc.set_mailbox(&mbx);
-    esc.set_process_data_input(reinterpret_cast<uint8_t *>(&input_PDO), process_data_in);
-    esc.set_process_data_output(reinterpret_cast<uint8_t *>(&output_PDO), process_data_out);
+    esc.set_process_data_input(reinterpret_cast<uint8_t *>(&input_PDO));
+    esc.set_process_data_output(reinterpret_cast<uint8_t *>(&output_PDO));
 
     uint8_t esc_config;
     esc.read(reg::ESC_CONFIG, &esc_config, sizeof(esc_config));

--- a/examples/slave/nuttx/xmc4800/main_foot.cc
+++ b/examples/slave/nuttx/xmc4800/main_foot.cc
@@ -74,7 +74,7 @@ int main(int, char *[])
     SyncManagerConfig process_data_out = SYNC_MANAGER_PI_OUT(2, 0x1600, out_pdo_size); // Process data out (master view), address consistent with eeprom conf.
     SyncManagerConfig process_data_in = SYNC_MANAGER_PI_IN(3, 0x1800, in_pdo_size);    // Process data in (master view), address consistent with eeprom conf.
 
-    esc.set_mailbox_config({{mbx_out_cfg, mbx_in_cfg}});
+    esc.set_mailbox(&mbx);
     esc.set_process_data_input(reinterpret_cast<uint8_t *>(&input_PDO), process_data_in);
     esc.set_process_data_output(reinterpret_cast<uint8_t *>(&output_PDO), process_data_out);
 

--- a/examples/slave/nuttx/xmc4800/main_relax.cc
+++ b/examples/slave/nuttx/xmc4800/main_relax.cc
@@ -32,11 +32,8 @@ int main(int, char *[])
         buffer_out[i] = 0xFF;
     }
 
-    SyncManagerConfig process_data_out = SYNC_MANAGER_PI_OUT(0, 0x1000, pdo_size); // Process data out (master view), address consistent with eeprom conf.
-    SyncManagerConfig process_data_in = SYNC_MANAGER_PI_IN(1, 0x1200, pdo_size); // Process data in (master view), address consistent with eeprom conf.
-
-    esc.set_process_data_input(buffer_in, process_data_in);
-    esc.set_process_data_output(buffer_out, process_data_out);
+    esc.set_process_data_input(buffer_in);
+    esc.set_process_data_output(buffer_out);
 
     uint8_t esc_config;
     esc.read(reg::ESC_CONFIG, &esc_config, sizeof(esc_config));

--- a/examples/slave/nuttx/xmc4800/main_relax.cc
+++ b/examples/slave/nuttx/xmc4800/main_relax.cc
@@ -35,7 +35,6 @@ int main(int, char *[])
     SyncManagerConfig process_data_out = SYNC_MANAGER_PI_OUT(0, 0x1000, pdo_size); // Process data out (master view), address consistent with eeprom conf.
     SyncManagerConfig process_data_in = SYNC_MANAGER_PI_IN(1, 0x1200, pdo_size); // Process data in (master view), address consistent with eeprom conf.
 
-    esc.set_mailbox_config({{}});
     esc.set_process_data_input(buffer_in, process_data_in);
     esc.set_process_data_output(buffer_out, process_data_out);
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -6,6 +6,7 @@ set(KICKCAT_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/Mailbox.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/protocol.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/TapSocket.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/SIIParser.cc
 
   ${CMAKE_CURRENT_SOURCE_DIR}/src/OS/Time.cc
 

--- a/lib/include/kickcat/Mailbox.h
+++ b/lib/include/kickcat/Mailbox.h
@@ -11,6 +11,11 @@
 #include "CoE/OD.h"
 
 
+namespace kickcat
+{
+    class AbstractESC;
+}
+
 namespace kickcat::mailbox
 {
     enum class ProcessingResult
@@ -163,16 +168,17 @@ namespace kickcat::mailbox::response
     {
         friend class AbstractMessage;
     public:
-        /// \param max_msgs Max messages allowed simultaneously in the processing queue
-        Mailbox(AbstractESC* esc, SyncManagerConfig mbx_in, SyncManagerConfig mbx_out, uint16_t max_msgs = 1);
+        Mailbox(AbstractESC* esc, uint16_t max_allocated_ram_by_msg, uint16_t max_msgs = 1);
         ~Mailbox() = default;
 
         void enableCoE(CoE::Dictionary&& dictionary);
         CoE::Dictionary& getDictionary(){return dictionary_;}
 
-        void receive(); // Try to receive a message from the ESC
-        void process(); // Process a message in the to_process_ queue if any
-        void send();    // Send a message in the to_send_ queue if any, keep it in the queue if the ESC is not ready yet
+        std::tuple<SyncManagerConfig, SyncManagerConfig> configureSm();
+
+        void receive();  // Try to receive a message from the ESC
+        void process();  // Process a message in the to_process_ queue if any
+        void send();  // Send a message in the to_send_ queue if any, keep it in the queue if the ESC is not ready yet
 
     private:
         void replyError(std::vector<uint8_t>&& raw_message, uint16_t code);
@@ -180,6 +186,7 @@ namespace kickcat::mailbox::response
         AbstractESC* esc_;
         SyncManagerConfig mbx_in_;
         SyncManagerConfig mbx_out_;
+        uint16_t max_allocated_ram_by_msg_;
         uint16_t max_msgs_;
 
         // session handle, from 1 to 7, it is used to detect duplicate frame

--- a/lib/include/kickcat/debug.h
+++ b/lib/include/kickcat/debug.h
@@ -145,6 +145,25 @@ namespace kickcat
 #endif
 
 
+#ifdef DEBUG_ESI_ERROR
+    #define esi_error   _error
+#else
+    #define esi_error   _none
+#endif
+
+#ifdef DEBUG_ESI_WARNING
+    #define esi_warning _warning
+#else
+    #define esi_warning _none
+#endif
+
+#ifdef DEBUG_ESI_INFO
+    #define esi_info    _info
+#else
+    #define esi_info    _none
+#endif
+
+
 }
 
 #endif

--- a/lib/include/kickcat/protocol.h
+++ b/lib/include/kickcat/protocol.h
@@ -351,6 +351,23 @@ namespace kickcat
         uint8_t  pdi_control;
     } __attribute__((__packed__));
 
+    
+    constexpr uint8_t SM_CONTROL_MODE_MASK = 0x03;
+    constexpr uint8_t SM_CONTROL_MODE_BUFFERED = 0x00;
+    constexpr uint8_t SM_CONTROL_MODE_MAILBOX = 0x02;
+    constexpr uint8_t SM_CONTROL_DIRECTION_MASK = 0x0C;
+    constexpr uint8_t SM_CONTROL_DIRECTION_READ = 0x00; // ECAT read access, PDI write access
+    constexpr uint8_t SM_CONTROL_DIRECTION_WRITE = 0x04; // ECAT write access, PDI read access
+    constexpr uint8_t SM_CONTROL_INTERRUPT_ECAT_MASK = 0x10; 
+    constexpr uint8_t SM_CONTROL_INTERRUPT_ECAT_DISABLED = 0x00; 
+    constexpr uint8_t SM_CONTROL_INTERRUPT_ECAT_ENABLED = 0x10; 
+    constexpr uint8_t SM_CONTROL_INTERRUPT_AL_MASK = 0x20; 
+    constexpr uint8_t SM_CONTROL_INTERRUPT_AL_DISABLED = 0x00; 
+    constexpr uint8_t SM_CONTROL_INTERRUPT_AL_ENABLED = 0x20; 
+    constexpr uint8_t SM_CONTROL_WATCHDOG_MASK = 0x40; 
+    constexpr uint8_t SM_CONTROL_WATCHDOG_DISABLED = 0x00; 
+    constexpr uint8_t SM_CONTROL_WATCHDOG_ENABLED = 0x40; 
+
     enum SyncManagerType
     {
         Unused     = 0,

--- a/lib/master/include/kickcat/SIIParser.h
+++ b/lib/master/include/kickcat/SIIParser.h
@@ -1,0 +1,50 @@
+#ifndef KICKCAT_SII_PARSER_H
+#define KICKCAT_SII_PARSER_H
+
+#include <vector>
+#include "kickcat/protocol.h"
+
+namespace kickcat::eeprom
+{
+    // see ETG2010_S_R_V1.0.1 SII Specification
+    struct SII
+    {
+        std::vector<uint32_t> eeprom;
+
+        // Identity
+        uint32_t vendor_id;
+        uint32_t product_code;
+        uint32_t revision_number;
+        uint32_t serial_number;
+
+        // Bootstrap Mailbox
+        uint16_t mailboxBootstrap_recv_offset;
+        uint16_t mailboxBootstrap_recv_size;
+        uint16_t mailboxBootstrap_send_offset;
+        uint16_t mailboxBootstrap_send_size;
+
+        // Mailbox
+        uint16_t mailbox_recv_offset;
+        uint16_t mailbox_recv_size;
+        uint16_t mailbox_send_offset;
+        uint16_t mailbox_send_size;
+        eeprom::MailboxProtocol supported_mailbox;
+
+        // Size
+        uint32_t eeprom_size;  // in bytes
+        uint16_t eeprom_version;
+
+        // Categories
+        std::vector<std::string_view> strings;
+        eeprom::GeneralEntry const* general;
+        std::vector<uint8_t> fmmus;
+        std::vector<eeprom::SyncManagerEntry const*> syncManagers;
+        std::vector<eeprom::PDOEntry const*> TxPDO;
+        std::vector<eeprom::PDOEntry const*> RxPDO;
+
+        void parse();
+    };
+}
+
+#endif
+

--- a/lib/master/include/kickcat/Slave.h
+++ b/lib/master/include/kickcat/Slave.h
@@ -1,12 +1,13 @@
 #ifndef KICKCAT_SLAVE_H
 #define KICKCAT_SLAVE_H
 
-#include <vector>
-#include <string_view>
 #include <sstream>
+#include <string_view>
+#include <vector>
 
-#include "kickcat/protocol.h"
 #include "kickcat/Mailbox.h"
+#include "kickcat/SIIParser.h"
+#include "kickcat/protocol.h"
 
 namespace kickcat
 {
@@ -30,58 +31,32 @@ namespace kickcat
         uint8_t al_status{State::INVALID};
         uint16_t al_status_code;
 
-        uint32_t vendor_id;
-        uint32_t product_code;
-        uint32_t revision_number;
-        uint32_t serial_number;
-
         mailbox::request::Mailbox mailbox;
         mailbox::request::Mailbox mailbox_bootstrap;
-        eeprom::MailboxProtocol supported_mailbox;
-        int32_t waiting_datagram; // how many datagram to process for this slave
-
-        uint32_t eeprom_size; // in bytes
-        uint16_t eeprom_version;
+        int32_t waiting_datagram;  // how many datagram to process for this slave
 
         DLStatus dl_status;
 
-        struct SII
-        {
-            std::vector<uint32_t> buffer;
-            std::vector<std::string_view> strings;
-            eeprom::GeneralEntry const* general;
-            std::vector<uint8_t> fmmus;
-            std::vector<eeprom::SyncManagerEntry const*> syncManagers;
-            std::vector<eeprom::PDOEntry const*> RxPDO;
-            std::vector<eeprom::PDOEntry const*> TxPDO;
-
-        };
-        SII sii{};
+        eeprom::SII sii{};
 
         struct PIMapping
         {
-            uint8_t* data;          // buffer client to read or write back
-            int32_t size;           // size fo the mapping (in bits)
-            int32_t bsize;          // size of the mapping (in bytes)
-            int32_t sync_manager;   // associated Sync manager
-            uint32_t address;       // logical address
+            uint8_t* data;         // buffer client to read or write back
+            int32_t size;          // size fo the mapping (in bits)
+            int32_t bsize;         // size of the mapping (in bytes)
+            int32_t sync_manager;  // associated Sync manager
+            uint32_t address;      // logical address
         };
         // set it to true to let user define the mapping, false to autodetect it
         // If set to true, user shall set input and output mapping bsize and sync_manager members.
         bool is_static_mapping;
-        PIMapping input;            // slave to master
+        PIMapping input;  // slave to master
         PIMapping output;
 
         ErrorCounters error_counters;
         int previous_errors_sum{0};
 
         ESCDescription esc;
-
-    private:
-        void parseStrings(uint8_t const* section_start);
-        void parseFMMU(uint8_t const* section_start, uint16_t section_size);
-        void parseSyncM(uint8_t const* section_start, uint16_t section_size);
-        void parsePDO(uint8_t const* section_start, std::vector<eeprom::PDOEntry const*>& pdo);
     };
 
 }

--- a/lib/master/src/Bus.cc
+++ b/lib/master/src/Bus.cc
@@ -108,7 +108,7 @@ namespace kickcat
         // create CoE emergency reception callback
         for (auto& slave : slaves_)
         {
-            if (slave.supported_mailbox & eeprom::MailboxProtocol::CoE)
+            if (slave.sii.supported_mailbox & eeprom::MailboxProtocol::CoE)
             {
                 auto emg = std::make_shared<mailbox::request::EmergencyMessage>(slave.mailbox);
                 slave.mailbox.to_process.push_back(emg);
@@ -327,7 +327,7 @@ namespace kickcat
 
         for (auto& slave : slaves_)
         {
-            if (slave.supported_mailbox)
+            if (slave.sii.supported_mailbox)
             {
                 SyncManager SM[2];
                 slave.mailbox.generateSMConfig(SM);
@@ -362,7 +362,7 @@ namespace kickcat
                 continue;
             }
 
-            if (slave.supported_mailbox & eeprom::MailboxProtocol::CoE)
+            if (slave.sii.supported_mailbox& eeprom::MailboxProtocol::CoE)
             {
                 // Slave support CAN over EtherCAT -> use mailbox/SDO to get mapping size
                 uint8_t sm[512];
@@ -801,7 +801,7 @@ namespace kickcat
             readEeprom(static_cast<uint16_t>(pos), slaves,
             [](Slave& s, uint32_t word)
             {
-                s.sii.buffer.push_back(word);
+                s.sii.eeprom.push_back(word);
             });
 
             pos += 2;
@@ -810,9 +810,9 @@ namespace kickcat
             [](Slave* s)
             {
                 // First section (64 words == 32 double words) may have bytes with the eeprom::Category::End value
-                return ((((s->sii.buffer.back() >> 16) == eeprom::Category::End) or
-                         ((s->sii.buffer.back() & eeprom::Category::End) == eeprom::Category::End)) and
-                          (s->sii.buffer.size() > 32));
+                return ((((s->sii.eeprom.back() >> 16) == eeprom::Category::End) or
+                         ((s->sii.eeprom.back() & eeprom::Category::End) == eeprom::Category::End)) and
+                          (s->sii.eeprom.size() > 32));
             }),
             slaves.end());
         }
@@ -933,7 +933,7 @@ namespace kickcat
                 return DatagramState::OK;
             };
 
-            if (slave.supported_mailbox == 0)
+            if (slave.sii.supported_mailbox == 0)
             {
                 continue;
             }
@@ -961,7 +961,7 @@ namespace kickcat
                 return DatagramState::OK;
             };
 
-            if (slave.supported_mailbox == 0)
+            if (slave.sii.supported_mailbox == 0)
             {
                 continue;
             }

--- a/lib/master/src/Prints.cc
+++ b/lib/master/src/Prints.cc
@@ -8,10 +8,10 @@ namespace kickcat
     {
         std::stringstream os;
         os << "\n -*-*-*-*- slave " << std::to_string(slave.address) << " -*-*-*-*-\n";
-        os << "Vendor ID:       " << "0x" << std::setfill('0') << std::setw(8) << std::hex << slave.vendor_id << "\n";
-        os << "Product code:    " << "0x" << std::setfill('0') << std::setw(8) << std::hex << slave.product_code << "\n";
-        os << "Revision number: " << "0x" << std::setfill('0') << std::setw(8) << std::hex << slave.revision_number << "\n";
-        os << "Serial number:   " << "0x" << std::setfill('0') << std::setw(8) << std::hex << slave.serial_number << "\n";
+        os << "Vendor ID:       " << "0x" << std::setfill('0') << std::setw(8) << std::hex << slave.sii.vendor_id << "\n";
+        os << "Product code:    " << "0x" << std::setfill('0') << std::setw(8) << std::hex << slave.sii.product_code << "\n";
+        os << "Revision number: " << "0x" << std::setfill('0') << std::setw(8) << std::hex << slave.sii.revision_number << "\n";
+        os << "Serial number:   " << "0x" << std::setfill('0') << std::setw(8) << std::hex << slave.sii.serial_number << "\n";
         os << "mailbox in:  size " << std::dec << slave.mailbox.recv_size << " - offset " << "0x" << std::setfill('0')
             << std::setw(4) << std::hex << slave.mailbox.recv_offset << "\n";
 
@@ -19,12 +19,12 @@ namespace kickcat
             << std::setw(4) << std::hex << slave.mailbox.send_offset << "\n";
 
         os << "supported mailbox protocol: " << "0x" << std::setfill('0') << std::setw(2)
-            << std::hex << slave.supported_mailbox << "\n";
+            << std::hex << slave.sii.supported_mailbox<< "\n";
 
-        os << "EEPROM: size: " << std::dec << slave.eeprom_size << " - version "<< "0x" << std::setfill('0')
-            << std::setw(2) << std::hex << slave.eeprom_version << "\n";
+        os << "EEPROM: size: " << std::dec << slave.sii.eeprom_size << " - version "<< "0x" << std::setfill('0')
+            << std::setw(2) << std::hex << slave.sii.eeprom_version << "\n";
 
-        os << "\nSII size: " << std::dec << slave.sii.buffer.size() * sizeof(uint32_t) << "\n";
+        os << "\nSII size: " << std::dec << slave.sii.eeprom_size * sizeof(uint32_t) << "\n";
 
         for (size_t i = 0; i < slave.sii.fmmus.size(); ++i)
         {

--- a/lib/master/src/Slave.cc
+++ b/lib/master/src/Slave.cc
@@ -6,173 +6,20 @@
 
 namespace kickcat
 {
-    void Slave::parseStrings(uint8_t const* section_start)
-    {
-        sii.strings.push_back(std::string_view()); // index 0 is an empty string
-        uint8_t const* pos = section_start;
-
-        uint8_t number_of_strings = *pos;
-        pos += 1;
-
-        for (int32_t i = 0; i < number_of_strings; ++i)
-        {
-            uint8_t len = *pos;
-            pos += 1;
-
-            sii.strings.push_back(std::string_view(reinterpret_cast<char const*>(pos), len));
-            pos += len;
-        }
-    }
-
-    void Slave::parseFMMU(uint8_t const* section_start, uint16_t section_size)
-    {
-        for (int32_t i = 0; i < section_size; ++i)
-        {
-            sii.fmmus.push_back(*(section_start + i));
-        }
-    }
-
-    void Slave::parseSyncM(uint8_t const* section_start, uint16_t section_size)
-    {
-        uint8_t const* pos = section_start;
-        uint8_t const* end = section_start + section_size;
-
-        while (pos < end)
-        {
-            sii.syncManagers.push_back(reinterpret_cast<eeprom::SyncManagerEntry const*>(pos));
-            pos += sizeof(eeprom::SyncManagerEntry);
-        }
-    }
-
-    void Slave::parsePDO(uint8_t const* section_start, std::vector<eeprom::PDOEntry const*>& pdo)
-    {
-        uint8_t const* pos = section_start;
-
-        //uint16_t index = *reinterpret_cast<uint16_t const*>(pos); // not used yet
-        pos += 2;
-
-        uint8_t number_of_entries = *pos;
-        pos += 1;
-
-        //uint8_t sync_manager = *pos; // not used yet
-        pos +=1;
-
-        //uint8_t synchronization = *pos; // not use yet
-        pos += 1;
-
-        //uint8_t name_index = *pos; // not used yet
-        pos += 1;
-
-        // flags (word) - unused
-        pos += 2;
-
-        for (int32_t i = 0; i < number_of_entries; ++i)
-        {
-            pdo.push_back(reinterpret_cast<eeprom::PDOEntry const*>(pos));
-            pos += sizeof(eeprom::PDOEntry);
-        }
-    }
 
     void Slave::parseSII()
     {
-        uint32_t temp_word = 0;
+        sii.parse();
 
-        // Identity
-        vendor_id       = sii.buffer.at(eeprom::VENDOR_ID       / sizeof(uint16_t));
-        product_code    = sii.buffer.at(eeprom::PRODUCT_CODE    / sizeof(uint16_t));
-        revision_number = sii.buffer.at(eeprom::REVISION_NUMBER / sizeof(uint16_t));
-        serial_number   = sii.buffer.at(eeprom::SERIAL_NUMBER   / sizeof(uint16_t));
-
-        // Mailbox info
-        temp_word = sii.buffer.at((eeprom::BOOTSTRAP_MAILBOX  + eeprom::RECV_MBO_OFFSET) / sizeof(uint16_t));
-        mailbox_bootstrap.recv_offset = static_cast<uint16_t>(temp_word);
-        mailbox_bootstrap.recv_size   = static_cast<uint16_t>(temp_word >> 16);
-
-        temp_word = sii.buffer.at((eeprom::BOOTSTRAP_MAILBOX  + eeprom::SEND_MBO_OFFSET) / sizeof(uint16_t));
-        mailbox_bootstrap.send_offset = static_cast<uint16_t>(temp_word);
-        mailbox_bootstrap.send_size   = static_cast<uint16_t>(temp_word >> 16);
-
-        temp_word = sii.buffer.at((eeprom::STANDARD_MAILBOX  + eeprom::RECV_MBO_OFFSET) / sizeof(uint16_t));
-        mailbox.recv_offset = static_cast<uint16_t>(temp_word);
-        mailbox.recv_size   = static_cast<uint16_t>(temp_word >> 16);
-
-        temp_word = sii.buffer.at((eeprom::STANDARD_MAILBOX  + eeprom::SEND_MBO_OFFSET) / sizeof(uint16_t));
-        mailbox.send_offset = static_cast<uint16_t>(temp_word);
-        mailbox.send_size   = static_cast<uint16_t>(temp_word >> 16);
-
-        temp_word = sii.buffer.at(eeprom::MAILBOX_PROTOCOL / sizeof(uint16_t));
-        supported_mailbox = static_cast<eeprom::MailboxProtocol>(temp_word);
-
-        // EEPROM
-        temp_word = sii.buffer.at(eeprom::EEPROM_SIZE / sizeof(uint16_t));
-        eeprom_size = (temp_word & 0xFF) + 1;   // 0 means 1024 bits
-        eeprom_size *= 128;                     // Kibit to bytes
-        eeprom_version = static_cast<uint16_t>(temp_word >> 16);
-
-        // Categories
-        uint8_t const* pos = reinterpret_cast<uint8_t*>(sii.buffer.data()) + eeprom::START_CATEGORY * 2;
-        uint8_t const* const max_pos = reinterpret_cast<uint8_t*>(sii.buffer.data() + sii.buffer.size() - 4);
-        while (pos < max_pos)
-        {
-            uint16_t const* category = reinterpret_cast<uint16_t const*>(pos);
-            uint16_t category_size = *(category + 1) * sizeof(uint16_t);
-            uint8_t const*  category_data = pos + 4;
-            pos += (4 + category_size);
-
-            switch (*category)
-            {
-                case eeprom::Category::Strings:
-                {
-                    parseStrings(category_data);
-                    break;
-                }
-                case eeprom::Category::DataTypes:
-                {
-                    slave_warning("DataTypes section: parsing not implemented\n");
-                    break;
-                }
-                case eeprom::Category::General:
-                {
-                    sii.general = reinterpret_cast<eeprom::GeneralEntry const*>(category_data);
-                    break;
-                }
-                case eeprom::Category::FMMU:
-                {
-                    parseFMMU(category_data, category_size);
-                    break;
-                }
-                case eeprom::Category::SyncM:
-                {
-                    parseSyncM(category_data, category_size);
-                    break;
-                }
-                case eeprom::Category::TxPDO:
-                {
-                    parsePDO(category_data, sii.TxPDO);
-                    break;
-                }
-                case eeprom::Category::RxPDO:
-                {
-                    parsePDO(category_data, sii.RxPDO);
-                    break;
-                }
-                case eeprom::Category::DC:
-                {
-                    slave_warning("DC section: parsing not implemented\n");
-                    break;
-                }
-                case eeprom::Category::End:
-                {
-                    break;
-                }
-                default:
-                {
-
-                }
-            }
-        };
+        mailbox.recv_offset = sii.mailbox_recv_offset;
+        mailbox.recv_size = sii.mailbox_recv_size;
+        mailbox.send_offset= sii.mailbox_send_offset;
+        mailbox.send_size= sii.mailbox_send_size;
+        mailbox_bootstrap.recv_offset = sii.mailboxBootstrap_recv_offset;
+        mailbox_bootstrap.recv_size = sii.mailboxBootstrap_recv_size;
+        mailbox_bootstrap.send_offset= sii.mailboxBootstrap_send_offset;
+        mailbox_bootstrap.send_size= sii.mailboxBootstrap_send_size;
     }
-
 
     ErrorCounters const& Slave::errorCounters() const
     {

--- a/lib/slave/include/kickcat/AbstractESC.h
+++ b/lib/slave/include/kickcat/AbstractESC.h
@@ -2,7 +2,6 @@
 #define SLAVE_STACK_INCLUDE_ABSTRACTESC_H_
 
 #include <cstdint>
-#include <memory>
 #include <vector>
 
 #include "kickcat/protocol.h"
@@ -30,22 +29,30 @@ namespace kickcat
     #define SYNC_MANAGER_MBX_OUT(index, address, length) SyncManagerConfig{index, address, length, 0x06, SyncManagerType::MailboxOut}
 
 
+    namespace mailbox::response
+    {
+        class Mailbox;
+    }
+
     // Regarding the state machine, see ETG1000.6 6.4.1 AL state machine
     class AbstractESC
     {
     public:
         virtual ~AbstractESC() = default;
 
-        virtual hresult init() = 0;
-        virtual int32_t read(uint16_t address, void* data, uint16_t size) = 0;
+        virtual hresult init()                                                   = 0;
+        virtual int32_t read(uint16_t address, void* data, uint16_t size)        = 0;
         virtual int32_t write(uint16_t address, void const* data, uint16_t size) = 0;
 
         void routine();
 
-        void set_mailbox_config(std::vector<SyncManagerConfig> const& mailbox);
-        void set_process_data_input(uint8_t* buffer, SyncManagerConfig const& config);
-        void set_process_data_output(uint8_t* buffer, SyncManagerConfig const& config);
+
+        // Mailbox that the ESC will try to configure before passing to preop
+        void set_mailbox(mailbox::response::Mailbox* mailbox);
+        void set_process_data_input(uint8_t* buffer);
+        void set_process_data_output(uint8_t* buffer);
         void set_valid_output_data_received(bool are_valid_output);
+        std::tuple<uint8_t, SyncManager> find_sm(uint16_t controlMode);
 
         void routine_init();
         void routine_preop();
@@ -60,20 +67,19 @@ namespace kickcat
         bool has_expired_watchdog() { return not (watchdog_ & 0x1); }
 
     private:
+        bool configure_pdo_sm();
+
         void update_process_data_input();
         void update_process_data_output();
 
         bool is_valid_sm(SyncManagerConfig const& sm_ref);
         bool are_valid_sm(std::vector<SyncManagerConfig> const& sm);
-        void set_sm_activate(SyncManagerConfig const& sm_ref, bool is_activated);
+        void set_sm_activate(std::vector<SyncManagerConfig> const& sync_managers, bool is_activated);
 
         void set_error(StatusCode code);
 
         /// \brief Set only the state, preserve the other fields.
         void set_al_status(State state);
-
-        std::vector<SyncManagerConfig> sm_mailbox_configs_ = {};
-        std::vector<SyncManagerConfig> sm_process_data_configs_ = {};
 
         StatusCode al_status_code_ = {StatusCode::NO_ERROR};
         uint16_t al_status_ = {0};
@@ -87,7 +93,12 @@ namespace kickcat
         uint8_t* process_data_output_ = {nullptr};
         SyncManagerConfig sm_pd_output_ = {};
 
+        SyncManagerConfig sm_mbx_input_  = {};
+        SyncManagerConfig sm_mbx_output_ = {};
+
         bool are_valid_output_data_ = false;
+
+        mailbox::response::Mailbox* mbx_;
     };
 
 }

--- a/lib/slave/src/ESC/EmulatedESC.cc
+++ b/lib/slave/src/ESC/EmulatedESC.cc
@@ -20,9 +20,6 @@ namespace kickcat
         memory_.port_desc       = 0x0f;     // 2 ports (0, 1), MII
         memory_.esc_features    = 0x01cc;
 
-        // Device emulation is ON
-        memory_.esc_configuration = 0x01;
-
         // Default value is 'Request INIT State'
         memory_.al_control = State::INIT;
 
@@ -44,6 +41,9 @@ namespace kickcat
         eeprom_.resize(size / 2); // vector of uint16_t so / 2 since the size is in byte
         eeprom_file.read((char*)eeprom_.data(), size);
         eeprom_file.close();
+
+        // Device emulation
+        memory_.esc_configuration = eeprom_[0] >> 8;
 
         memory_.station_alias = eeprom_[4]; // fourth word of eeprom, at first load
     }
@@ -352,7 +352,10 @@ namespace kickcat
         }
 
         // Mirror AL_STATUS - Device Emulation
-        memory_.al_status = memory_.al_control;
+        if(memory_.esc_configuration & 0x01)
+        {
+            memory_.al_status = memory_.al_control;
+        }
 
         // Handle eeprom access
         uint16_t order = memory_.eeprom_control & 0x0701;

--- a/lib/src/CoE/EsiParser.cc
+++ b/lib/src/CoE/EsiParser.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <stdexcept>
+#include "kickcat/debug.h"
 
 #include "kickcat/CoE/EsiParser.h"
 
@@ -159,8 +160,7 @@ namespace kickcat::CoE
 
         if (data.size() != (entry.bitlen / 8))
         {
-            // throw ?
-            printf("Cannot load default data for 0x%04x.%d, expected size mismatch.\n"
+            esi_warning("Cannot load default data for 0x%04x.%d, expected size mismatch.\n"
                     "-> Got %ld bits, expected: %d bit\n"
                     "==> Skipping entry\n",
                 obj.index, entry.subindex,

--- a/lib/src/SIIParser.cc
+++ b/lib/src/SIIParser.cc
@@ -1,0 +1,172 @@
+#include "SIIParser.h"
+#include "debug.h"
+
+
+namespace kickcat::eeprom
+{
+    void parseStrings(SII& sii, uint8_t const* section_start)
+    {
+        sii.strings.push_back(std::string_view());  // index 0 is an empty string
+        uint8_t const* pos = section_start;
+
+        uint8_t number_of_strings = *pos;
+        pos += 1;
+
+        for (int32_t i = 0; i < number_of_strings; ++i)
+        {
+            uint8_t len = *pos;
+            pos += 1;
+
+            sii.strings.push_back(std::string_view(reinterpret_cast<char const*>(pos), len));
+            pos += len;
+        }
+    }
+
+    void parseFMMU(SII& sii, uint8_t const* section_start, uint16_t section_size)
+    {
+        for (int32_t i = 0; i < section_size; ++i)
+        {
+            sii.fmmus.push_back(*(section_start + i));
+        }
+    }
+
+    void parseSyncM(SII& sii, uint8_t const* section_start, uint16_t section_size)
+    {
+        uint8_t const* pos = section_start;
+        uint8_t const* end = section_start + section_size;
+
+        while (pos < end)
+        {
+            sii.syncManagers.push_back(reinterpret_cast<eeprom::SyncManagerEntry const*>(pos));
+            pos += sizeof(eeprom::SyncManagerEntry);
+        }
+    }
+
+    void parsePDO(uint8_t const* section_start, std::vector<eeprom::PDOEntry const*>& pdo)
+    {
+        uint8_t const* pos = section_start;
+
+        //uint16_t index = *reinterpret_cast<uint16_t const*>(pos); // not used yet
+        pos += 2;
+
+        uint8_t number_of_entries = *pos;
+        pos += 1;
+
+        //uint8_t sync_manager = *pos; // not used yet
+        pos += 1;
+
+        //uint8_t synchronization = *pos; // not use yet
+        pos += 1;
+
+        //uint8_t name_index = *pos; // not used yet
+        pos += 1;
+
+        // flags (word) - unused
+        pos += 2;
+
+        for (int32_t i = 0; i < number_of_entries; ++i)
+        {
+            pdo.push_back(reinterpret_cast<eeprom::PDOEntry const*>(pos));
+            pos += sizeof(eeprom::PDOEntry);
+        }
+    }
+
+    void SII::parse()
+    {
+        uint32_t temp_word = 0;
+
+        // Identity
+        vendor_id       = eeprom.at(eeprom::VENDOR_ID / sizeof(uint16_t));
+        product_code    = eeprom.at(eeprom::PRODUCT_CODE / sizeof(uint16_t));
+        revision_number = eeprom.at(eeprom::REVISION_NUMBER / sizeof(uint16_t));
+        serial_number   = eeprom.at(eeprom::SERIAL_NUMBER / sizeof(uint16_t));
+
+        // Mailbox info
+        temp_word = eeprom.at((eeprom::BOOTSTRAP_MAILBOX + eeprom::RECV_MBO_OFFSET) / sizeof(uint16_t));
+        mailboxBootstrap_recv_offset = static_cast<uint16_t>(temp_word);
+        mailboxBootstrap_recv_size   = static_cast<uint16_t>(temp_word >> 16);
+
+        temp_word = eeprom.at((eeprom::BOOTSTRAP_MAILBOX + eeprom::SEND_MBO_OFFSET) / sizeof(uint16_t));
+        mailboxBootstrap_send_offset = static_cast<uint16_t>(temp_word);
+        mailboxBootstrap_send_size   = static_cast<uint16_t>(temp_word >> 16);
+
+        temp_word           = eeprom.at((eeprom::STANDARD_MAILBOX + eeprom::RECV_MBO_OFFSET) / sizeof(uint16_t));
+        mailbox_recv_offset = static_cast<uint16_t>(temp_word);
+        mailbox_recv_size   = static_cast<uint16_t>(temp_word >> 16);
+
+        temp_word           = eeprom.at((eeprom::STANDARD_MAILBOX + eeprom::SEND_MBO_OFFSET) / sizeof(uint16_t));
+        mailbox_send_offset = static_cast<uint16_t>(temp_word);
+        mailbox_send_size   = static_cast<uint16_t>(temp_word >> 16);
+
+        temp_word         = eeprom.at(eeprom::MAILBOX_PROTOCOL / sizeof(uint16_t));
+        supported_mailbox = static_cast<eeprom::MailboxProtocol>(temp_word);
+
+        // EEPROM
+        temp_word   = eeprom.at(eeprom::EEPROM_SIZE / sizeof(uint16_t));
+        eeprom_size = (temp_word & 0xFF) + 1;  // 0 means 1024 bits
+        eeprom_size *= 128;                    // Kibit to bytes
+        eeprom_version = static_cast<uint16_t>(temp_word >> 16);
+
+        // Categories
+        uint8_t const* pos           = reinterpret_cast<uint8_t*>(eeprom.data()) + eeprom::START_CATEGORY * 2;
+        uint8_t const* const max_pos = reinterpret_cast<uint8_t*>(eeprom.data() + eeprom.size() - 4);
+        while (pos < max_pos)
+        {
+            uint16_t const* category     = reinterpret_cast<uint16_t const*>(pos);
+            uint16_t category_size       = *(category + 1) * sizeof(uint16_t);
+            uint8_t const* category_data = pos + 4;
+            pos += (4 + category_size);
+
+            switch (*category)
+            {
+                case eeprom::Category::Strings:
+                {
+                    parseStrings(*this, category_data);
+                    break;
+                }
+                case eeprom::Category::DataTypes:
+                {
+                    slave_warning("DataTypes section: parsing not implemented\n");
+                    break;
+                }
+                case eeprom::Category::General:
+                {
+                    general = reinterpret_cast<eeprom::GeneralEntry const*>(category_data);
+                    break;
+                }
+                case eeprom::Category::FMMU:
+                {
+                    parseFMMU(*this, category_data, category_size);
+                    break;
+                }
+                case eeprom::Category::SyncM:
+                {
+                    parseSyncM(*this, category_data, category_size);
+                    break;
+                }
+                case eeprom::Category::TxPDO:
+                {
+                    parsePDO(category_data, TxPDO);
+                    break;
+                }
+                case eeprom::Category::RxPDO:
+                {
+                    parsePDO(category_data, RxPDO);
+                    break;
+                }
+                case eeprom::Category::DC:
+                {
+                    slave_warning("DC section: parsing not implemented\n");
+                    break;
+                }
+                case eeprom::Category::End:
+                {
+                    break;
+                }
+                default:
+                {
+                }
+            }
+        };
+    }
+}

--- a/simulation/network_simulator.cc
+++ b/simulation/network_simulator.cc
@@ -38,11 +38,10 @@ int main(int argc, char* argv[])
     std::vector<nanoseconds> stats;
     stats.reserve(1000);
 
-    auto const mbx_out_cfg  = SYNC_MANAGER_MBX_OUT (0, 0x1000, 128);
-    auto const mbx_in_cfg = SYNC_MANAGER_MBX_IN(1, 0x1400, 128);
     auto& esc0 = escs.at(0);
-    mailbox::response::Mailbox mbx(&esc0, mbx_in_cfg, mbx_out_cfg);
+    mailbox::response::Mailbox mbx(&esc0, 1024);
     mbx.enableCoE(std::move(coe_dict));
+    esc0.set_mailbox(&mbx);
 
     while (true)
     {

--- a/tools/eeprom.cc
+++ b/tools/eeprom.cc
@@ -117,12 +117,12 @@ int main(int argc, char* argv[])
 
     if (shall_dump)
     {
-        auto const& sii = slave.sii.buffer;
+        auto const& sii = slave.sii.eeprom;
         char const* raw_data = reinterpret_cast<char const*>(sii.data());
         std::ofstream f(file, std::ofstream::binary);
 
         // Create an eeprom binary file with the right size of empty data
-        std::vector<char> empty(slave.eeprom_size, -1);
+        std::vector<char> empty(slave.sii.eeprom_size, -1);
         f.write(empty.data(), empty.size());
         f.seekp(0);
 

--- a/unit/bus-t.cc
+++ b/unit/bus-t.cc
@@ -212,10 +212,10 @@ public:
         ASSERT_EQ(1, bus.detectedSlaves());
 
         auto const& slave = bus.slaves().at(0);
-        ASSERT_EQ(0xCAFEDECA, slave.vendor_id);
-        ASSERT_EQ(0xA5A5A5A5, slave.product_code);
-        ASSERT_EQ(0x5A5A5A5A, slave.revision_number);
-        ASSERT_EQ(0x12345678, slave.serial_number);
+        ASSERT_EQ(0xCAFEDECA, slave.sii.vendor_id);
+        ASSERT_EQ(0xA5A5A5A5, slave.sii.product_code);
+        ASSERT_EQ(0x5A5A5A5A, slave.sii.revision_number);
+        ASSERT_EQ(0x12345678, slave.sii.serial_number);
         ASSERT_EQ(0x1000,     slave.mailbox.recv_offset);
         ASSERT_EQ(0x2000,     slave.mailbox.send_offset);
         ASSERT_EQ(0x0100,     slave.mailbox.recv_size);
@@ -314,7 +314,7 @@ TEST_F(BusTest, logical_cmd)
     InSequence s;
 
     auto& slave = bus.slaves().at(0);
-    slave.supported_mailbox = eeprom::MailboxProtocol::None; // disable mailbox protocol to use SII PDO mapping
+    slave.sii.supported_mailbox = eeprom::MailboxProtocol::None; // disable mailbox protocol to use SII PDO mapping
 
     checkSendFrameSimple(Command::FPWR, 4);
     io_nominal->handleReply<uint8_t>({2, 3});

--- a/unit/prints-t.cc
+++ b/unit/prints-t.cc
@@ -44,7 +44,7 @@ TEST(Prints, slave_uninitialized_prints)
 TEST(Prints, slave_initialized_prints)
 {
     Slave slave;
-    slave.sii.buffer =
+    slave.sii.eeprom =
     {
         //
         0x00000000,

--- a/unit/slave-t.cc
+++ b/unit/slave-t.cc
@@ -7,7 +7,7 @@ using namespace kickcat;
 TEST(Slave, parse_SII)
 {
     Slave slave;
-    slave.sii.buffer =
+    slave.sii.eeprom =
     {
         //
         0x00000000,


### PR DESCRIPTION
Change the way of SyncManagers configuration. 
Originally we configure the SyncManagers statically : The AL gives the configuration. This can be avoided as the master should be the one to configure the mailbox sync managers thanks to the eeprom. And the slave only need to check the coherency of this configuration

This PR also export the SII parser to common folder