### PR TITLE
Improve the network_simulator and EsiParser

### DIFF
--- a/FlexibleEC1.json
+++ b/FlexibleEC1.json
@@ -1,0 +1,4 @@
+{
+    "eeprom": "/home/etherdog/etherdog-fmu/Examples/EsiFiles/BIN/Box 1 (EtherDOG).bin",
+    "coe_xml": "/home/etherdog/etherdog-fmu/Examples/EsiFiles/XML/EtherDOG.xml"
+}

--- a/examples/master/load_esi/load_esi.cc
+++ b/examples/master/load_esi/load_esi.cc
@@ -28,7 +28,7 @@ int main(int argc, char const* argv[])
     CoE::EsiParser parser;
 
     nanoseconds t1 = since_epoch();
-    CoE::Dictionary coe_dict = parser.loadFile(esi_file);
+    CoE::Dictionary coe_dict = parser.loadFirstDictionaryFromFile(esi_file);
     nanoseconds t2 = since_epoch();
 
     // dangerous lack of error checking.

--- a/lib/include/kickcat/CoE/EsiParser.h
+++ b/lib/include/kickcat/CoE/EsiParser.h
@@ -14,17 +14,18 @@ namespace kickcat::CoE
         EsiParser() = default;
         ~EsiParser() = default;
 
-        CoE::Dictionary loadFile  (std::string const& file);
-        CoE::Dictionary loadString(std::string const& xml);
+        Dictionary loadFirstDictionaryFromFile  (std::string const& file);
+        std::vector<Device> loadDevicesFromFile  (std::string const& file);
+        std::vector<Device> loadString(std::string const& xml);
 
         char const* vendor() const  { return vendor_->FirstChildElement("Name")->GetText();       }
         char const* profile() const { return profile_->FirstChildElement("ProfileNo")->GetText(); }
 
     private:
+    
         template<typename T>
-        T toNumber(tinyxml2::XMLElement* node)
+        T toNumber(std::string& field)
         {
-            std::string field = node->GetText();
             if (field.rfind("#x", 0) == 0)
             {
                 field[0] = '0';
@@ -32,7 +33,15 @@ namespace kickcat::CoE
             return std::stoi(field, nullptr, 0);
         }
 
-        CoE::Dictionary parse(); // main method
+        template<typename T>
+        T toNumber(tinyxml2::XMLElement* node)
+        {
+            std::string field = node->GetText();
+            return toNumber<T>(field);
+        }
+
+        std::vector<Device> parse(); // main method
+        Dictionary loadDictionary();
         std::vector<uint8_t> loadHexBinary(tinyxml2::XMLElement* node);
         std::vector<uint8_t> loadString(tinyxml2::XMLElement* node);
 
@@ -58,6 +67,7 @@ namespace kickcat::CoE
         tinyxml2::XMLElement* desc_;
 
         // jump on profile and associated dictionnary
+        tinyxml2::XMLElement* type_;
         tinyxml2::XMLElement* profile_;
         tinyxml2::XMLElement* devices_;
         tinyxml2::XMLElement* device_;

--- a/lib/include/kickcat/CoE/OD.h
+++ b/lib/include/kickcat/CoE/OD.h
@@ -265,6 +265,16 @@ namespace kickcat::CoE
 
     Dictionary createOD();
     Dictionary& dictionary();
+
+    struct Device 
+    {
+        uint32_t vendor_id;
+        uint32_t product_code;
+        uint32_t revision_number;
+        // uint32_t serial_number;
+
+        Dictionary dictionary;
+    };
 }
 
 #endif

--- a/lib/slave/include/kickcat/ESC/EmulatedESC.h
+++ b/lib/slave/include/kickcat/ESC/EmulatedESC.h
@@ -32,6 +32,15 @@ namespace kickcat
         // Access from the PDI POV
         int32_t read (uint16_t address, void* data,       uint16_t size) override;
         int32_t write(uint16_t address, void const* data, uint16_t size) override;
