### PR TITLE
Add lib files to coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,10 @@ jobs:
         conan install conan/conanfile_${conan_profile}.txt -of=build/ -pr:b conan/profile_${conan_profile}_x86_64.txt -pr:h conan/profile_${conan_profile}_x86_64.txt --build=missing -s build_type=${{env.BUILD_TYPE}}
       shell: bash
 
-    - name: Install Gcovr
+    - name: Install Gcovr and Lcov
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo apt install gcovr
+        sudo apt install gcovr lcov
 
     - name: Configure CMake
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ if (GTest_FOUND)
                               unit/slave-t.cc
                               unit/socket-t.cc
                               unit/Time.cc
+                              unit/CoE/protocol-t.cc
   )
 
   target_link_libraries(kickcat_unit kickcat GTest::gmock_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ if (NOT NUTTX)
   option(BUILD_TOOLS        "Build tools" ON)
 endif()
 
-add_subdirectory(lib)
 
 if (BUILD_UNIT_TESTS)
   find_package(GTest QUIET CONFIG)
@@ -45,7 +44,6 @@ if (GTest_FOUND)
                               unit/slave-t.cc
                               unit/socket-t.cc
                               unit/Time.cc
-                              unit/CoE/protocol-t.cc
   )
 
   target_link_libraries(kickcat_unit kickcat GTest::gmock_main)
@@ -69,8 +67,16 @@ if (GTest_FOUND)
         EXECUTABLE kickcat_unit
         EXCLUDE ${EXCLUDE_FILES}
         )
+
+    setup_target_for_coverage_lcov(
+        NAME coverage_lcov
+        EXECUTABLE kickcat_unit
+        EXCLUDE ${EXCLUDE_FILES}
+        )
   endif()
 endif()
+
+add_subdirectory(lib)
 
 if (BUILD_EXAMPLES)
   if (NOT NUTTX)


### PR DESCRIPTION
It seems that since a lot of time, the coverage doesn't take into account the files in lib. 

Seems to be due to the order in CMakeLists.

In addition I have add the lcov files to cmake target. Easier to visualize coverage locally.