### PR TITLE
Avoid updating pdo if buffer not set

### DIFF
--- a/lib/slave/src/PDO.cc
+++ b/lib/slave/src/PDO.cc
@@ -66,19 +66,25 @@ namespace kickcat
 
     void PDO::updateInput()
     {
-        int32_t written = esc_->write(sm_input_.start_address, input_, sm_input_.length);
-        if (written != sm_input_.length)
+        if (input_ != nullptr)
         {
-            slave_error("\n update_process_data_input ERROR\n");
+            int32_t written = esc_->write(sm_input_.start_address, input_, sm_input_.length);
+            if (written != sm_input_.length)
+            {
+                slave_error("\n update_process_data_input ERROR\n");
+            }
         }
     }
 
     void PDO::updateOutput()
     {
-        int32_t r = esc_->read(sm_output_.start_address, output_, sm_output_.length);
-        if (r != sm_output_.length)
+        if (output_ != nullptr)
         {
-            slave_error("\n update_process_data_output ERROR\n");
+            int32_t r = esc_->read(sm_output_.start_address, output_, sm_output_.length);
+            if (r != sm_output_.length)
+            {
+                slave_error("\n update_process_data_output ERROR\n");
+            }
         }
     }
 }

--- a/unit/mocks/ESMStateTest.h
+++ b/unit/mocks/ESMStateTest.h
@@ -24,6 +24,8 @@ public:
     MockESC esc_{};
     PDO pdo_{&esc_};
     mailbox::response::Mailbox mbx_{&esc_, 200};
+    uint8_t buffer_in_[1024];
+    uint8_t buffer_out_[1024];
 
     SyncManager mbx_in;
     SyncManager mbx_out;
@@ -50,6 +52,9 @@ public:
         mbx_out = {0x01, 100, SM_CONTROL_MODE_MAILBOX | SM_CONTROL_DIRECTION_WRITE, 0x00, SM_ACTIVATE_ENABLE, 0x00};
         pdo_in  = {0x02, 200, SM_CONTROL_MODE_BUFFERED | SM_CONTROL_DIRECTION_READ, 0x00, SM_ACTIVATE_ENABLE, 0x00};
         pdo_out = {0x03, 200, SM_CONTROL_MODE_BUFFERED | SM_CONTROL_DIRECTION_WRITE, 0x00, SM_ACTIVATE_ENABLE, 0x00};
+
+        pdo_.setInput(buffer_in_);
+        pdo_.setOutput(buffer_out_);
 
         SetUpSpecific();
     }


### PR DESCRIPTION
If no buffer has been set as input or output pdo, don't update them, avoiding null pointer exception