+        uint32_t getVendorId() const { return vendor_id_; }
+        uint32_t getProductCode() const { return product_code_; }
+        uint32_t getRevisionNumber() const { return revision_number_; }
+
+
+    private:
+        uint32_t vendor_id_ = 0;
+        uint32_t product_code_ = 0;
+        uint32_t revision_number_ = 0;
 
     private:
         struct Memory

--- a/lib/slave/src/ESC/EmulatedESC.cc
+++ b/lib/slave/src/ESC/EmulatedESC.cc
@@ -69,10 +69,25 @@ namespace kickcat
 
     void EmulatedESC::loadEeprom()
     {
-        // Device emulation
+        // 1. ESC Configuration (Word 0, high byte)
         memory_.esc_configuration = eeprom_[0] >> 8;
 
-        memory_.station_alias = eeprom_[4]; // fourth word of eeprom, at first load
+        // 2. Station Alias (Word 4)
+        // Note: If you use Word 4 for Alias, ensure your BIN file actually has 
+        // an alias there, otherwise it may interfere with identity reading logic.
+        memory_.station_alias = eeprom_[4];
+
+        // 3. MANDATORY IDENTITY OFFSETS (Words 8 through 13)
+        // In many Beckhoff BIN files, the Identity section starts at Word 8 (Byte 16)
+        
+        // Vendor ID (Word 8 & 9)
+        vendor_id_ = (static_cast<uint32_t>(eeprom_[9]) << 16) | eeprom_[8];
+        
+        // Product Code (Word 10 & 11)
+        product_code_ = (static_cast<uint32_t>(eeprom_[11]) << 16) | eeprom_[10];
+        
+        // Revision Number (Word 12 & 13)
+        revision_number_ = (static_cast<uint32_t>(eeprom_[13]) << 16) | eeprom_[12];
     }
 
 

--- a/lib/slave/src/ESC/EmulatedESC.cc
+++ b/lib/slave/src/ESC/EmulatedESC.cc
@@ -360,42 +360,46 @@ namespace kickcat
         {
             State before  = static_cast<State>(memory_.al_status  & 0xf);
             State current = static_cast<State>(memory_.al_control & 0xf);
-            simu_info("%f  %s -> %s  \n", seconds_f(since_epoch() - start).count(), toString(before), toString(current));
+
+            memory_.al_status_code = 0;
+            memory_.al_status &= ~AL_STATUS_ERR_IND;
 
             switch (current)
             {
-                case State::BOOT: { break; }
-                case State::INIT: { break; }
-                case State::PRE_OP:
+            case State::PRE_OP:
+                if (before == State::INIT)
                 {
-                    if (before == State::INIT)
-                    {
-                        configureSMs();
+                    configureSMs();
+                }
+                memory_.al_status = State::PRE_OP;
+                break;
 
-                        seconds_f wdgPDI = pdiWatchdog();
-                        seconds_f wdgPDO = pdoWatchdog();
-                        simu_info("PDI watchdog: %04fs\n", wdgPDI.count());
-                        simu_info("PDO watchdog: %04fs\n", wdgPDO.count());
-                    }
-                    break;
-                }
-                case State::SAFE_OP:
+            case State::SAFE_OP:
+                if (before == State::PRE_OP)
                 {
-                    if (before == State::PRE_OP)
-                    {
-                        configurePDOs();
-                    }
-                    break;
+                    configurePDOs();
+                    lastLogicalWrite_ = since_epoch();
                 }
-                case State::OPERATIONAL: { break; }
-                default: {}
+                memory_.watchdog_status_process_data = 1;
+                memory_.al_status = State::SAFE_OP;
+                break;
+
+            case State::OPERATIONAL:
+                if (before == State::SAFE_OP)
+                {
+                    lastLogicalWrite_ = since_epoch();
+                    memory_.watchdog_status_process_data = 1;
+                    memory_.al_status = State::OPERATIONAL;
+                }
+                break;
+
+            case State::INIT:
+                memory_.al_status = State::INIT;
+                break;
+
+            default:
+                break;
             }
