### PR TITLE
mailbox check through PDOs

### DIFF
--- a/lib/master/include/kickcat/Bus.h
+++ b/lib/master/include/kickcat/Bus.h
@@ -10,6 +10,21 @@
 
 namespace kickcat
 {
+    enum MailboxStatusFMMU : uint8_t
+    {
+        NONE        = 0,
+        READ_CHECK  = (1 << 0),
+        WRITE_CHECK = (1 << 1),
+    };
+    constexpr MailboxStatusFMMU operator|(MailboxStatusFMMU a, MailboxStatusFMMU b)
+    {
+        return static_cast<MailboxStatusFMMU>(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
+    }
+    constexpr bool operator&(MailboxStatusFMMU a, MailboxStatusFMMU b)
+    {
+        return (static_cast<uint8_t>(a) & static_cast<uint8_t>(b)) != 0;
+    }
+
     class Bus
     {
     public:
@@ -53,6 +68,17 @@ namespace kickcat
         // wait for all slaves to reached a state
         // background_task may be used to keep updated PDO while waiting for a particular state.
         void waitForState(State request, nanoseconds timeout, std::function<void()> background_task = [](){});
+
+        /// \brief Select and validate the preferred mailbox status check mode.
+        /// \details Must be called during PRE_OP, before createMapping(). Validates that all
+        ///          mailbox-capable slaves have enough FMMUs for the requested mode. Throws on error.
+        ///          When set, createMapping() transparently integrates bit-wise FMMU mapping so that
+        ///          mailbox status flags (can_read / can_write) are updated in the LRD/LRW callbacks.
+        /// \param mode  READ_CHECK, WRITE_CHECK, or both OR'd together
+        void configureMailboxStatusCheck(MailboxStatusFMMU mode);
+
+        /// \return the currently configured mailbox status FMMU mode
+        MailboxStatusFMMU mailboxStatusFMMUMode() const { return mailbox_status_fmmu_; }
 
         // create the mapping between slaves PI and client buffer
         // if OK, set the bus to SAFE_OP state
@@ -163,6 +189,7 @@ namespace kickcat
         void detectMapping();
         void readMappedPDO(Slave& slave, uint16_t index);
         void configureFMMUs();
+        void configureMailboxFMMUs();
 
         // DC helpers
         void fetchReceivedTimes();
@@ -183,12 +210,25 @@ namespace kickcat
             Slave*   slave;     // associated slave of this input
         };
 
+        struct MailboxStatusEntry
+        {
+            uint32_t byte_offset;   // byte offset within frame data
+            uint8_t  bit_position;  // bit position within that byte (0-7)
+            Slave*   slave;
+        };
+
         struct PIFrame
         {
             uint32_t address;               // logical address
-            int32_t size;                   // frame size
+            int32_t  logical_size;          // full logical address range (PDO + mailbox status bits)
+            int32_t  pdo_size;              // process data only (used by LWR)
             std::vector<blockIO> inputs;    // slave to master
             std::vector<blockIO> outputs;
+            std::vector<MailboxStatusEntry> mailbox_read_status;
+            std::vector<MailboxStatusEntry> mailbox_write_status;
+
+            // Adjust wkc in case the slave do not have a PDO read but still answer because of the mbx check
+            uint16_t mailbox_status_wkc_read_adjust{0};
         };
         std::vector<PIFrame> pi_frames_; // PI frame description
 
@@ -198,6 +238,8 @@ namespace kickcat
         uint16_t irq_mask_{0};
 
         Slave* dc_slave_{nullptr};
+
+        MailboxStatusFMMU mailbox_status_fmmu_{MailboxStatusFMMU::NONE};
     };
 
     /**

--- a/lib/master/src/Bus.cc
+++ b/lib/master/src/Bus.cc
@@ -463,6 +463,39 @@ namespace kickcat
     }
 
 
+    void Bus::configureMailboxStatusCheck(MailboxStatusFMMU mode)
+    {
+        if (mode == MailboxStatusFMMU::NONE)
+        {
+            mailbox_status_fmmu_ = mode;
+            return;
+        }
+
+        uint8_t required_fmmus = 3;
+        if ((mode & MailboxStatusFMMU::READ_CHECK) and (mode & MailboxStatusFMMU::WRITE_CHECK))
+        {
+            required_fmmus = 4;
+        }
+
+        for (auto const& slave : slaves_)
+        {
+            if (slave.sii.supported_mailbox == 0)
+            {
+                continue;
+            }
+
+            if (slave.esc.fmmus < required_fmmus)
+            {
+                bus_error("Slave %d has %d FMMUs, need %d for requested mailbox status FMMU mode\n",
+                    slave.address, slave.esc.fmmus, required_fmmus);
+                THROW_ERROR("Insufficient FMMUs for mailbox status mapping");
+            }
+        }
+
+        mailbox_status_fmmu_ = mode;
+    }
+
+
     void Bus::createMapping(uint8_t* iomap)
     {
         // First we need to know:
@@ -476,6 +509,7 @@ namespace kickcat
         // Note B: a frame cannot handle more than 1486 bytes
         pi_frames_.resize(1);
         pi_frames_[0].address = 0;
+        std::vector<std::vector<Slave*>> frame_mbx_slaves(1);
         uint32_t address = 0;
         for (auto& slave : slaves_)
         {
@@ -483,11 +517,12 @@ namespace kickcat
             int32_t size = std::max(slave.input.bsize, slave.output.bsize);
             if ((address + size) > (pi_frames_.size() * MAX_ETHERCAT_PAYLOAD_SIZE)) // do we overflow current frame ?
             {
-                pi_frames_.back().size = address - pi_frames_.back().address; // frame size = current address - frame address
+                pi_frames_.back().logical_size = address - pi_frames_.back().address; // frame size = current address - frame address
 
                 // current size will overflow the frame at the current offset: set in on the next frame
                 address = static_cast<uint32_t>(pi_frames_.size()) * MAX_ETHERCAT_PAYLOAD_SIZE;
-                pi_frames_.push_back({address, 0, {}, {}});
+                pi_frames_.push_back({address, 0, 0, {}, {}, {}, {}, 0});
+                frame_mbx_slaves.push_back({});
             }
 
             // create block IO entries
@@ -507,10 +542,89 @@ namespace kickcat
 
             // update offset
             address += size;
+
+            if (slave.sii.supported_mailbox != 0)
+            {
+                frame_mbx_slaves.back().push_back(&slave);
+            }
         }
 
         // update last frame size
-        pi_frames_.back().size = address - pi_frames_.back().address;
+        pi_frames_.back().logical_size = address - pi_frames_.back().address;
+
+        // Set pdo_size for all frames (equals logical_size before mailbox status extension)
+        for (auto& frame : pi_frames_)
+        {
+            frame.pdo_size = frame.logical_size;
+        }
+
+        // Extend frames with bit-wise mailbox status mappings
+        if (mailbox_status_fmmu_ != MailboxStatusFMMU::NONE)
+        {
+            for (size_t fi = 0; fi < pi_frames_.size(); ++fi)
+            {
+                auto& frame = pi_frames_[fi];
+                auto const& mbx_slaves = frame_mbx_slaves[fi];
+                if (mbx_slaves.empty())
+                {
+                    continue;
+                }
+
+                // ESC constraint: two read-direction FMMUs using bit-wise mapping on the
+                // same ESC must be separated by at least 3 logical bytes not configured by
+                // any FMMU of the same type (see ESC datasheet, "Restrictions on FMMU settings").
+                // PDO input FMMU (FMMU1) is read-direction, and so are mailbox status FMMUs,
+                // so we insert a 3-byte gap between the PDO region and the status region,
+                // and between the read-check and write-check regions when both are active.
+                uint32_t status_offset = static_cast<uint32_t>(frame.pdo_size);
+                constexpr uint32_t FMMU_BYTE_SEPARATION = 3;
+
+                if (mailbox_status_fmmu_ & MailboxStatusFMMU::READ_CHECK)
+                {
+                    status_offset += FMMU_BYTE_SEPARATION;
+                    for (size_t i = 0; i < mbx_slaves.size(); ++i)
+                    {
+                        frame.mailbox_read_status.push_back({
+                            status_offset + static_cast<uint32_t>(i / 8),
+                            static_cast<uint8_t>(i % 8),
+                            mbx_slaves[i]
+                        });
+                    }
+                    uint32_t read_bytes = (static_cast<uint32_t>(mbx_slaves.size()) + 7) / 8;
+                    status_offset += read_bytes;
+                }
+
+                if (mailbox_status_fmmu_ & MailboxStatusFMMU::WRITE_CHECK)
+                {
+                    status_offset += FMMU_BYTE_SEPARATION;
+                    for (size_t i = 0; i < mbx_slaves.size(); ++i)
+                    {
+                        frame.mailbox_write_status.push_back({
+                            status_offset + static_cast<uint32_t>(i / 8),
+                            static_cast<uint8_t>(i % 8),
+                            mbx_slaves[i]
+                        });
+                    }
+                    uint32_t write_bytes = (static_cast<uint32_t>(mbx_slaves.size()) + 7) / 8;
+                    status_offset += write_bytes;
+                }
+
+                frame.logical_size = static_cast<int32_t>(status_offset);
+
+                // WKC adjustment: only count slaves that gain a read-direction FMMU
+                // but have no TxPDO (input). Slaves with TxPDO already increment WKC
+                // on LRD/LRW, so their mailbox status FMMU adds no extra increment.
+                uint16_t adjust = 0;
+                for (auto const* slave : mbx_slaves)
+                {
+                    if (slave->input.bsize == 0)
+                    {
+                        ++adjust;
+                    }
+                }
+                frame.mailbox_status_wkc_read_adjust = adjust;
+            }
+        }
 
         // Third step: associate client buffer address to block IO and slaves
         // Note: inputs are mapped first, outputs second
@@ -536,6 +650,11 @@ namespace kickcat
 
         // Fourth step: program FMMUs and SyncManagers
         configureFMMUs();
+
+        if (mailbox_status_fmmu_ != MailboxStatusFMMU::NONE)
+        {
+            configureMailboxFMMUs();
+        }
     }
 
 
@@ -551,16 +670,26 @@ namespace kickcat
                     std::memcpy(input.iomap, data + input.offset, input.size);
                 }
 
-                if (wkc != pi_frame.inputs.size())
+                for (auto const& ms : pi_frame.mailbox_read_status)
                 {
-                    bus_error("Invalid working counter: expected %zu, got %d\n", pi_frame.inputs.size(), wkc);
+                    ms.slave->mailbox.can_read = (data[ms.byte_offset] >> ms.bit_position) & 1;
+                }
+                for (auto const& ms : pi_frame.mailbox_write_status)
+                {
+                    ms.slave->mailbox.can_write = not ((data[ms.byte_offset] >> ms.bit_position) & 1);
+                }
+
+                uint16_t expected_wkc = static_cast<uint16_t>(pi_frame.inputs.size() + pi_frame.mailbox_status_wkc_read_adjust);
+                if (wkc != expected_wkc)
+                {
+                    bus_error("Invalid working counter: expected %d, got %d\n", expected_wkc, wkc);
                     return DatagramState::INVALID_WKC;
                 }
 
                 return DatagramState::OK;
             };
 
-            link_->addDatagram(Command::LRD, pi_frame.address, nullptr, static_cast<uint16_t>(pi_frame.size), process, error);
+            link_->addDatagram(Command::LRD, pi_frame.address, nullptr, static_cast<uint16_t>(pi_frame.logical_size), process, error);
         }
     }
 
@@ -591,7 +720,7 @@ namespace kickcat
                 }
                 return DatagramState::OK;
             };
-            link_->addDatagram(Command::LWR, pi_frame.address, buffer, static_cast<uint16_t>(pi_frame.size), process, error);
+            link_->addDatagram(Command::LWR, pi_frame.address, buffer, static_cast<uint16_t>(pi_frame.pdo_size), process, error);
         }
 
         if (dc_slave_ != nullptr)
@@ -620,8 +749,9 @@ namespace kickcat
 
             auto process = [pi_frame](DatagramHeader const*, uint8_t const* data, uint16_t wkc)
             {
-                uint16_t expected_wkc = static_cast<uint16_t>(pi_frame.inputs.size() + pi_frame.outputs.size() * 2);
-                if (wkc != expected_wkc) //TODO: buggy in master?
+                uint16_t expected_wkc = static_cast<uint16_t>(pi_frame.inputs.size() + pi_frame.outputs.size() * 2
+                    + pi_frame.mailbox_status_wkc_read_adjust);
+                if (wkc != expected_wkc)
                 {
                     bus_error("Invalid working counter: expected %d, got %d\n", expected_wkc, wkc);
                     return DatagramState::INVALID_WKC;
@@ -631,10 +761,20 @@ namespace kickcat
                 {
                     std::memcpy(input.iomap, data + input.offset, input.size);
                 }
+
+                for (auto const& ms : pi_frame.mailbox_read_status)
+                {
+                    ms.slave->mailbox.can_read = (data[ms.byte_offset] >> ms.bit_position) & 1;
+                }
+                for (auto const& ms : pi_frame.mailbox_write_status)
+                {
+                    ms.slave->mailbox.can_write = not ((data[ms.byte_offset] >> ms.bit_position) & 1);
+                }
+
                 return DatagramState::OK;
             };
 
-            link_->addDatagram(Command::LRW, pi_frame.address, buffer, static_cast<uint16_t>(pi_frame.size), process, error);
+            link_->addDatagram(Command::LRW, pi_frame.address, buffer, static_cast<uint16_t>(pi_frame.logical_size), process, error);
         }
 
         if (dc_slave_ != nullptr)
@@ -719,6 +859,75 @@ namespace kickcat
         {
             prepareDatagrams(slave, slave.input,  SyncManagerType::Input);
             prepareDatagrams(slave, slave.output, SyncManagerType::Output);
+        }
+
+        link_->processDatagrams();
+    }
+
+
+    void Bus::configureMailboxFMMUs()
+    {
+        auto process = [](DatagramHeader const*, uint8_t const*, uint16_t wkc)
+        {
+            if (wkc != 1)
+            {
+                return DatagramState::INVALID_WKC;
+            }
+            return DatagramState::OK;
+        };
+
+        auto error = [](DatagramState const& state)
+        {
+            THROW_ERROR_DATAGRAM("Invalid working counter while programming mailbox status FMMU", state);
+        };
+
+        for (auto const& frame : pi_frames_)
+        {
+            auto configureBitFMMU = [&](auto const& entries, uint16_t physical_address, uint16_t fmmu_reg_offset)
+            {
+                for (auto const& entry : entries)
+                {
+                    FMMU fmmu;
+                    std::memset(&fmmu, 0, sizeof(FMMU));
+                    fmmu.logical_address    = frame.address + entry.byte_offset;
+                    fmmu.length             = 1;
+                    fmmu.logical_start_bit  = entry.bit_position;
+                    fmmu.logical_stop_bit   = entry.bit_position;
+                    fmmu.physical_address   = physical_address;
+                    fmmu.physical_start_bit = 3; // SM_STATUS_MAILBOX bit
+                    fmmu.type               = 1; // read access (slave to master)
+                    fmmu.activate           = 1;
+
+                    link_->addDatagram(Command::FPWR,
+                        createAddress(entry.slave->address, static_cast<uint16_t>(reg::FMMU + fmmu_reg_offset)),
+                        fmmu, process, error);
+
+                    bus_info("Mailbox FMMU slave %04x - FMMU%d - logical 0x%08x bit %d - physical 0x%04x bit 3\n",
+                        entry.slave->address, fmmu_reg_offset / 0x10,
+                        fmmu.logical_address, entry.bit_position, physical_address);
+                }
+            };
+
+            // FMMU0 and FMMU1 are reserved for PDO (output and input).
+            // FMMU2 is used by the first enabled mailbox check mode.
+            // FMMU3 is used by the second one, only when both modes are active.
+            constexpr uint16_t FMMU2_OFFSET  = 0x20;
+            constexpr uint16_t FMMU_REG_SIZE = 0x10;
+
+            uint16_t fmmu_offset = FMMU2_OFFSET;
+
+            if (mailbox_status_fmmu_ & MailboxStatusFMMU::READ_CHECK)
+            {
+                configureBitFMMU(frame.mailbox_read_status,
+                    static_cast<uint16_t>(reg::SYNC_MANAGER_1 + reg::SM_STATS), fmmu_offset);
+                fmmu_offset += FMMU_REG_SIZE;
+            }
+
+            if (mailbox_status_fmmu_ & MailboxStatusFMMU::WRITE_CHECK)
+            {
+                configureBitFMMU(frame.mailbox_write_status,
+                    static_cast<uint16_t>(reg::SYNC_MANAGER_0 + reg::SM_STATS), fmmu_offset);
+            }
         }
 
         link_->processDatagrams();

--- a/lib/master/src/MailboxSequencer.cc
+++ b/lib/master/src/MailboxSequencer.cc
@@ -16,12 +16,22 @@ namespace kickcat
         }
         counter_ = 0;
 
+        auto mode = bus_.mailboxStatusFMMUMode();
+
+        // When mailbox status is mapped via FMMU, the check is already done in the
+        // LRD/LRW callback — skip the FPRD phase to stay reactive.
+        if ((phase_ == 0 and (mode & MailboxStatusFMMU::READ_CHECK))
+         or (phase_ == 2 and (mode & MailboxStatusFMMU::WRITE_CHECK)))
+        {
+            phase_ = (phase_ + 1) % PHASES;
+        }
+
         switch (phase_)
         {
-            case 0: bus_.sendMailboxesReadChecks(error);  break;
-            case 1: bus_.sendReadMessages(error);         break;
-            case 2: bus_.sendMailboxesWriteChecks(error);  break;
-            case 3: bus_.sendWriteMessages(error);         break;
+            case 0: { bus_.sendMailboxesReadChecks(error);  break; }
+            case 1: { bus_.sendReadMessages(error);         break; }
+            case 2: { bus_.sendMailboxesWriteChecks(error);  break; }
+            case 3: { bus_.sendWriteMessages(error);         break; }
         }
 
         phase_ = (phase_ + 1) % PHASES;

--- a/unit/src/bus-t.cc
+++ b/unit/src/bus-t.cc
@@ -835,3 +835,263 @@ TEST_F(BusTest, writeEeprom_data_write_wkc_error)
 
     ASSERT_THROW(bus.writeEeprom(slave, 0x0010, &data, sizeof(data)), Error);
 }
+
+
+// ---------- Mailbox status FMMU tests ----------
+
+TEST_F(BusTest, configureMailboxStatusCheck_read_check_OK)
+{
+    ASSERT_NO_THROW(bus.configureMailboxStatusCheck(MailboxStatusFMMU::READ_CHECK));
+    ASSERT_EQ(MailboxStatusFMMU::READ_CHECK, bus.mailboxStatusFMMUMode());
+}
+
+TEST_F(BusTest, configureMailboxStatusCheck_write_check_OK)
+{
+    ASSERT_NO_THROW(bus.configureMailboxStatusCheck(MailboxStatusFMMU::WRITE_CHECK));
+    ASSERT_EQ(MailboxStatusFMMU::WRITE_CHECK, bus.mailboxStatusFMMUMode());
+}
+
+TEST_F(BusTest, configureMailboxStatusCheck_both_OK)
+{
+    auto mode = MailboxStatusFMMU::READ_CHECK | MailboxStatusFMMU::WRITE_CHECK;
+    ASSERT_NO_THROW(bus.configureMailboxStatusCheck(mode));
+    ASSERT_EQ(mode, bus.mailboxStatusFMMUMode());
+}
+
+TEST_F(BusTest, configureMailboxStatusCheck_none)
+{
+    bus.configureMailboxStatusCheck(MailboxStatusFMMU::READ_CHECK);
+    ASSERT_NO_THROW(bus.configureMailboxStatusCheck(MailboxStatusFMMU::NONE));
+    ASSERT_EQ(MailboxStatusFMMU::NONE, bus.mailboxStatusFMMUMode());
+}
+
+TEST_F(BusTest, configureMailboxStatusCheck_insufficient_fmmus_single)
+{
+    auto& slave = bus.slaves().at(0);
+    slave.esc.fmmus = 2;
+    ASSERT_THROW(bus.configureMailboxStatusCheck(MailboxStatusFMMU::READ_CHECK), Error);
+    ASSERT_EQ(MailboxStatusFMMU::NONE, bus.mailboxStatusFMMUMode());
+}
+
+TEST_F(BusTest, configureMailboxStatusCheck_insufficient_fmmus_both)
+{
+    auto& slave = bus.slaves().at(0);
+    slave.esc.fmmus = 3;
+    ASSERT_NO_THROW(bus.configureMailboxStatusCheck(MailboxStatusFMMU::READ_CHECK));
+    bus.configureMailboxStatusCheck(MailboxStatusFMMU::NONE);
+    ASSERT_THROW(bus.configureMailboxStatusCheck(MailboxStatusFMMU::READ_CHECK | MailboxStatusFMMU::WRITE_CHECK), Error);
+}
+
+TEST_F(BusTest, configureMailboxStatusCheck_no_mailbox_slave_skipped)
+{
+    auto& slave = bus.slaves().at(0);
+    slave.sii.supported_mailbox = eeprom::MailboxProtocol::None;
+    slave.esc.fmmus = 2;
+    ASSERT_NO_THROW(bus.configureMailboxStatusCheck(MailboxStatusFMMU::READ_CHECK | MailboxStatusFMMU::WRITE_CHECK));
+}
+
+
+TEST_F(BusTest, mailbox_status_fmmu_read_check_LRD)
+{
+    auto& slave = bus.slaves().at(0);
+    slave.is_static_mapping = true;
+    slave.input.bsize = 4;
+    slave.input.sync_manager = 1;
+    slave.output.bsize = 4;
+    slave.output.sync_manager = 0;
+
+    bus.configureMailboxStatusCheck(MailboxStatusFMMU::READ_CHECK);
+
+    // configureFMMUs: 4 FPWR (SM+FMMU for output & input)
+    for (int i = 0; i < 4; ++i)
+    {
+        mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+    }
+    // configureMailboxFMMUs: 1 FPWR for FMMU2 (read check)
+    mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+
+    uint8_t iomap[64];
+    bus.createMapping(iomap);
+
+    // Frame layout: [4 PDO][3 pad][1 status] = 8 bytes
+    // Status byte at offset 7, bit 0 = SM1 mailbox status
+    // WKC = 1 (input PDO, slave already increments for TxPDO so adjust = 0)
+
+    // LRD with status bit set -> can_read = true
+    uint64_t lrd_data = uint64_t(0x01) << 56; // byte 7 = 0x01, bit 0 set
+    mock_link->handleProcess(Command::LRD, lrd_data, 1);
+    slave.mailbox.can_read = false;
+    bus.processDataRead([](DatagramState const&){});
+    ASSERT_TRUE(slave.mailbox.can_read);
+
+    // LRD with status bit clear -> can_read = false
+    uint64_t lrd_clear = 0;
+    mock_link->handleProcess(Command::LRD, lrd_clear, 1);
+    bus.processDataRead([](DatagramState const&){});
+    ASSERT_FALSE(slave.mailbox.can_read);
+}
+
+
+TEST_F(BusTest, mailbox_status_fmmu_both_LRW)
+{
+    auto& slave = bus.slaves().at(0);
+    slave.is_static_mapping = true;
+    slave.input.bsize = 4;
+    slave.input.sync_manager = 1;
+    slave.output.bsize = 4;
+    slave.output.sync_manager = 0;
+
+    bus.configureMailboxStatusCheck(MailboxStatusFMMU::READ_CHECK | MailboxStatusFMMU::WRITE_CHECK);
+
+    // configureFMMUs: 4 FPWR
+    for (int i = 0; i < 4; ++i)
+    {
+        mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+    }
+    // configureMailboxFMMUs: 2 FPWR (FMMU2 for read + FMMU3 for write)
+    mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+    mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+
+    uint8_t iomap[64];
+    bus.createMapping(iomap);
+
+    // Frame layout: [4 PDO][3 pad][1 read_status][3 pad][1 write_status] = 12 bytes
+    // Read status: byte 7, bit 0
+    // Write status: byte 11, bit 0
+    // LRW WKC = 1 (read) + 1*2 (write) = 3 (slave has TxPDO so adjust = 0)
+
+    struct Response { uint8_t data[12]; } __attribute__((__packed__));
+    Response resp{};
+    resp.data[7]  = 0x01; // read check: SM1 full -> can_read = true
+    resp.data[11] = 0x00; // write check: SM0 empty -> can_write = !0 = true
+    mock_link->handleProcess(Command::LRW, resp, 3);
+
+    slave.mailbox.can_read = false;
+    slave.mailbox.can_write = false;
+    bus.processDataReadWrite([](DatagramState const&){});
+    ASSERT_TRUE(slave.mailbox.can_read);
+    ASSERT_TRUE(slave.mailbox.can_write);
+
+    // Now test SM0 full -> can_write = false
+    Response resp2{};
+    resp2.data[7]  = 0x00; // read check: SM1 empty -> can_read = false
+    resp2.data[11] = 0x01; // write check: SM0 full -> can_write = !1 = false
+    mock_link->handleProcess(Command::LRW, resp2, 3);
+
+    bus.processDataReadWrite([](DatagramState const&){});
+    ASSERT_FALSE(slave.mailbox.can_read);
+    ASSERT_FALSE(slave.mailbox.can_write);
+}
+
+
+TEST_F(BusTest, mailbox_status_fmmu_LWR_uses_pdo_size)
+{
+    auto& slave = bus.slaves().at(0);
+    slave.is_static_mapping = true;
+    slave.input.bsize = 4;
+    slave.input.sync_manager = 1;
+    slave.output.bsize = 4;
+    slave.output.sync_manager = 0;
+
+    bus.configureMailboxStatusCheck(MailboxStatusFMMU::READ_CHECK);
+
+    for (int i = 0; i < 4; ++i)
+    {
+        mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+    }
+    mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+
+    uint8_t iomap[64];
+    bus.createMapping(iomap);
+
+    // LWR WKC should still be 1 (only output PDO, read FMMUs don't respond to LWR)
+    uint32_t lwr_data = 0;
+    mock_link->handleProcess(Command::LWR, lwr_data, 1);
+    bus.processDataWrite([](DatagramState const&){});
+}
+
+
+TEST_F(BusTest, mailbox_status_fmmu_wkc_error_during_programming)
+{
+    auto& slave = bus.slaves().at(0);
+    slave.is_static_mapping = true;
+    slave.input.bsize = 4;
+    slave.input.sync_manager = 1;
+    slave.output.bsize = 4;
+    slave.output.sync_manager = 0;
+
+    bus.configureMailboxStatusCheck(MailboxStatusFMMU::READ_CHECK);
+
+    // configureFMMUs: 4 FPWR OK
+    for (int i = 0; i < 4; ++i)
+    {
+        mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+    }
+    // configureMailboxFMMUs: FPWR with WKC=0 -> error
+    mock_link->handleProcess(Command::FPWR, uint8_t{0}, 0);
+
+    uint8_t iomap[64];
+    ASSERT_THROW(bus.createMapping(iomap), Error);
+}
+
+
+TEST_F(BusTest, mailbox_sequencer_skip_fmmu_read_check)
+{
+    bus.configureMailboxStatusCheck(MailboxStatusFMMU::READ_CHECK);
+    MailboxSequencer sequencer(bus);
+    auto noop = [](DatagramState const&){};
+
+    // Step 1: phase 0 skipped (FMMU) -> immediately executes sendReadMessages (phase 1)
+    sequencer.step(noop);
+
+    // Step 2: sendMailboxesWriteChecks (phase 2, not covered by FMMU)
+    mock_link->handleProcess(Command::FPRD, uint8_t{0x00}, 1);
+    sequencer.step(noop);
+    bus.processAwaitingFrames();
+
+    // Step 3: sendWriteMessages (phase 3)
+    sequencer.step(noop);
+
+    // Step 4: phase 0 skipped again -> sendReadMessages (phase 1)
+    sequencer.step(noop);
+}
+
+
+TEST_F(BusTest, mailbox_sequencer_skip_fmmu_both)
+{
+    bus.configureMailboxStatusCheck(MailboxStatusFMMU::READ_CHECK | MailboxStatusFMMU::WRITE_CHECK);
+    MailboxSequencer sequencer(bus);
+    auto noop = [](DatagramState const&){};
+
+    // Step 1: phase 0 skipped, phase 1 executes -> sendReadMessages
+    sequencer.step(noop);
+
+    // Step 2: phase 2 skipped, phase 3 executes -> sendWriteMessages
+    sequencer.step(noop);
+
+    // Step 3: phase 0 skipped -> sendReadMessages again (full cycle in 2 calls)
+    sequencer.step(noop);
+}
+
+
+TEST_F(BusTest, mailbox_sequencer_no_skip_without_fmmu)
+{
+    MailboxSequencer sequencer(bus);
+    auto noop = [](DatagramState const&){};
+
+    // Phase 0: sendMailboxesReadChecks -> NOT skipped
+    mock_link->handleProcess(Command::FPRD, uint8_t{0x00}, 1);
+    sequencer.step(noop);
+    bus.processAwaitingFrames();
+
+    // Phase 1: sendReadMessages -> nothing
+    sequencer.step(noop);
+
+    // Phase 2: sendMailboxesWriteChecks -> NOT skipped
+    mock_link->handleProcess(Command::FPRD, uint8_t{0x00}, 1);
+    sequencer.step(noop);
+    bus.processAwaitingFrames();
+
+    // Phase 3: sendWriteMessages -> nothing
+    sequencer.step(noop);
+}


### PR DESCRIPTION
Closes #56 

Add a config that enable the usage of remaining FMMUs to fetch the mailbox status directly at the end of the PDOs/Process Image provided that the slave has enough FMMUs available (i.e. lan9252 have only 3 FMMUs, so all checks cannot be enable).

Note that for now the FMMus selection is static:
FMMU0/1 -> PDOs
FMMU2/3 -> mbx checks