### PR TITLE
Fix SYNC_MANAGER_CONTROL bitmasks for operation mode and direction

### DIFF
--- a/lib/include/kickcat/protocol.h
+++ b/lib/include/kickcat/protocol.h
@@ -410,8 +410,8 @@ namespace kickcat
     constexpr uint8_t SM_CONTROL_WATCHDOG_MASK          = 0x40;
     constexpr uint8_t SM_CONTROL_WATCHDOG_DISABLED      = 0x00;
     constexpr uint8_t SM_CONTROL_WATCHDOG_ENABLED       = 0x40;
-    constexpr uint8_t SYNC_MANAGER_CONTROL_OPERATION_MODE_MASK = (1 << 0);
-    constexpr uint8_t SYNC_MANAGER_CONTROL_DIRECTION_MASK = (1 << 1);
+    constexpr uint8_t SYNC_MANAGER_CONTROL_OPERATION_MODE_MASK = 0x03; // bits [1:0]
+    constexpr uint8_t SYNC_MANAGER_CONTROL_DIRECTION_MASK      = 0x0C; // bits [3:2]
 
     constexpr uint8_t SM_ACTIVATE_ENABLE        = (1 << 0);
     constexpr uint8_t SM_ACTIVATE_REPEAT_REQ    = (1 << 1);


### PR DESCRIPTION
From Section II Register Description:
<img width="853" height="755" alt="Screenshot from 2026-04-11 13-07-56" src="https://github.com/user-attachments/assets/d7ec27e3-a6e0-4de5-9d38-90cb47827428" />

- `SYNC_MANAGER_CONTROL_OPERATION_MODE_MASK` was `0x01` — bit 0 is always 0 for all valid modes (buffered=00, mailbox=10), so the check was a no-op.
- `SYNC_MANAGER_CONTROL_DIRECTION_MASK` was `0x02` — bit 1 is the MSB of the operation mode field, not direction, so `isSmValid()` was accidentally checking mode (partially) while never checking direction at all.

We've been always in an unconditionally true case, which is why everything works its just that we could have slaves that has its  SMs configured incorrectly and `isSmValid()` would have returned true.

- [x] Test on hardware