-        }
-
-        // Mirror AL_STATUS - Device Emulation
-        if(memory_.esc_configuration & 0x01)
-        {
-            memory_.al_status = memory_.al_control;
         }
 
         // Handle eeprom access
@@ -456,7 +460,10 @@ namespace kickcat
             }
         }
 
-        checkWatchdog();
+        if (memory_.al_status & State::OPERATIONAL)
+        {
+            checkWatchdog();
+        }
     }
 
 

--- a/lib/src/CoE/EsiParser.cc
+++ b/lib/src/CoE/EsiParser.cc
@@ -50,7 +50,12 @@ namespace kickcat::CoE
         {"Inputs",   4},
     };
 
-    Dictionary EsiParser::loadFile(std::string const& file)
+    Dictionary EsiParser::loadFirstDictionaryFromFile  (std::string const& file) 
+    {
+        return std::move(loadDevicesFromFile(file).front().dictionary);
+    }
+
+    std::vector<Device> EsiParser::loadDevicesFromFile(std::string const& file)
     {
         XMLError result = doc_.LoadFile(file.c_str());
         if (result != XML_SUCCESS)
@@ -61,7 +66,7 @@ namespace kickcat::CoE
         return parse();
     }
 
-    Dictionary EsiParser::loadString(std::string const& xml)
+    std::vector<Device> EsiParser::loadString(std::string const& xml)
     {
         XMLError result = doc_.Parse(xml.c_str());
         if (result != XML_SUCCESS)
@@ -72,41 +77,74 @@ namespace kickcat::CoE
         return parse();
     }
 
-    Dictionary EsiParser::parse()
+    // Helper to find and check a child element, throw if not found
+    XMLElement* firstChildElement(XMLNode* node, char const* name)
+    {
+        auto element = node->FirstChildElement(name);
+        if (element == nullptr)
+        {
+            std::string desc = "Cannot find child element <";
+            desc += node->Value();
+            desc += "> -> ";
+            desc += name;
+            throw std::invalid_argument(desc);
+        }
+        return element;
+    };
+
+    std::vector<Device> EsiParser::parse()
     {
         root_ = doc_.RootElement();
 
-        // Helper to find and check a child element, throw if not found
-        auto firstChildElement = [](XMLNode* node, char const* name) -> XMLElement*
-        {
-            auto element = node->FirstChildElement(name);
-            if (element == nullptr)
-            {
-                std::string desc = "Cannot find child element <";
-                desc += node->Value();
-                desc += "> -> ";
-                desc += name;
-                throw std::invalid_argument(desc);
-            }
-            return element;
-        };
-
         // Position handler on main entry points
         vendor_ = firstChildElement(root_, "Vendor");
+        uint32_t vendorId = toNumber<uint32_t>(firstChildElement(vendor_, "Id"));
         desc_   = firstChildElement(root_, "Descriptions");
+        devices_ = firstChildElement(desc_, "Devices");
 
-        // jump on profile and associated dictionnary
-        devices_    = firstChildElement(desc_,       "Devices");
-        device_     = firstChildElement(devices_,    "Device");
-        profile_    = firstChildElement(device_,     "Profile");
-        dictionary_ = firstChildElement(profile_,    "Dictionary");
-        dtypes_     = firstChildElement(dictionary_, "DataTypes");
-        objects_    = firstChildElement(dictionary_, "Objects");
+        // Loop through devices to find one with a Profile and Dictionary
+        device_ = devices_->FirstChildElement("Device");
 
-        // Load dictionary
+       std::vector<Device> devices;
+
+        while (device_)
+        {
+            type_ = device_->FirstChildElement("Type");
+            std::string product_code_str = type_->Attribute("ProductCode");
+            std::string revision_number_str = type_->Attribute("RevisionNo");
+            uint32_t productCode = toNumber<uint32_t>(product_code_str);
+            uint32_t revision_number = toNumber<uint32_t>(revision_number_str);
+            
+            Device new_device;
+            new_device.vendor_id = vendorId;
+            new_device.product_code = productCode;
+            new_device.revision_number = revision_number;
+            printf("Found device with vendor id 0x%08x, product code 0x%08x, revision number 0x%08x\n", new_device.vendor_id, new_device.product_code, new_device.revision_number);
+            profile_ = device_->FirstChildElement("Profile");
+            if (profile_)
+            {
+                dictionary_ = profile_->FirstChildElement("Dictionary");
+                if (dictionary_)
+                {
+                    // If we find the dictionary, set the remaining pointers and break
+                    dtypes_  = firstChildElement(dictionary_, "DataTypes");
+                    objects_ = firstChildElement(dictionary_, "Objects");
+                    new_device.dictionary = loadDictionary();
+                }
+            }
+            devices.push_back(std::move(new_device));
+            // Move to the next <Device> in the XML file (e.g., skip EL1002)
+            device_ = device_->NextSiblingElement("Device");
+        }
+
+        return devices;
+    }
+
+    Dictionary EsiParser::loadDictionary() 
+    {
         Dictionary dictionary;
 
-        // loop over dictionnary
+        // loop over dictionary
         auto node_object = objects_->FirstChildElement();
         while (node_object)
         {
@@ -520,7 +558,6 @@ namespace kickcat::CoE
                 object_subitem = object_subitem->NextSiblingElement();
             }
         }
