### PR TITLE
Fix lan9252 example and move setMailbox to constructor

### DIFF
--- a/examples/slave/nuttx/lan9252/boards/arduino_due/README.md
+++ b/examples/slave/nuttx/lan9252/boards/arduino_due/README.md
@@ -5,8 +5,17 @@ https://nuttx.apache.org/docs/latest/quickstart/install.html
 
 ### Build and flash
 
+- Checkout nuttx and apps repository to `nuttx-12.6.0` tag.
 - Copy the defconfig file into your Nuttx installation in `nuttx/boards/arm/sam34/arduino-due/configs/nsh/defconfig`
 - In nuttx folder: `./tools/configure.sh -l arduino-due:nsh`
 - Download and add to your path a gcc > to 12.0. https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads
 - Retrieve the `bossac-1.6.1-arduino` version. One way to get it is to install the arduino IDE and retrieve the executable from its installation folder.
 - See the script `export_nuttx_archive.sh` for reference as how to build and flash your program (Paths are not properly handled in the script).
+
+
+Bossac troubleshooting:
+
+In case of `No device found on ttyACM0` but you can see the device listed in `/dev/tty*`.
+- make sure the usb is connected to the port closest to the arduino-due's alimentation.
+- press erase on the board for a few second, release, then press reset.
+- try again to upload the binary.

--- a/examples/slave/nuttx/lan9252/boards/arduino_due/export_nuttx_archive.sh
+++ b/examples/slave/nuttx/lan9252/boards/arduino_due/export_nuttx_archive.sh
@@ -9,7 +9,7 @@ src=~/wdc_workspace/src/KickCAT/
 
 bin=easycat_slave
 
-nuttx_version=nuttx-export-12.3.0
+nuttx_version=nuttx-export-12.6.0
 
 rm -f ${nuttx_src}/${nuttx_version}.tar.gz
 rm -rf ${build}/${nuttx_version}

--- a/examples/slave/nuttx/lan9252/main.cc
+++ b/examples/slave/nuttx/lan9252/main.cc
@@ -19,6 +19,7 @@ int main(int argc, char *argv[])
     (void) argv;
     std::shared_ptr<SPI> spi_driver = std::make_shared<SPI>();
     Lan9252 esc = Lan9252(spi_driver);
+    esc.init();
     PDO pdo(&esc);
     slave::Slave slave(&esc, &pdo);
 

--- a/lib/slave/include/kickcat/ESC/Lan9252.h
+++ b/lib/slave/include/kickcat/ESC/Lan9252.h
@@ -77,9 +77,9 @@ namespace kickcat
 
         int32_t read(uint16_t address, void* data, uint16_t size) override;
         int32_t write(uint16_t address, void const* data, uint16_t size) override;
+        hresult init() override;
 
     private:
-        hresult init() override;
         template <typename T>
         void readInternalRegister(uint16_t address, T& payload)
         {

--- a/lib/slave/include/kickcat/slave/Slave.h
+++ b/lib/slave/include/kickcat/slave/Slave.h
@@ -22,7 +22,7 @@ namespace kickcat::slave
 
     private:
         AbstractESC* esc_;
-        mailbox::response::Mailbox* mbx_;
+        mailbox::response::Mailbox* mbx_{nullptr};
         PDO* pdo_;
 
         ESM::Init init_{*esc_, *pdo_};


### PR DESCRIPTION
- Fix example of Lan9252 usage
- Fix a bug in mbx_ pointer initialization (the check if(mbx_) in slave was working on an uninitialized pointer leading to dummy interpretation) 