-
         return object;
     }
 }

--- a/simulation/network_simulator.cc
+++ b/simulation/network_simulator.cc
@@ -98,13 +98,6 @@ int main(int argc, char* argv[])
         expanded_slave_configs = slave_configs;
     }
 
-	if (slave_configs.empty())
-    {
-        std::cerr << "No slave configuration files provided" << std::endl;
-        std::cerr << program;
-        return 1;
-    }
-
     size_t slave_count = expanded_slave_configs.size();
     std::vector<std::unique_ptr<EmulatedESC>> escs;
     std::vector<std::unique_ptr<PDO>> pdos;

--- a/simulation/network_simulator.cc
+++ b/simulation/network_simulator.cc
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <nlohmann/json.hpp>
 #include <numeric>
 
@@ -19,6 +20,21 @@ using namespace kickcat;
 using namespace kickcat::slave;
 using json = nlohmann::json;
 namespace fs = std::filesystem;
+
+CoE::Device findDeviceByVendorAndProduct(std::vector<CoE::Device>&& devices, uint32_t vendor_id, uint32_t product_code, uint32_t revision_number)
+{
+    for (CoE::Device& device : devices)
+    {
+        if (device.vendor_id == vendor_id && device.product_code == product_code && device.revision_number == revision_number)
+        {
+            printf("Found matching device in ESI file for vendor_id 0x%08x, product_code 0x%08x, revision_number 0x%08x\n", vendor_id, product_code, revision_number);
+            return std::move(device);
+        }
+    }
+    std::stringstream ss;
+    ss << "No matching device found for vendor_id 0x" << std::hex << vendor_id << " and product_code 0x" << product_code << " and revision_number 0x" << revision_number;
+    throw std::runtime_error(ss.str());
+}
 
 int main(int argc, char* argv[])
 {
@@ -147,8 +163,14 @@ int main(int argc, char* argv[])
             std::string coe_xml_path = config["coe_xml"];
             fs::path coe_xml_full_path = config_dir / coe_xml_path;
             auto mbx = std::make_unique<mailbox::response::Mailbox>(esc.get(), 1024);
-            auto dictionary = parser.loadFile(coe_xml_full_path.string());
-            mbx->enableCoE(std::move(dictionary));
+            auto devices = parser.loadDevicesFromFile(coe_xml_full_path.string());
+
+            // search for productcode / vendor id:
+            uint32_t vendor_id = esc->getVendorId(); // from EEPROM
+            uint32_t product_code = esc->getProductCode(); // from EEPROM
+            uint32_t revision_number = esc->getRevisionNumber(); // from EEPROM
+            CoE::Device device = findDeviceByVendorAndProduct(std::move(devices), vendor_id, product_code, revision_number);
+            mbx->enableCoE(std::move(device.dictionary));
             slave->setMailbox(mbx.get());
             mailboxes.push_back(std::move(mbx));
         }

--- a/tools/od_generator.cc
+++ b/tools/od_generator.cc
@@ -147,7 +147,7 @@ namespace kickcat
     CoE::Dictionary loadOD(std::string esiFileName)
     {
         CoE::EsiParser parser;
-        return parser.loadFile(esiFileName);
+        return parser.loadFirstDictionaryFromFile(esiFileName);
     }
 
     std::string addBeginning()

--- a/unit/src/CoE/EsiParser-t.cc
+++ b/unit/src/CoE/EsiParser-t.cc
@@ -11,7 +11,7 @@ using namespace kickcat;
 TEST(EsiParser, load_error_not_an_xml)
 {
     CoE::EsiParser parser;
-    ASSERT_THROW((void) parser.loadFile(""),   std::runtime_error);
+    ASSERT_THROW((void) parser.loadFirstDictionaryFromFile(""),   std::runtime_error);
     ASSERT_THROW((void) parser.loadString(""), std::runtime_error);
 }
 
@@ -25,7 +25,7 @@ TEST(EsiParser, load_error_xml_not_an_esi)
 TEST(EsiParser, load)
 {
     CoE::EsiParser parser;
-    auto dictionary = parser.loadFile("foot.xml");
+    auto dictionary = parser.loadFirstDictionaryFromFile("foot.xml");
 
     ASSERT_EQ(dictionary.size(), 22);
     ASSERT_STREQ(parser.profile(), "0");
@@ -140,7 +140,7 @@ TEST(EsiParser, load)
 TEST(EsiParser, load_complex_with_enums_and_default_value)
 {
     CoE::EsiParser parser;
-    auto dictionary = parser.loadFile("kickcat_esi_test_complex.xml");
+    auto dictionary = parser.loadFirstDictionaryFromFile("kickcat_esi_test_complex.xml");
 
     ASSERT_STREQ(parser.profile(), "5002");
     ASSERT_STREQ(parser.vendor(),  "KickCAT");
@@ -251,7 +251,7 @@ TEST(EsiParser, load_complex_with_enums_and_default_value)
 TEST(EsiParser, load_basic_with_bit_types_and_no_info)
 {
     CoE::EsiParser parser;
-    auto dictionary = parser.loadFile("kickcat_esi_test_basic.xml");
+    auto dictionary = parser.loadFirstDictionaryFromFile("kickcat_esi_test_basic.xml");
 
     ASSERT_STREQ(parser.profile(), "5001");
     ASSERT_STREQ(parser.vendor(),  "KickCAT");


### PR DESCRIPTION
This modification is making the KickCAT more compliance with the official Beckhoff EtherCAT module. So the XML file from Beckhoff can contain several EtherCAT devices (e.g. EL1xxx.xml) but the EEPROM BIN only contains 1 device. With these changes, the program will get the vendor_id, product_code, and revision_number from the EEPROM BIN. From that, the program go look into the xml file until it find the matching vendor_id, product_code, and revision_number instead of finding the first elements. 
Also I agree with the ENI vs ESI seperation because for example the EL1xxx modules need a EtherCAT bus coupler infront of it. It's more convenient to have a .json file that contains whole network instead of `-s <EtherCAT coupler (EK1xxx)>.json <EL1xxx>.json`