### PR TITLE
ESI parser step 4: PDOs + EEPROM + Distributed Clocks

### DIFF
--- a/lib/include/kickcat/ESI/Device.h
+++ b/lib/include/kickcat/ESI/Device.h
@@ -1,6 +1,7 @@
 #ifndef KICKCAT_ESI_DEVICE_H
 #define KICKCAT_ESI_DEVICE_H
 
+#include <array>
 #include <cstdint>
 #include <cstddef>
 #include <optional>
@@ -12,9 +13,11 @@
 
 namespace kickcat::ESI
 {
-    struct SyncManager
+    // Distinct from kickcat::SyncManager (the runtime register-layout namespace,
+    // which it would otherwise shadow): the parsed attributes of an ESI <Sm>.
+    struct SmInfo
     {
-        kickcat::SyncManager::Type type = kickcat::SyncManager::Unused;
+        SyncManager::Type type = SyncManager::Unused;
         uint16_t min_size       = 0;
         uint16_t max_size       = 0;
         uint16_t default_size   = 0;
@@ -149,6 +152,125 @@ namespace kickcat::ESI
         std::optional<VoE> voe;
     };
 
+    // ETG.2000 RxPdo/TxPdo: a Process Data Object declared at device level. The
+    // master uses these to compose the 0x1C12/0x1C13 SyncManager assignment and
+    // the 0x16xx/0x1Axx mapping CoE objects when the slave doesn't expose them
+    // directly in <Objects>.
+    struct PdoEntry
+    {
+        uint16_t    index    = 0;
+        uint8_t     subindex = 0;
+        uint16_t    bit_len  = 0;
+        std::string name;
+        std::string comment;
+        std::string data_type;  // ESI text label (e.g. "UINT", "UDINT")
+
+        bool                       fixed = false;
+        std::optional<int32_t>     safety_conn_number;
+        std::string                safety_pdo_entry_type;
+    };
+
+    struct Pdo
+    {
+        uint16_t              index = 0;
+        std::string           name;
+        std::optional<int32_t> sm;             // index into Device::sync_managers
+        std::optional<int32_t> su;             // index into Device::sync_units
+        bool                  fixed                 = false;
+        bool                  mandatory             = false;
+        bool                  is_virtual            = false;
+        std::optional<int32_t> os_fac;
+        std::optional<int32_t> os_min;
+        std::optional<int32_t> os_max;
+        std::optional<int32_t> os_index_inc;
+        std::optional<int32_t> pdo_order;
+        bool                  overwritten_by_module = false;
+        bool                  sra_parameter         = false;
+        std::string           safety_pdo_type;
+        std::optional<int32_t> safety_conn_number;
+        std::vector<uint16_t> exclude;         // mutually exclusive PDO indexes
+        std::vector<int32_t>  excluded_sm;
+        std::vector<PdoEntry> entries;
+    };
+
+    // ETG.2000 <Eeprom>: describes the slave's SII content. Two mutually
+    // exclusive forms — raw_data populated (full image as hex) OR the
+    // structured form (byte_size + config_data + optional bootstrap +
+    // categories).
+    struct Eeprom
+    {
+        struct Category
+        {
+            int32_t                    cat_no = 0;
+            std::vector<uint8_t>       data;          // <Data>
+            std::optional<std::string> data_string;   // <DataString>
+            std::optional<int32_t>     data_uint;     // <DataUINT>
+            std::optional<int32_t>     data_udint;    // <DataUDINT>
+            bool                       preserve_online_data = false;
+        };
+
+        std::vector<uint8_t>     raw_data;        // <Data> at Eeprom level (raw image)
+        std::optional<int32_t>   byte_size;
+        std::vector<uint8_t>     config_data;     // first 16 SII bytes
+        std::vector<uint8_t>     config_data2;
+        std::vector<uint8_t>     bootstrap;       // bootstrap mailbox config
+        std::vector<Category>    categories;
+        bool                     assign_to_pdi = false;
+    };
+
+    // ETG.2000 <Dc>/<OpMode>: distributed-clocks configuration.
+    struct OpMode
+    {
+        struct SyncTime
+        {
+            int32_t                value = 0;
+            std::optional<int32_t> factor;
+        };
+
+        struct ShiftTime
+        {
+            int32_t                value = 0;
+            std::optional<int32_t> factor;
+            std::optional<bool>    input;
+            std::optional<int32_t> output_delay_time;
+            std::optional<int32_t> input_delay_time;
+        };
+
+        // <OpMode>/<Sm No="..">. The SyncType/CycleTime/ShiftTime children are
+        // obsolete in the ESI XSD and have no fields here.
+        struct SmConfig
+        {
+            struct PdoRef
+            {
+                uint16_t               index = 0;
+                std::optional<int32_t> os_fac;   // <Pdo>/@OSFac: oversampling factor
+            };
+
+            int32_t             no = 0;   // required @No: target SyncManager index
+            std::vector<PdoRef> pdos;
+        };
+
+        std::string             name;
+        std::string             desc;
+        uint32_t                assign_activate = 0;
+        std::optional<uint32_t> activate_additional;
+
+        std::array<std::optional<SyncTime>,  4> cycle_time;   // CycleTimeSync0..3
+        std::array<std::optional<ShiftTime>, 4> shift_time;   // ShiftTimeSync0..3
+        std::vector<SmConfig>                   sm_configs;
+    };
+
+    struct Dc
+    {
+        bool                unknown_frmw              = false;
+        bool                unknown_64bit             = false;
+        bool                external_ref_clock        = false;
+        bool                potential_reference_clock = false;
+        bool                time_loop_control_only    = false;
+        bool                pdo_oversampling          = false;
+        std::vector<OpMode> op_modes;
+    };
+
     struct DeviceSummary
     {
         std::string type;
@@ -179,10 +301,14 @@ namespace kickcat::ESI
         std::string  vendor_name;
         uint32_t     vendor_id = 0;
 
-        std::vector<SyncManager> sync_managers;
+        std::vector<SmInfo>      sync_managers;
         std::vector<SyncUnit>    sync_units;
         std::vector<Fmmu>        fmmus;
-        Mailbox                  mailbox;
+        std::optional<Mailbox>   mailbox;
+        std::vector<Pdo>         rx_pdos;
+        std::vector<Pdo>         tx_pdos;
+        std::optional<Eeprom>    eeprom;
+        std::optional<Dc>        dc;
 
         CoE::Dictionary          dictionary;
     };

--- a/lib/include/kickcat/ESI/Parser.h
+++ b/lib/include/kickcat/ESI/Parser.h
@@ -30,6 +30,11 @@ namespace kickcat::ESI
         Device loadDevice      (std::string const& file, DeviceFilter const& filter = {});
         Device loadDeviceString(std::string const& xml,  DeviceFilter const& filter = {});
 
+        // Pure CoE-object synthesis from parsed PDO data (ETG.1000.6 layout),
+        // independent of any XML/parser state. Exposed for direct unit testing.
+        static CoE::Object buildMappingObject   (Pdo const& pdo, bool is_rx);
+        static CoE::Object buildAssignmentObject(std::vector<Pdo> const& pdos, uint16_t index, bool is_rx);
+
     private:
         static std::optional<uint32_t> readHexDecAttr(tinyxml2::XMLElement* node, char const* name);
 
@@ -43,16 +48,23 @@ namespace kickcat::ESI
         tinyxml2::XMLElement* selectDevice(DeviceFilter const& filter);
         DeviceSummary         summarize   (tinyxml2::XMLElement* device);
 
-        void parseSyncManagers(tinyxml2::XMLElement* device, std::vector<SyncManager>& out);
+        void parseSyncManagers(tinyxml2::XMLElement* device, std::vector<SmInfo>& out);
         void parseSyncUnits   (tinyxml2::XMLElement* device, std::vector<SyncUnit>&    out);
         void parseFmmus       (tinyxml2::XMLElement* device, std::vector<Fmmu>&        out);
-        void parseMailbox     (tinyxml2::XMLElement* device, Mailbox&                  out);
+        void parseMailbox     (tinyxml2::XMLElement* device, std::optional<Mailbox>&   out);
+        void parsePdos        (tinyxml2::XMLElement* device, char const* element_name, std::vector<Pdo>& out);
+        void parseEeprom      (tinyxml2::XMLElement* device, std::optional<Eeprom>&    out);
+        void parseDc          (tinyxml2::XMLElement* device, std::optional<Dc>&        out);
 
         CoE::Dictionary buildDictionary(tinyxml2::XMLElement* profile,
-                                        std::vector<SyncManager> const& sms);
+                                        std::vector<SmInfo> const& sms);
+
+        // Appends 0x16xx/0x1Axx mapping objects and 0x1C12/0x1C13 SM-assignment
+        // objects to the dictionary based on the parsed Pdo lists, but only
+        // for objects that aren't already declared in <Dictionary>/<Objects>.
+        void synthesizePdoMappingObjects(Device& device);
 
         std::vector<uint8_t> loadHexBinary(tinyxml2::XMLElement* node);
-        std::vector<uint8_t> loadStringData(tinyxml2::XMLElement* node);
 
         void loadDefaultData(tinyxml2::XMLNode* node, CoE::Object& obj, CoE::Entry& entry);
         uint16_t loadAccess(tinyxml2::XMLNode* node);

--- a/lib/src/ESI/Parser.cc
+++ b/lib/src/ESI/Parser.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cstring>
+#include <limits>
 #include <stdexcept>
 #include <string>
 
@@ -97,8 +98,11 @@ namespace
         return text;
     }
 
-    // Parent + child-name overload: fetches then validates.
-    char const* requireText(XMLNode* parent, char const* child, std::string const& where)
+    // Parent + child-name convenience: fetches the child element, then
+    // delegates to requireText. Distinct name from requireText to avoid an
+    // overload-resolution trap where a derived-class pointer (XMLElement*)
+    // silently binds to the wrong overload.
+    char const* requireChildText(XMLNode* parent, char const* child, std::string const& where)
     {
         return requireText(parent->FirstChildElement(child), child, where);
     }
@@ -114,37 +118,108 @@ namespace
         return elem->GetText();
     }
 
-    int64_t parseHexDec(std::string text)
+    int64_t parseHexDec(std::string text, std::string const& where = {})
     {
+        auto fail = [&](char const* msg)
+        {
+            std::string what = "ESI: ";
+            what += msg;
+            what += " '";
+            what += text;
+            what += "'";
+            if (not where.empty())
+            {
+                what += " in ";
+                what += where;
+            }
+            throw std::invalid_argument(what);
+        };
+
         if (text.empty())
         {
-            throw std::invalid_argument("ESI: empty numeric value");
+            fail("empty numeric value");
         }
-        if (text.rfind("#x", 0) == 0)
+        try
         {
-            if (text.size() == 2)
+            if (text.rfind("#x", 0) == 0)
             {
-                throw std::invalid_argument("ESI: '#x' with no hex digits");
+                if (text.size() == 2) { fail("'#x' with no hex digits"); }
+                text[0] = '0';
+                return std::stoll(text, nullptr, 16);
             }
-            text[0] = '0';
-            return std::stoll(text, nullptr, 16);
+            if (text.rfind("0x", 0) == 0 or text.rfind("0X", 0) == 0)
+            {
+                if (text.size() == 2) { fail("'0x' with no hex digits"); }
+                return std::stoll(text, nullptr, 16);
+            }
+            return std::stoll(text, nullptr, 10);
         }
-        if (text.rfind("0x", 0) == 0 or text.rfind("0X", 0) == 0)
+        catch (std::invalid_argument const&)
         {
-            if (text.size() == 2)
-            {
-                throw std::invalid_argument("ESI: '0x' with no hex digits");
-            }
-            return std::stoll(text, nullptr, 16);
+            fail("invalid numeric value");
         }
-        return std::stoll(text, nullptr, 10);
+        catch (std::out_of_range const&)
+        {
+            fail("numeric value exceeds int64 range");
+        }
+        return 0;  // unreachable; fail() always throws
+    }
+
+    // Narrow an int64_t to T with bounds checking. For signed T, also accepts
+    // the unsigned bit pattern in [0, max-of-make_unsigned_t<T>] so that real
+    // ETG ESIs using #xFFFFFFFF as a signed-int32 sentinel parse as -1 rather
+    // than throwing.
+    template<typename T>
+    T narrowChecked(int64_t value, std::string const& text, std::string const& where)
+    {
+        static_assert(sizeof(T) <= sizeof(int64_t), "narrowChecked unsupported for T wider than int64");
+        auto fail = [&](char const* kind)
+        {
+            std::string what = "ESI: value '";
+            what += text;
+            what += "' out of range for ";
+            what += std::to_string(sizeof(T) * 8);
+            what += "-bit ";
+            what += kind;
+            what += " type in ";
+            what += where;
+            throw std::invalid_argument(what);
+        };
+
+        if constexpr (std::is_signed_v<T>)
+        {
+            using U = std::make_unsigned_t<T>;
+            int64_t lo = static_cast<int64_t>(std::numeric_limits<T>::min());
+            int64_t hi = static_cast<int64_t>(std::numeric_limits<U>::max());
+            if (value < lo or value > hi)
+            {
+                fail("signed");
+            }
+            return static_cast<T>(static_cast<U>(value));
+        }
+        else
+        {
+            int64_t hi = static_cast<int64_t>(std::numeric_limits<T>::max());
+            if (value < 0 or value > hi)
+            {
+                fail("unsigned");
+            }
+            return static_cast<T>(value);
+        }
+    }
+
+    template<typename T>
+    T parseHexDec(std::string text, std::string const& where)
+    {
+        int64_t value = parseHexDec(text, where);
+        return narrowChecked<T>(value, text, where);
     }
 
     template<typename T>
     T requireNumber(XMLNode* parent, char const* child, std::string const& where)
     {
-        char const* text = requireText(parent, child, where);
-        return static_cast<T>(parseHexDec(text));
+        char const* text = requireChildText(parent, child, where);
+        return parseHexDec<T>(text, where);
     }
 
     std::string objectLabel(uint16_t index)
@@ -254,7 +329,7 @@ std::optional<uint32_t> Parser::readHexDecAttr(XMLElement* node, char const* nam
     {
         return std::nullopt;
     }
-    return static_cast<uint32_t>(parseHexDec(raw));
+    return parseHexDec<uint32_t>(raw, std::string{"@"} + name);
 }
 
 void Parser::openFile(std::string const& file)
@@ -279,7 +354,17 @@ void Parser::openString(std::string const& xml)
 
 void Parser::resolveTopLevel()
 {
-    root_       = doc_.RootElement();
+    // Reset per-load cached state so values from a previous load don't bleed
+    // through if the next ESI omits an optional element.
+    vendor_name_.clear();
+    profile_no_.clear();
+    dtypes_ = nullptr;
+
+    root_ = doc_.RootElement();
+    if (root_ == nullptr)
+    {
+        throw std::invalid_argument("ESI: document has no root element");
+    }
     vendor_xml_ = requireChild(root_, "Vendor");
     auto desc   = requireChild(root_, "Descriptions");
     devices_    = requireChild(desc,  "Devices");
@@ -387,18 +472,19 @@ Device Parser::loadDeviceString(std::string const& xml, DeviceFilter const& filt
 
 Device Parser::loadDeviceImpl(DeviceFilter const& filter)
 {
-    auto* device_node  = selectDevice(filter);
-    auto* profile_node = requireChild(device_node, "Profile");
+    auto* device_node = selectDevice(filter);
 
     Device device;
     device.vendor_name = vendor_name_;
-    if (auto* id = vendor_xml_->FirstChildElement("Id"); id != nullptr)
+    // <Vendor>/<Id> is mandatory per ETG.2000 in spirit, but real vendor ESI
+    // files (notably some catalog placeholders) ship with <Id></Id> empty.
+    // Require the element to be present; allow empty text -> vendor_id = 0
+    // to preserve compatibility with those files.
+    auto* id_node = requireChild(vendor_xml_, "Id");
+    char const* id_text = id_node->GetText();
+    if (id_text != nullptr and *id_text != '\0')
     {
-        char const* text = id->GetText();
-        if (text != nullptr and *text != '\0')
-        {
-            device.vendor_id = static_cast<uint32_t>(parseHexDec(text));
-        }
+        device.vendor_id = parseHexDec<uint32_t>(id_text, "Vendor/Id");
     }
 
     auto* type_node = device_node->FirstChildElement("Type");
@@ -409,19 +495,33 @@ Device Parser::loadDeviceImpl(DeviceFilter const& filter)
     device.name         = textOrEmpty(device_node->FirstChildElement("Name"));
     device.group_type   = textOrEmpty(device_node->FirstChildElement("GroupType"));
 
-    auto* profile_no = profile_node->FirstChildElement("ProfileNo");
-    profile_no_ = textOrEmpty(profile_no);
-    if (not profile_no_.empty())
+    // <Profile> is optional in real-world ESIs — Beckhoff IO terminal entries
+    // and other simple slaves have no CoE dictionary. Accept devices without
+    // <Profile>; the dictionary will only contain the synthesised 0x1C00/PDO
+    // mapping objects derived from <Sm>/<Pdo> declarations.
+    auto* profile_node = device_node->FirstChildElement("Profile");
+    if (profile_node != nullptr)
     {
-        device.profile_no = static_cast<uint16_t>(parseHexDec(profile_no_));
+        auto* profile_no = profile_node->FirstChildElement("ProfileNo");
+        profile_no_ = textOrEmpty(profile_no);
+        if (not profile_no_.empty())
+        {
+            device.profile_no = parseHexDec<uint16_t>(profile_no_, "Profile/ProfileNo");
+        }
     }
 
     parseSyncManagers(device_node, device.sync_managers);
     parseSyncUnits   (device_node, device.sync_units);
     parseFmmus       (device_node, device.fmmus);
     parseMailbox     (device_node, device.mailbox);
+    parsePdos        (device_node, "RxPdo", device.rx_pdos);
+    parsePdos        (device_node, "TxPdo", device.tx_pdos);
+    parseEeprom      (device_node, device.eeprom);
+    parseDc          (device_node, device.dc);
+    // Modular-device composition (<Slots>/<ModuleGroups>) is not modeled.
 
     device.dictionary = buildDictionary(profile_node, device.sync_managers);
+    synthesizePdoMappingObjects(device);
     return device;
 }
 
@@ -457,7 +557,7 @@ namespace transition
     }
 }
 
-void Parser::parseMailbox(XMLElement* device, Mailbox& out)
+void Parser::parseMailbox(XMLElement* device, std::optional<Mailbox>& out)
 {
     // The <Device>/<Mailbox> block is distinct from <Device>/<Info>/<Mailbox>
     // (which carries request/response timeouts). Iterate children only — never
@@ -468,8 +568,9 @@ void Parser::parseMailbox(XMLElement* device, Mailbox& out)
         return;
     }
 
-    out.data_link_layer = readBoolAttr(mbx, "DataLinkLayer");
-    out.real_time_mode  = readBoolAttr(mbx, "RealTimeMode");
+    out.emplace();
+    out->data_link_layer = readBoolAttr(mbx, "DataLinkLayer");
+    out->real_time_mode  = readBoolAttr(mbx, "RealTimeMode");
 
     if (auto* coe = mbx->FirstChildElement("CoE"))
     {
@@ -488,8 +589,7 @@ void Parser::parseMailbox(XMLElement* device, Mailbox& out)
             block.eds_file = eds;
         }
 
-        // CoE/Object (legacy form per ETG.2000 — flagged obsolete in the XSD) is
-        // intentionally ignored; modern ESIs use <InitCmd> below.
+        // CoE/Object (obsolete in the XSD) is ignored; modern ESIs use <InitCmd>.
         for (auto* ic = coe->FirstChildElement("InitCmd"); ic != nullptr; ic = ic->NextSiblingElement("InitCmd"))
         {
             Mailbox::CoE::InitCmd cmd;
@@ -504,7 +604,7 @@ void Parser::parseMailbox(XMLElement* device, Mailbox& out)
             cmd.comment = commentOf(ic);
             block.init_cmds.push_back(std::move(cmd));
         }
-        out.coe = std::move(block);
+        out->coe = std::move(block);
     }
 
     if (auto* eoe = mbx->FirstChildElement("EoE"))
@@ -523,12 +623,12 @@ void Parser::parseMailbox(XMLElement* device, Mailbox& out)
             cmd.comment = commentOf(ic);
             block.init_cmds.push_back(std::move(cmd));
         }
-        out.eoe = std::move(block);
+        out->eoe = std::move(block);
     }
 
     if (mbx->FirstChildElement("FoE") != nullptr)
     {
-        out.foe = Mailbox::FoE{};
+        out->foe = Mailbox::FoE{};
     }
 
     if (auto* soe = mbx->FirstChildElement("SoE"))
@@ -547,7 +647,7 @@ void Parser::parseMailbox(XMLElement* device, Mailbox& out)
             cmd.comment = commentOf(ic);
             block.init_cmds.push_back(std::move(cmd));
         }
-        out.soe = std::move(block);
+        out->soe = std::move(block);
     }
 
     if (auto* aoe = mbx->FirstChildElement("AoE"))
@@ -565,23 +665,490 @@ void Parser::parseMailbox(XMLElement* device, Mailbox& out)
             cmd.comment = commentOf(ic);
             block.init_cmds.push_back(std::move(cmd));
         }
-        out.aoe = std::move(block);
+        out->aoe = std::move(block);
     }
 
     if (mbx->FirstChildElement("VoE") != nullptr)
     {
-        out.voe = Mailbox::VoE{};
+        out->voe = Mailbox::VoE{};
     }
 
-    // <Mailbox>/<VendorSpecific> is part of the schema but intentionally not
-    // surfaced on the Mailbox aggregate — open vendor content has no consumer.
+    // <Mailbox>/<VendorSpecific> is open vendor content and is not surfaced.
 }
 
-void Parser::parseSyncManagers(XMLElement* device, std::vector<SyncManager>& out)
+namespace
+{
+    PdoEntry parsePdoEntry(XMLElement* node, std::string const& where)
+    {
+        PdoEntry entry;
+        entry.index   = requireNumber<uint16_t>(node, "Index", where);
+        // SubIndex is optional per the XSD (minOccurs=0); padding entries use 0.
+        if (char const* sub = findText(node, "SubIndex"))
+        {
+            entry.subindex = parseHexDec<uint8_t>(sub, where + " SubIndex");
+        }
+        entry.bit_len = requireNumber<uint16_t>(node, "BitLen", where);
+
+        if (char const* name = findText(node, "Name"))
+        {
+            entry.name = name;
+        }
+        if (char const* comment = findText(node, "Comment"))
+        {
+            entry.comment = comment;
+        }
+        if (char const* data_type = findText(node, "DataType"))
+        {
+            entry.data_type = data_type;
+        }
+
+        entry.fixed              = readBoolAttr(node, "Fixed");
+        entry.safety_conn_number = readIntAttr (node, "SafetyConnNumber");
+        if (char const* type = node->Attribute("SafetyPdoEntryType"))
+        {
+            entry.safety_pdo_entry_type = type;
+        }
+        return entry;
+    }
+}
+
+void Parser::parsePdos(XMLElement* device, char const* element_name, std::vector<Pdo>& out)
+{
+    for (auto* pdo_node = device->FirstChildElement(element_name); pdo_node != nullptr;
+         pdo_node       = pdo_node->NextSiblingElement(element_name))
+    {
+        Pdo pdo;
+
+        std::string where = element_name;
+        // <Index>/@DependOnSlot/@DependOnSlotGroup are modular-device attributes
+        // and are not read.
+        pdo.index = requireNumber<uint16_t>(pdo_node, "Index", where);
+
+        char buf[40];
+        std::snprintf(buf, sizeof(buf), "%s 0x%04x", element_name, pdo.index);
+        where = buf;
+
+        // <Name> is mandatory per PdoType. Multi-language variants (@LcId) are
+        // not distinguished; the first <Name> wins.
+        pdo.name = requireChildText(pdo_node, "Name", where);
+
+        pdo.sm                    = readIntAttr (pdo_node, "Sm");
+        pdo.su                    = readIntAttr (pdo_node, "Su");
+        pdo.fixed                 = readBoolAttr(pdo_node, "Fixed");
+        pdo.mandatory             = readBoolAttr(pdo_node, "Mandatory");
+        pdo.is_virtual            = readBoolAttr(pdo_node, "Virtual");
+        pdo.os_fac                = readIntAttr (pdo_node, "OSFac");
+        pdo.os_min                = readIntAttr (pdo_node, "OSMin");
+        pdo.os_max                = readIntAttr (pdo_node, "OSMax");
+        pdo.os_index_inc          = readIntAttr (pdo_node, "OSIndexInc");
+        pdo.pdo_order             = readIntAttr (pdo_node, "PdoOrder");
+        pdo.overwritten_by_module = readBoolAttr(pdo_node, "OverwrittenByModule");
+        pdo.sra_parameter         = readBoolAttr(pdo_node, "SRA_Parameter");
+        pdo.safety_conn_number    = readIntAttr (pdo_node, "SafetyConnNumber");
+        if (char const* type = pdo_node->Attribute("SafetyPdoType"))
+        {
+            pdo.safety_pdo_type = type;
+        }
+
+        for (auto* ex = pdo_node->FirstChildElement("Exclude"); ex != nullptr; ex = ex->NextSiblingElement("Exclude"))
+        {
+            char const* text = ex->GetText();
+            if (text == nullptr)
+            {
+                throw std::invalid_argument("ESI: empty <Exclude> in " + where);
+            }
+            pdo.exclude.push_back(parseHexDec<uint16_t>(text, where + " Exclude"));
+        }
+        for (auto* ex_sm = pdo_node->FirstChildElement("ExcludedSm"); ex_sm != nullptr; ex_sm = ex_sm->NextSiblingElement("ExcludedSm"))
+        {
+            char const* text = ex_sm->GetText();
+            if (text == nullptr)
+            {
+                throw std::invalid_argument("ESI: empty <ExcludedSm> in " + where);
+            }
+            pdo.excluded_sm.push_back(parseHexDec<int32_t>(text, where + " ExcludedSm"));
+        }
+        for (auto* entry = pdo_node->FirstChildElement("Entry"); entry != nullptr; entry = entry->NextSiblingElement("Entry"))
+        {
+            pdo.entries.push_back(parsePdoEntry(entry, where + " Entry"));
+        }
+
+        for (auto const& existing : out)
+        {
+            if (existing.index == pdo.index)
+            {
+                char buf[64];
+                std::snprintf(buf, sizeof(buf), "ESI: duplicate %s <Index> 0x%04x", element_name, pdo.index);
+                throw std::invalid_argument(buf);
+            }
+        }
+        out.push_back(std::move(pdo));
+    }
+}
+
+namespace
+{
+    bool dictionaryContains(CoE::Dictionary const& dict, uint16_t index)
+    {
+        for (auto const& obj : dict)
+        {
+            if (obj.index == index)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+// Build the per-PDO mapping object (0x16xx or 0x1Axx) from a parsed Pdo.
+// Layout per ETG.1000.6: SubIndex 0 = entry count (uint8), SubIndex N =
+// packed uint32 = (Index << 16) | (SubIndex << 8) | BitLen.
+CoE::Object Parser::buildMappingObject(Pdo const& pdo, bool is_rx)
+{
+    CoE::Object obj;
+    obj.index = pdo.index;
+    obj.code  = CoE::ObjectCode::RECORD;
+    if (not pdo.name.empty())
+    {
+        obj.name = pdo.name;
+    }
+    else if (is_rx)
+    {
+        obj.name = "RxPDO Mapping";
+    }
+    else
+    {
+        obj.name = "TxPDO Mapping";
+    }
+
+    if (pdo.entries.size() > 0xFF)
+    {
+        throw std::invalid_argument("ESI: PDO has more than 255 entries (cannot synthesize mapping)");
+    }
+
+    CoE::Entry subindex0{0, 8, 0, CoE::Access::READ, CoE::DataType::UNSIGNED8, "Number of entries"};
+    subindex0.data = std::malloc(1);
+    uint8_t count = static_cast<uint8_t>(pdo.entries.size());
+    std::memcpy(subindex0.data, &count, 1);
+    obj.entries.push_back(std::move(subindex0));
+
+    uint16_t bitoff = 8;  // SubIndex 0 occupies the first byte (bits 0..7)
+    for (std::size_t i = 0; i < pdo.entries.size(); ++i)
+    {
+        auto const& e = pdo.entries[i];
+        if (e.bit_len > 0xFF)
+        {
+            throw std::invalid_argument("ESI: PDO entry BitLen > 255 cannot fit in mapping word");
+        }
+        CoE::Entry entry;
+        entry.subindex    = static_cast<uint8_t>(i + 1);
+        entry.bitlen      = 32;
+        entry.bitoff      = bitoff;
+        entry.access      = CoE::Access::READ;
+        entry.type        = CoE::DataType::UNSIGNED32;
+        if (not e.name.empty())
+        {
+            entry.description = e.name;
+        }
+        else
+        {
+            entry.description = "Entry " + std::to_string(i + 1);
+        }
+        entry.data        = std::malloc(sizeof(uint32_t));
+        uint32_t packed = (static_cast<uint32_t>(e.index) << 16)
+                        | (static_cast<uint32_t>(e.subindex) << 8)
+                        | static_cast<uint32_t>(e.bit_len);
+        std::memcpy(entry.data, &packed, sizeof(uint32_t));
+        obj.entries.push_back(std::move(entry));
+        bitoff = static_cast<uint16_t>(bitoff + 32);
+    }
+    return obj;
+}
+
+// Build the SM-assignment object (0x1C12 for RxPDO, 0x1C13 for TxPDO).
+// SubIndex 0 = PDO count (uint8), SubIndex N = PDO mapping index (uint16).
+CoE::Object Parser::buildAssignmentObject(std::vector<Pdo> const& pdos, uint16_t index, bool is_rx)
+{
+    CoE::Object obj;
+    obj.index = index;
+    obj.code  = CoE::ObjectCode::ARRAY;
+    if (is_rx)
+    {
+        obj.name = "RxPDO assign";
+    }
+    else
+    {
+        obj.name = "TxPDO assign";
+    }
+
+    if (pdos.size() > 0xFF)
+    {
+        throw std::invalid_argument("ESI: more than 255 PDOs assigned to a SyncManager");
+    }
+
+    CoE::Entry subindex0{0, 8, 0, CoE::Access::READ, CoE::DataType::UNSIGNED8, "Number of assigned PDOs"};
+    subindex0.data = std::malloc(1);
+    uint8_t count = static_cast<uint8_t>(pdos.size());
+    std::memcpy(subindex0.data, &count, 1);
+    obj.entries.push_back(std::move(subindex0));
+
+    uint16_t bitoff = 8;  // SubIndex 0 occupies the first byte (bits 0..7)
+    for (std::size_t i = 0; i < pdos.size(); ++i)
+    {
+        CoE::Entry entry;
+        entry.subindex    = static_cast<uint8_t>(i + 1);
+        entry.bitlen      = 16;
+        entry.bitoff      = bitoff;
+        entry.access      = CoE::Access::READ;
+        entry.type        = CoE::DataType::UNSIGNED16;
+        entry.description = "PDO " + std::to_string(i + 1);
+        entry.data        = std::malloc(sizeof(uint16_t));
+        uint16_t pdo_index = pdos[i].index;
+        std::memcpy(entry.data, &pdo_index, sizeof(uint16_t));
+        obj.entries.push_back(std::move(entry));
+        bitoff = static_cast<uint16_t>(bitoff + 16);
+    }
+    return obj;
+}
+
+void Parser::synthesizePdoMappingObjects(Device& device)
+{
+    // Per-PDO mapping objects (0x16xx, 0x1Axx) — only add when the slave's
+    // <Dictionary> doesn't already declare them explicitly. Explicit wins.
+    for (auto const& pdo : device.rx_pdos)
+    {
+        if (not dictionaryContains(device.dictionary, pdo.index))
+        {
+            device.dictionary.push_back(buildMappingObject(pdo, true));
+        }
+    }
+    for (auto const& pdo : device.tx_pdos)
+    {
+        if (not dictionaryContains(device.dictionary, pdo.index))
+        {
+            device.dictionary.push_back(buildMappingObject(pdo, false));
+        }
+    }
+
+    // SM assignment objects 0x1C12 (RxPDO) and 0x1C13 (TxPDO). Per ETG.1000.6
+    // these list the indexes of mapping objects assigned to the master->slave
+    // and slave->master SyncManagers respectively. NOTE: we lump ALL rx_pdos
+    // under 0x1C12 and ALL tx_pdos under 0x1C13 regardless of each Pdo's @Sm
+    // attribute. Modular devices using non-default SMs (e.g. Sm=4 for RxPDO)
+    // are misrepresented by this synthesis — the per-SM correct form would be
+    // one assignment object per unique pdo.sm value at 0x1C10 + sm_index.
+    if (not device.rx_pdos.empty() and not dictionaryContains(device.dictionary, 0x1C12))
+    {
+        device.dictionary.push_back(buildAssignmentObject(device.rx_pdos, 0x1C12, true));
+    }
+    if (not device.tx_pdos.empty() and not dictionaryContains(device.dictionary, 0x1C13))
+    {
+        device.dictionary.push_back(buildAssignmentObject(device.tx_pdos, 0x1C13, false));
+    }
+}
+
+void Parser::parseEeprom(XMLElement* device, std::optional<Eeprom>& out)
+{
+    auto* eep = device->FirstChildElement("Eeprom");
+    if (eep == nullptr)
+    {
+        return;
+    }
+
+    Eeprom block;
+    block.assign_to_pdi = readBoolAttr(eep, "AssignToPdi");
+
+    // EepromType is an xs:choice between raw <Data> and the structured form
+    // (<ByteSize>+<ConfigData>+…). Reject documents carrying both so the error
+    // names the real problem.
+    auto* data_raw   = eep->FirstChildElement("Data");
+    auto* byte_size  = eep->FirstChildElement("ByteSize");
+    if (data_raw != nullptr and byte_size != nullptr)
+    {
+        throw std::invalid_argument(
+            "ESI: <Eeprom> has both <Data> (raw form) and <ByteSize> (structured form); "
+            "they are mutually exclusive per the schema");
+    }
+    if (data_raw != nullptr)
+    {
+        block.raw_data = loadHexBinary(data_raw);
+        out = std::move(block);
+        return;
+    }
+
+    // ByteSize and ConfigData are mandatory children of the structured form.
+    block.byte_size   = parseHexDec<int32_t>(requireChildText(eep, "ByteSize", "Eeprom"), "Eeprom/ByteSize");
+    block.config_data = loadHexBinary(requireChild(eep, "ConfigData"));
+
+    if (auto* cfg2 = eep->FirstChildElement("ConfigData2"))
+    {
+        block.config_data2 = loadHexBinary(cfg2);
+    }
+    if (auto* boot = eep->FirstChildElement("BootStrap"))
+    {
+        block.bootstrap = loadHexBinary(boot);
+    }
+    for (auto* cat = eep->FirstChildElement("Category"); cat != nullptr; cat = cat->NextSiblingElement("Category"))
+    {
+        Eeprom::Category c;
+        c.cat_no = requireNumber<int32_t>(cat, "CatNo", "Eeprom/Category");
+        c.preserve_online_data = readBoolAttr(cat, "PreserveOnlineData");
+        // Payload is an xs:choice; pick by element presence, not text content,
+        // so an empty <DataString/> reads as an empty string rather than absent.
+        // The numeric forms still require a value.
+        if (auto* d = cat->FirstChildElement("Data"))
+        {
+            c.data = loadHexBinary(d);
+        }
+        else if (auto* s = cat->FirstChildElement("DataString"))
+        {
+            char const* text = s->GetText();
+            if (text != nullptr)
+            {
+                c.data_string = text;
+            }
+            else
+            {
+                c.data_string.emplace();
+            }
+        }
+        else if (cat->FirstChildElement("DataUINT") != nullptr)
+        {
+            c.data_uint = parseHexDec<int32_t>(requireChildText(cat, "DataUINT", "Eeprom/Category"), "Eeprom/Category/DataUINT");
+        }
+        else if (cat->FirstChildElement("DataUDINT") != nullptr)
+        {
+            c.data_udint = parseHexDec<int32_t>(requireChildText(cat, "DataUDINT", "Eeprom/Category"), "Eeprom/Category/DataUDINT");
+        }
+        else
+        {
+            throw std::invalid_argument("ESI: <Category> in Eeprom/Category missing payload (expected one of Data/DataString/DataUINT/DataUDINT)");
+        }
+        block.categories.push_back(std::move(c));
+    }
+
+    out = std::move(block);
+}
+
+namespace
+{
+    std::optional<OpMode::SyncTime> parseSyncTime(XMLElement* parent, char const* name)
+    {
+        auto* node = parent->FirstChildElement(name);
+        if (node == nullptr)
+        {
+            return std::nullopt;
+        }
+        OpMode::SyncTime st;
+        char const* text = node->GetText();
+        if (text != nullptr)
+        {
+            st.value = parseHexDec<int32_t>(text, std::string{"Dc/OpMode/"} + name);
+        }
+        st.factor = readIntAttr(node, "Factor");
+        return st;
+    }
+
+    std::optional<OpMode::ShiftTime> parseShiftTime(XMLElement* parent, char const* name)
+    {
+        auto* node = parent->FirstChildElement(name);
+        if (node == nullptr)
+        {
+            return std::nullopt;
+        }
+        OpMode::ShiftTime st;
+        char const* text = node->GetText();
+        if (text != nullptr)
+        {
+            st.value = parseHexDec<int32_t>(text, std::string{"Dc/OpMode/"} + name);
+        }
+        st.factor             = readIntAttr(node, "Factor");
+        if (node->Attribute("Input") != nullptr)
+        {
+            st.input = readBoolAttr(node, "Input");
+        }
+        st.output_delay_time  = readIntAttr(node, "OutputDelayTime");
+        st.input_delay_time   = readIntAttr(node, "InputDelayTime");
+        return st;
+    }
+}
+
+void Parser::parseDc(XMLElement* device, std::optional<Dc>& out)
+{
+    auto* dc = device->FirstChildElement("Dc");
+    if (dc == nullptr)
+    {
+        return;
+    }
+
+    Dc block;
+    block.unknown_frmw              = readBoolAttr(dc, "UnknownFRMW");
+    block.unknown_64bit             = readBoolAttr(dc, "Unknown64Bit");
+    block.external_ref_clock        = readBoolAttr(dc, "ExternalRefClock");
+    block.potential_reference_clock = readBoolAttr(dc, "PotentialReferenceClock");
+    block.time_loop_control_only    = readBoolAttr(dc, "TimeLoopControlOnly");
+    block.pdo_oversampling          = readBoolAttr(dc, "PdoOversampling");
+
+    static char const* const CYCLE_NAMES[4] = {"CycleTimeSync0", "CycleTimeSync1", "CycleTimeSync2", "CycleTimeSync3"};
+    static char const* const SHIFT_NAMES[4] = {"ShiftTimeSync0", "ShiftTimeSync1", "ShiftTimeSync2", "ShiftTimeSync3"};
+
+    for (auto* om = dc->FirstChildElement("OpMode"); om != nullptr; om = om->NextSiblingElement("OpMode"))
+    {
+        OpMode mode;
+        mode.name = requireChildText(om, "Name", "Dc/OpMode");
+        if (char const* desc = findText(om, "Desc"))
+        {
+            mode.desc = desc;
+        }
+        mode.assign_activate = requireNumber<uint32_t>(om, "AssignActivate", "Dc/OpMode");
+        if (char const* aa = findText(om, "ActivateAdditional"))
+        {
+            mode.activate_additional = parseHexDec<uint32_t>(aa, "Dc/OpMode/ActivateAdditional");
+        }
+        for (int i = 0; i < 4; ++i)
+        {
+            mode.cycle_time[i] = parseSyncTime (om, CYCLE_NAMES[i]);
+            mode.shift_time[i] = parseShiftTime(om, SHIFT_NAMES[i]);
+        }
+
+        // <OpMode>/<Sm No="..">: @No plus the <Pdo>/@OSFac oversampling map. The
+        // SyncType/CycleTime/ShiftTime children are obsolete in the XSD; skipped.
+        for (auto* sm = om->FirstChildElement("Sm"); sm != nullptr; sm = sm->NextSiblingElement("Sm"))
+        {
+            OpMode::SmConfig cfg;
+            auto no = readIntAttr(sm, "No");
+            if (not no)
+            {
+                throw std::invalid_argument("ESI: <Sm> in Dc/OpMode missing required @No");
+            }
+            cfg.no = *no;
+
+            for (auto* p = sm->FirstChildElement("Pdo"); p != nullptr; p = p->NextSiblingElement("Pdo"))
+            {
+                char const* text = p->GetText();
+                if (text == nullptr)
+                {
+                    throw std::invalid_argument("ESI: empty <Pdo> in Dc/OpMode/Sm");
+                }
+                OpMode::SmConfig::PdoRef ref;
+                ref.index  = parseHexDec<uint16_t>(text, "Dc/OpMode/Sm/Pdo");
+                ref.os_fac = readIntAttr(p, "OSFac");
+                cfg.pdos.push_back(ref);
+            }
+            mode.sm_configs.push_back(std::move(cfg));
+        }
+        block.op_modes.push_back(std::move(mode));
+    }
+
+    out = std::move(block);
+}
+
+void Parser::parseSyncManagers(XMLElement* device, std::vector<SmInfo>& out)
 {
     for (auto* sm = device->FirstChildElement("Sm"); sm != nullptr; sm = sm->NextSiblingElement("Sm"))
     {
-        SyncManager entry;
+        SmInfo entry;
 
         char const* text = sm->GetText();
         if (text != nullptr)
@@ -640,22 +1207,45 @@ void Parser::parseFmmus(XMLElement* device, std::vector<Fmmu>& out)
     }
 }
 
-CoE::Dictionary Parser::buildDictionary(XMLElement* profile, std::vector<SyncManager> const& sms)
+CoE::Dictionary Parser::buildDictionary(XMLElement* profile, std::vector<SmInfo> const& sms)
 {
-    auto* dictionary = requireChild(profile,    "Dictionary");
-    dtypes_          = requireChild(dictionary, "DataTypes");
-    auto* objects    = requireChild(dictionary, "Objects");
-
     CoE::Dictionary out;
 
-    for (auto* node_object = objects->FirstChildElement(); node_object != nullptr; node_object = node_object->NextSiblingElement())
+    // Profile is optional (see loadDeviceImpl). If absent, skip the inline
+    // dictionary entirely and proceed straight to the synthesised 0x1C00 below.
+    // DataTypes is also optional per the XSD (DictionaryType minOccurs=0); a
+    // device whose Objects only reference basic types has no <DataTypes>.
+    // Objects is required when Dictionary is present.
+    dtypes_ = nullptr;
+    XMLElement* dictionary = nullptr;
+    if (profile != nullptr)
     {
-        out.push_back(createObject(node_object));
+        dictionary = profile->FirstChildElement("Dictionary");
+    }
+    if (dictionary != nullptr)
+    {
+        dtypes_       = dictionary->FirstChildElement("DataTypes");
+        // <Dictionary> itself is optional, but when present the XSD requires an
+        // <Objects> child (DictionaryType sequence).
+        auto* objects = requireChild(dictionary, "Objects");
+        for (auto* node_object = objects->FirstChildElement(); node_object != nullptr; node_object = node_object->NextSiblingElement())
+        {
+            out.push_back(createObject(node_object));
+        }
     }
 
-    // Synthesize CoE object 0x1C00 (Sync Manager Communication Type) from
-    // the device's <Sm> declarations so legacy callers of loadFile/loadString
-    // still get an SM-type array in their CoE::Dictionary.
+    // Synthesize CoE object 0x1C00 (Sync Manager Communication Type) from the
+    // device's <Sm> declarations so callers of loadFile/loadString still get an
+    // SM-type array in their CoE::Dictionary. An explicit 0x1C00 in the ESI wins.
+    if (dictionaryContains(out, 0x1C00))
+    {
+        return out;
+    }
+    if (sms.size() > 0xFF)
+    {
+        throw std::invalid_argument("ESI: more than 255 <Sm> entries cannot fit in 0x1C00 SubIndex space");
+    }
+
     CoE::Object sms_type;
     sms_type.index = 0x1c00;
     sms_type.code  = CoE::ObjectCode::ARRAY;
@@ -710,25 +1300,35 @@ std::vector<uint8_t> Parser::loadHexBinary(XMLElement* node)
         return {};
     }
     std::string field = raw;
+    if (field.size() % 2 != 0)
+    {
+        throw std::invalid_argument("ESI: hex binary <" + std::string{node->Value()}
+            + "> has odd length (" + std::to_string(field.size()) + " chars)");
+    }
     std::vector<uint8_t> data;
     data.reserve(field.size() / 2);
 
     for (std::size_t i = 0; i < field.size(); i += 2)
     {
-        std::string hex = field.substr(i, 2);
-        uint8_t byte = static_cast<uint8_t>(std::stoi(hex, nullptr, 16));
-        data.push_back(byte);
+        char buf[3] = {field[i], field[i + 1], '\0'};
+        char* end = nullptr;
+        unsigned long byte = std::strtoul(buf, &end, 16);
+        if (end != buf + 2)
+        {
+            std::string what = "ESI: hex binary <";
+            what += node->Value();
+            what += "> contains non-hex pair '";
+            what += buf;
+            what += "' at byte ";
+            what += std::to_string(i / 2);
+            throw std::invalid_argument(what);
+        }
+        data.push_back(static_cast<uint8_t>(byte));
     }
 
     return data;
 }
 
-std::vector<uint8_t> Parser::loadStringData(XMLElement* node)
-{
-    auto data = loadHexBinary(node);
-    std::reverse(data.begin(), data.end());
-    return data;
-}
 
 void Parser::loadDefaultData(XMLNode* node, CoE::Object& obj, CoE::Entry& entry)
 {
@@ -741,15 +1341,10 @@ void Parser::loadDefaultData(XMLNode* node, CoE::Object& obj, CoE::Entry& entry)
     auto node_default_data = node_info->FirstChildElement("DefaultData");
     if (node_default_data != nullptr)
     {
-        std::vector<uint8_t> data;
-        if (entry.type == CoE::DataType::VISIBLE_STRING)
-        {
-            data = loadStringData(node_default_data);
-        }
-        else
-        {
-            data = loadHexBinary(node_default_data);
-        }
+        // VISIBLE_STRING and other binary defaults share the same loader; the
+        // ESI <DefaultData> hex-binary content is already in the natural byte
+        // order (ASCII bytes for strings, little-endian for numerics).
+        std::vector<uint8_t> data = loadHexBinary(node_default_data);
 
         if (data.size() != (entry.bitlen / 8))
         {
@@ -760,15 +1355,23 @@ void Parser::loadDefaultData(XMLNode* node, CoE::Object& obj, CoE::Entry& entry)
                 data.size() * 8, entry.bitlen);
             return;
         }
-        entry.data = std::malloc(entry.bitlen / 8);
+        if (data.empty())
+        {
+            return;
+        }
+        entry.data = std::malloc(data.size());
         std::memcpy(entry.data, data.data(), data.size());
         return;
     }
 
     if (char const* default_value = findText(node_info, "DefaultValue"))
     {
-        int64_t value = parseHexDec(default_value);
         uint32_t size = entry.bitlen / 8;
+        if (size == 0)
+        {
+            return;
+        }
+        int64_t value = parseHexDec(default_value, objectLabel(obj.index) + " DefaultValue");
         uint32_t copy_size = std::min<uint32_t>(size, sizeof(int64_t));
         entry.data = std::malloc(size);
         if (copy_size < size)
@@ -889,6 +1492,10 @@ CoE::DataType Parser::resolveType(std::string const& type_name, int depth)
         return CoE::DataType::VISIBLE_STRING;
     }
 
+    if (dtypes_ == nullptr)
+    {
+        return CoE::DataType::UNKNOWN;
+    }
     auto dtype = dtypes_->FirstChildElement();
     while (dtype)
     {
@@ -949,7 +1556,7 @@ std::tuple<CoE::DataType, uint16_t, uint16_t> Parser::parseType(XMLNode* node)
     uint16_t bitoff = 0;
     if (char const* bitoff_text = findText(node, "BitOffs"))
     {
-        bitoff = static_cast<uint16_t>(parseHexDec(bitoff_text));
+        bitoff = parseHexDec<uint16_t>(bitoff_text, "<BitOffs>");
     }
 
     return {type, bitlen, bitoff};
@@ -959,6 +1566,10 @@ XMLNode* Parser::findNodeType(XMLNode* node, std::string const& where)
 {
     char const* raw_type = requireText(node->FirstChildElement("Type"), "Type", where);
 
+    if (dtypes_ == nullptr)
+    {
+        return nullptr;
+    }
     auto dtype = dtypes_->FirstChildElement();
     while (dtype)
     {
@@ -983,7 +1594,7 @@ CoE::Object Parser::createObject(XMLNode* node)
     object.index = requireNumber<uint16_t>(node, "Index", "Object");
 
     std::string where = objectLabel(object.index);
-    object.name = requireText(node, "Name", where);
+    object.name = requireChildText(node, "Name", where);
 
     auto [type, bitlen, bitoff] = parseType(node);
     if (CoE::isBasic(type))
@@ -1005,6 +1616,11 @@ CoE::Object Parser::createObject(XMLNode* node)
     auto node_type = findNodeType(node, where);
     if (node_type == nullptr)
     {
+        if (dtypes_ == nullptr)
+        {
+            throw std::invalid_argument("ESI: " + where + " references a user-defined <Type> "
+                "but no <DataTypes> section is present in <Dictionary>");
+        }
         throw std::invalid_argument("ESI: unresolved <Type> reference in " + where);
     }
     auto node_subitem = node_type->FirstChildElement("SubItem");
@@ -1059,20 +1675,47 @@ CoE::Object Parser::createObject(XMLNode* node)
             }
             else
             {
-                uint8_t  elements       = requireNumber<uint8_t> (node_array_info, "Elements", sub_where);
+                // uint16_t loop counter is required: with an 8-bit counter and
+                // <Elements>255</Elements> (real ETG examples have this), the
+                // post-increment wraps 255 -> 0 and the loop never terminates.
+                uint16_t elements = requireNumber<uint16_t>(node_array_info, "Elements", sub_where);
                 if (elements == 0)
                 {
                     throw std::invalid_argument("ESI: <Elements> is zero in " + sub_where);
                 }
-                uint16_t element_bitlen = static_cast<uint16_t>(requireNumber<uint16_t>(node_subitem, "BitSize", sub_where) / elements);
-                uint16_t element_bitoff = requireNumber<uint16_t>(node_subitem, "BitOffs", sub_where);
-
-                for (uint8_t i = 1; i <= elements; ++i)
+                if (elements > 0xFF)
                 {
-                    entry.bitlen   = element_bitlen;
-                    entry.bitoff   = static_cast<uint16_t>(element_bitoff + element_bitlen * (i - 1));
-                    entry.subindex = i;
-                    object.entries.push_back(std::move(entry));
+                    throw std::invalid_argument("ESI: <Elements> > 255 exceeds CoE SubIndex space in " + sub_where);
+                }
+                uint16_t total_bitlen   = requireNumber<uint16_t>(node_subitem, "BitSize", sub_where);
+                uint16_t element_bitoff = requireNumber<uint16_t>(node_subitem, "BitOffs", sub_where);
+                if (total_bitlen % elements != 0)
+                {
+                    throw std::invalid_argument("ESI: array <BitSize> " + std::to_string(total_bitlen)
+                        + " not divisible by <Elements> " + std::to_string(elements) + " in " + sub_where);
+                }
+                uint16_t element_bitlen = static_cast<uint16_t>(total_bitlen / elements);
+
+                for (uint16_t i = 1; i <= elements; ++i)
+                {
+                    // Use uint32_t for the intermediate offset arithmetic to
+                    // detect the (degenerate but reachable) case where the
+                    // final offset exceeds the uint16_t range.
+                    uint32_t offset = static_cast<uint32_t>(element_bitoff)
+                                    + static_cast<uint32_t>(element_bitlen) * (i - 1);
+                    if (offset > 0xFFFF)
+                    {
+                        throw std::invalid_argument("ESI: array element bitoff " + std::to_string(offset)
+                            + " exceeds uint16 range in " + sub_where);
+                    }
+                    CoE::Entry e;
+                    e.type        = entry.type;
+                    e.access      = entry.access;
+                    e.description = entry.description;
+                    e.bitlen      = element_bitlen;
+                    e.bitoff      = static_cast<uint16_t>(offset);
+                    e.subindex    = static_cast<uint8_t>(i);
+                    object.entries.push_back(std::move(e));
                 }
             }
         }

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -38,12 +38,29 @@ add_executable(kickcat_unit src/adler32_sum-t.cc
                             src/Time.cc
 )
 
-# ESI fixtures used by Parser-t.cc
-file(COPY ${CMAKE_SOURCE_DIR}/examples/slave/nuttx/xmc4800/boards/wdc_foot/foot.xml DESTINATION ${CMAKE_BINARY_DIR})
-file(COPY ${CMAKE_SOURCE_DIR}/unit/kickcat_esi_test_basic.xml DESTINATION ${CMAKE_BINARY_DIR})
-file(COPY ${CMAKE_SOURCE_DIR}/unit/kickcat_esi_test_complex.xml DESTINATION ${CMAKE_BINARY_DIR})
-file(COPY ${CMAKE_SOURCE_DIR}/unit/kickcat_esi_test_multi_device.xml DESTINATION ${CMAKE_BINARY_DIR})
-file(COPY ${CMAKE_SOURCE_DIR}/unit/kickcat_esi_test_sm_fmmu.xml      DESTINATION ${CMAKE_BINARY_DIR})
+# ESI fixtures for Parser-t.cc, copied next to the test binary as a build
+# dependency so editing a fixture re-copies it without re-running CMake.
+set(KICKCAT_ESI_FIXTURES
+    ${CMAKE_SOURCE_DIR}/examples/slave/nuttx/xmc4800/boards/wdc_foot/foot.xml
+    ${CMAKE_CURRENT_SOURCE_DIR}/kickcat_esi_test_basic.xml
+    ${CMAKE_CURRENT_SOURCE_DIR}/kickcat_esi_test_complex.xml
+    ${CMAKE_CURRENT_SOURCE_DIR}/kickcat_esi_test_multi_device.xml
+    ${CMAKE_CURRENT_SOURCE_DIR}/kickcat_esi_test_sm_fmmu.xml
+)
+
+set(KICKCAT_ESI_FIXTURES_COPIED "")
+foreach(fixture ${KICKCAT_ESI_FIXTURES})
+    get_filename_component(fixture_name ${fixture} NAME)
+    add_custom_command(
+        OUTPUT  ${CMAKE_BINARY_DIR}/${fixture_name}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${fixture} ${CMAKE_BINARY_DIR}/${fixture_name}
+        DEPENDS ${fixture}
+        COMMENT "Copying ESI fixture ${fixture_name}"
+        VERBATIM)
+    list(APPEND KICKCAT_ESI_FIXTURES_COPIED ${CMAKE_BINARY_DIR}/${fixture_name})
+endforeach()
+add_custom_target(kickcat_unit_fixtures DEPENDS ${KICKCAT_ESI_FIXTURES_COPIED})
+add_dependencies(kickcat_unit kickcat_unit_fixtures)
 
 target_link_libraries(kickcat_unit kickcat GTest::gmock_main)
 target_include_directories(kickcat_unit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/unit/kickcat_esi_test_basic.xml
+++ b/unit/kickcat_esi_test_basic.xml
@@ -286,7 +286,7 @@
 								<Type>STRING(8)</Type>
 								<BitSize>64</BitSize>
 								<Info>
-									<DefaultData>4B69636B434154210</DefaultData>
+									<DefaultData>4B69636B43415421</DefaultData>
 								</Info>
 								<Flags>
 									<Access>ro</Access>

--- a/unit/kickcat_esi_test_sm_fmmu.xml
+++ b/unit/kickcat_esi_test_sm_fmmu.xml
@@ -46,6 +46,36 @@
 				<Sm MinSize="40" MaxSize="1486" DefaultSize="128" StartAddress="#x1400" ControlByte="#x22" Enable="1" Virtual="1">MBoxIn</Sm>
 				<Sm DefaultSize="40" StartAddress="#x1800" ControlByte="#x64" Enable="1" OpOnly="true">Outputs</Sm>
 				<Sm DefaultSize="22" StartAddress="#x1c00" ControlByte="#x20" Enable="1">Inputs</Sm>
+				<RxPdo Sm="2" Mandatory="1" Fixed="1" PdoOrder="5">
+					<Index>#x1600</Index>
+					<Name>Outputs</Name>
+					<Exclude>#x1601</Exclude>
+					<Entry>
+						<Index>#x7000</Index>
+						<SubIndex>1</SubIndex>
+						<BitLen>16</BitLen>
+						<Name>OutputWord</Name>
+						<DataType>UINT</DataType>
+					</Entry>
+				</RxPdo>
+				<TxPdo Sm="3" OSFac="2">
+					<Index>#x1A00</Index>
+					<Name>Inputs</Name>
+					<Entry>
+						<Index>#x6000</Index>
+						<SubIndex>1</SubIndex>
+						<BitLen>16</BitLen>
+						<Name>InputWord</Name>
+						<DataType>UINT</DataType>
+					</Entry>
+					<Entry>
+						<Index>#x6000</Index>
+						<SubIndex>2</SubIndex>
+						<BitLen>8</BitLen>
+						<Name>Status</Name>
+						<DataType>USINT</DataType>
+					</Entry>
+				</TxPdo>
 				<Mailbox DataLinkLayer="true">
 					<AoE AdsRouter="true" GenerateOwnNetId="1">
 						<InitCmd>
@@ -87,6 +117,36 @@
 					</SoE>
 					<VoE/>
 				</Mailbox>
+				<Dc PotentialReferenceClock="1" PdoOversampling="false">
+					<OpMode>
+						<Name>Synchron</Name>
+						<Desc>SM-Synchron</Desc>
+						<AssignActivate>#x300</AssignActivate>
+						<CycleTimeSync0 Factor="1">1000000</CycleTimeSync0>
+						<ShiftTimeSync0 Input="true" OutputDelayTime="500">100</ShiftTimeSync0>
+						<Sm No="3">
+							<SyncType>0</SyncType>
+							<Pdo OSFac="2">#x1A00</Pdo>
+						</Sm>
+					</OpMode>
+					<OpMode>
+						<Name>FreeRun</Name>
+						<AssignActivate>#x000</AssignActivate>
+					</OpMode>
+				</Dc>
+				<Eeprom AssignToPdi="true">
+					<ByteSize>2048</ByteSize>
+					<ConfigData>05000000F00000000000000000000000</ConfigData>
+					<BootStrap>0010800010108000</BootStrap>
+					<Category>
+						<CatNo>30</CatNo>
+						<DataString>BootCfg</DataString>
+					</Category>
+					<Category PreserveOnlineData="1">
+						<CatNo>40</CatNo>
+						<Data>DEADBEEF</Data>
+					</Category>
+				</Eeprom>
 			</Device>
 		</Devices>
 	</Descriptions>

--- a/unit/src/ESI/Parser-t.cc
+++ b/unit/src/ESI/Parser-t.cc
@@ -682,11 +682,13 @@ TEST(ESIParser, loadDevice_parses_mailbox)
     ESI::Parser parser;
     ESI::Device device = parser.loadDevice("kickcat_esi_test_sm_fmmu.xml");
 
-    ASSERT_TRUE (device.mailbox.data_link_layer);
-    ASSERT_FALSE(device.mailbox.real_time_mode);
+    ASSERT_TRUE(device.mailbox.has_value());
+    auto const& mailbox = *device.mailbox;
+    ASSERT_TRUE (mailbox.data_link_layer);
+    ASSERT_FALSE(mailbox.real_time_mode);
 
-    ASSERT_TRUE(device.mailbox.coe.has_value());
-    auto const& coe = *device.mailbox.coe;
+    ASSERT_TRUE(mailbox.coe.has_value());
+    auto const& coe = *mailbox.coe;
     ASSERT_TRUE(coe.sdo_info);
     ASSERT_TRUE(coe.complete_access);
     ASSERT_TRUE(coe.pdo_assign);
@@ -708,8 +710,8 @@ TEST(ESIParser, loadDevice_parses_mailbox)
     ASSERT_TRUE(coe_ic0.complete_access);
     ASSERT_EQ(coe_ic0.comment, "Assign RxPDO 0x1600");
 
-    ASSERT_TRUE(device.mailbox.eoe.has_value());
-    auto const& eoe = *device.mailbox.eoe;
+    ASSERT_TRUE(mailbox.eoe.has_value());
+    auto const& eoe = *mailbox.eoe;
     ASSERT_TRUE(eoe.ip);
     ASSERT_TRUE(eoe.mac);
     ASSERT_FALSE(eoe.time_stamp);
@@ -719,8 +721,8 @@ TEST(ESIParser, loadDevice_parses_mailbox)
     ASSERT_EQ(eoe.init_cmds[0].transitions[1], ESI::transition::PS);
     ASSERT_EQ(eoe.init_cmds[0].type, 5);
 
-    ASSERT_TRUE(device.mailbox.aoe.has_value());
-    auto const& aoe = *device.mailbox.aoe;
+    ASSERT_TRUE(mailbox.aoe.has_value());
+    auto const& aoe = *mailbox.aoe;
     ASSERT_TRUE(aoe.ads_router);
     ASSERT_TRUE(aoe.generate_own_net_id);
     ASSERT_FALSE(aoe.initialize_own_net_id);
@@ -728,8 +730,8 @@ TEST(ESIParser, loadDevice_parses_mailbox)
     ASSERT_EQ(aoe.init_cmds[0].comment, "AoE init");
     ASSERT_EQ(aoe.init_cmds[0].data.size(), 4u);
 
-    ASSERT_TRUE(device.mailbox.soe.has_value());
-    auto const& soe = *device.mailbox.soe;
+    ASSERT_TRUE(mailbox.soe.has_value());
+    auto const& soe = *mailbox.soe;
     ASSERT_TRUE(soe.channel_count.has_value());
     ASSERT_EQ(*soe.channel_count, 2);
     ASSERT_TRUE(soe.drive_follows_bit3);
@@ -737,8 +739,8 @@ TEST(ESIParser, loadDevice_parses_mailbox)
     ASSERT_EQ(soe.init_cmds[0].idn, 32);
     ASSERT_EQ(soe.init_cmds[0].channel, 1);
 
-    ASSERT_TRUE(device.mailbox.foe.has_value());
-    ASSERT_TRUE(device.mailbox.voe.has_value());
+    ASSERT_TRUE(mailbox.foe.has_value());
+    ASSERT_TRUE(mailbox.voe.has_value());
 }
 
 TEST(ESIParser, mailbox_absent_when_block_missing)
@@ -746,13 +748,7 @@ TEST(ESIParser, mailbox_absent_when_block_missing)
     ESI::Parser parser;
     ESI::Device device = parser.loadDevice("kickcat_esi_test_multi_device.xml");
 
-    ASSERT_FALSE(device.mailbox.data_link_layer);
-    ASSERT_FALSE(device.mailbox.coe.has_value());
-    ASSERT_FALSE(device.mailbox.eoe.has_value());
-    ASSERT_FALSE(device.mailbox.foe.has_value());
-    ASSERT_FALSE(device.mailbox.soe.has_value());
-    ASSERT_FALSE(device.mailbox.aoe.has_value());
-    ASSERT_FALSE(device.mailbox.voe.has_value());
+    ASSERT_FALSE(device.mailbox.has_value());
 }
 
 TEST(ESIParser, mailbox_throws_on_unknown_transition)
@@ -997,9 +993,233 @@ TEST(ESIParser, mailbox_soe_initcmd_channel_defaults_to_zero)
 
     ESI::Parser parser;
     ESI::Device device = parser.loadDeviceString(xml);
-    ASSERT_TRUE(device.mailbox.soe.has_value());
-    ASSERT_EQ(device.mailbox.soe->init_cmds.size(), 1u);
-    ASSERT_EQ(device.mailbox.soe->init_cmds[0].channel, 0);
+    ASSERT_TRUE(device.mailbox.has_value());
+    ASSERT_TRUE(device.mailbox->soe.has_value());
+    ASSERT_EQ(device.mailbox->soe->init_cmds.size(), 1u);
+    ASSERT_EQ(device.mailbox->soe->init_cmds[0].channel, 0);
+}
+
+TEST(ESIParser, loadDevice_parses_pdos)
+{
+    ESI::Parser parser;
+    ESI::Device device = parser.loadDevice("kickcat_esi_test_sm_fmmu.xml");
+
+    ASSERT_EQ(device.rx_pdos.size(), 1u);
+    auto const& rx = device.rx_pdos[0];
+    ASSERT_EQ(rx.index, 0x1600u);
+    ASSERT_EQ(rx.name,  "Outputs");
+    ASSERT_TRUE(rx.sm.has_value());
+    ASSERT_EQ(*rx.sm,    2);
+    ASSERT_TRUE(rx.pdo_order.has_value());
+    ASSERT_EQ(*rx.pdo_order, 5);
+    ASSERT_TRUE(rx.mandatory);
+    ASSERT_TRUE(rx.fixed);
+    ASSERT_EQ(rx.exclude.size(), 1u);
+    ASSERT_EQ(rx.exclude[0], 0x1601u);
+    ASSERT_EQ(rx.entries.size(), 1u);
+    ASSERT_EQ(rx.entries[0].index,    0x7000u);
+    ASSERT_EQ(rx.entries[0].subindex, 1u);
+    ASSERT_EQ(rx.entries[0].bit_len,  16u);
+    ASSERT_EQ(rx.entries[0].name,     "OutputWord");
+    ASSERT_EQ(rx.entries[0].data_type, "UINT");
+
+    ASSERT_EQ(device.tx_pdos.size(), 1u);
+    auto const& tx = device.tx_pdos[0];
+    ASSERT_EQ(tx.index, 0x1A00u);
+    ASSERT_TRUE(tx.os_fac.has_value());
+    ASSERT_EQ(*tx.os_fac, 2);
+    ASSERT_EQ(tx.entries.size(), 2u);
+    ASSERT_EQ(tx.entries[1].name,    "Status");
+    ASSERT_EQ(tx.entries[1].bit_len, 8u);
+}
+
+TEST(ESIParser, pdos_synthesize_legacy_mapping_objects)
+{
+    // Fixture's <RxPdo Index=0x1600> and <TxPdo Index=0x1A00> are not in
+    // <Dictionary>/<Objects>. The parser should synthesize them plus the
+    // 0x1C12/0x1C13 SM-assignment objects for legacy callers.
+    ESI::Parser parser;
+    auto dictionary = parser.loadFile("kickcat_esi_test_sm_fmmu.xml");
+
+    auto [obj_1600, _e1] = findObject(dictionary, 0x1600, 0);
+    ASSERT_NE(obj_1600, nullptr);
+    ASSERT_EQ(obj_1600->code, CoE::ObjectCode::RECORD);
+    ASSERT_EQ(obj_1600->entries.size(), 2u);  // size + 1 entry
+    uint8_t entry_count;
+    std::memcpy(&entry_count, obj_1600->entries[0].data, 1);
+    ASSERT_EQ(entry_count, 1u);
+    uint32_t packed;
+    std::memcpy(&packed, obj_1600->entries[1].data, 4);
+    ASSERT_EQ(packed, (0x7000u << 16) | (1u << 8) | 16u);
+
+    auto [obj_1A00, _e2] = findObject(dictionary, 0x1A00, 0);
+    ASSERT_NE(obj_1A00, nullptr);
+    ASSERT_EQ(obj_1A00->entries.size(), 3u);  // size + 2 entries
+
+    auto [obj_1C12, _e3] = findObject(dictionary, 0x1C12, 0);
+    ASSERT_NE(obj_1C12, nullptr);
+    ASSERT_EQ(obj_1C12->code, CoE::ObjectCode::ARRAY);
+    ASSERT_EQ(obj_1C12->entries.size(), 2u);  // size + 1 assigned PDO
+    uint16_t assigned_rx;
+    std::memcpy(&assigned_rx, obj_1C12->entries[1].data, 2);
+    ASSERT_EQ(assigned_rx, 0x1600u);
+
+    auto [obj_1C13, _e4] = findObject(dictionary, 0x1C13, 0);
+    ASSERT_NE(obj_1C13, nullptr);
+    ASSERT_EQ(obj_1C13->entries.size(), 2u);
+    uint16_t assigned_tx;
+    std::memcpy(&assigned_tx, obj_1C13->entries[1].data, 2);
+    ASSERT_EQ(assigned_tx, 0x1A00u);
+}
+
+TEST(ESIParser, pdos_do_not_overwrite_explicit_dictionary_objects)
+{
+    // If the slave's <Dictionary> already declares 0x1600, our auto-generated
+    // mapping object must not displace it.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes><DataType><Name>UDINT</Name><BitSize>32</BitSize></DataType></DataTypes>
+                        <Objects>
+                            <Object>
+                                <Index>#x1600</Index>
+                                <Name>Explicit RxPDO map</Name>
+                                <Type>UDINT</Type>
+                                <BitSize>32</BitSize>
+                                <Flags><Access>rw</Access></Flags>
+                            </Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+                <RxPdo Sm="2">
+                    <Index>#x1600</Index>
+                    <Name>Auto-generated map</Name>
+                    <Entry><Index>#x7000</Index><SubIndex>1</SubIndex><BitLen>16</BitLen></Entry>
+                </RxPdo>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    auto dictionary = parser.loadString(xml);
+    auto [obj, _] = findObject(dictionary, 0x1600, 0);
+    ASSERT_NE(obj, nullptr);
+    ASSERT_EQ(obj->name, "Explicit RxPDO map");  // explicit declaration wins
+}
+
+TEST(ESIParser, loadDevice_parses_eeprom)
+{
+    ESI::Parser parser;
+    ESI::Device device = parser.loadDevice("kickcat_esi_test_sm_fmmu.xml");
+
+    ASSERT_TRUE(device.eeprom.has_value());
+    auto const& eep = *device.eeprom;
+    ASSERT_TRUE(eep.assign_to_pdi);
+    ASSERT_TRUE(eep.byte_size.has_value());
+    ASSERT_EQ(*eep.byte_size, 2048);
+    ASSERT_EQ(eep.config_data.size(), 16u);
+    ASSERT_EQ(eep.config_data[0], 0x05);
+    ASSERT_EQ(eep.bootstrap.size(), 8u);
+    ASSERT_EQ(eep.categories.size(), 2u);
+
+    ASSERT_EQ(eep.categories[0].cat_no, 30);
+    ASSERT_TRUE(eep.categories[0].data_string.has_value());
+    ASSERT_EQ(*eep.categories[0].data_string, "BootCfg");
+    ASSERT_FALSE(eep.categories[0].preserve_online_data);
+
+    ASSERT_EQ(eep.categories[1].cat_no, 40);
+    ASSERT_TRUE(eep.categories[1].preserve_online_data);
+    ASSERT_EQ(eep.categories[1].data.size(), 4u);
+    ASSERT_EQ(eep.categories[1].data[0], 0xDE);
+}
+
+TEST(ESIParser, loadDevice_eeprom_raw_data_form)
+{
+    // Eeprom can also carry a raw image directly as <Data>; the structured
+    // form (ByteSize/ConfigData/etc.) must not be required in that case.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes><DataType><Name>UDINT</Name><BitSize>32</BitSize></DataType></DataTypes>
+                        <Objects>
+                            <Object><Index>#x1000</Index><Name>X</Name><Type>UDINT</Type><BitSize>32</BitSize></Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+                <Eeprom>
+                    <Data>0102030405060708</Data>
+                </Eeprom>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    ESI::Device device = parser.loadDeviceString(xml);
+    ASSERT_TRUE(device.eeprom.has_value());
+    ASSERT_EQ(device.eeprom->raw_data.size(), 8u);
+    ASSERT_EQ(device.eeprom->raw_data[7], 0x08u);
+    ASSERT_FALSE(device.eeprom->byte_size.has_value());
+}
+
+TEST(ESIParser, loadDevice_parses_dc)
+{
+    ESI::Parser parser;
+    ESI::Device device = parser.loadDevice("kickcat_esi_test_sm_fmmu.xml");
+
+    ASSERT_TRUE(device.dc.has_value());
+    auto const& dc = *device.dc;
+    ASSERT_TRUE (dc.potential_reference_clock);
+    ASSERT_FALSE(dc.pdo_oversampling);
+    ASSERT_FALSE(dc.external_ref_clock);
+    ASSERT_EQ(dc.op_modes.size(), 2u);
+
+    auto const& synchron = dc.op_modes[0];
+    ASSERT_EQ(synchron.name,            "Synchron");
+    ASSERT_EQ(synchron.desc,            "SM-Synchron");
+    ASSERT_EQ(synchron.assign_activate, 0x300u);
+    ASSERT_FALSE(synchron.activate_additional.has_value());
+
+    ASSERT_TRUE(synchron.cycle_time[0].has_value());
+    ASSERT_EQ(synchron.cycle_time[0]->value, 1000000);
+    ASSERT_TRUE(synchron.cycle_time[0]->factor.has_value());
+    ASSERT_EQ(*synchron.cycle_time[0]->factor, 1);
+
+    ASSERT_TRUE(synchron.shift_time[0].has_value());
+    ASSERT_EQ(synchron.shift_time[0]->value, 100);
+    ASSERT_TRUE(synchron.shift_time[0]->input.has_value());
+    ASSERT_TRUE(*synchron.shift_time[0]->input);
+    ASSERT_TRUE(synchron.shift_time[0]->output_delay_time.has_value());
+    ASSERT_EQ(*synchron.shift_time[0]->output_delay_time, 500);
+
+    // <Sm No="3"> with one oversampled <Pdo OSFac="2">#x1A00</Pdo>; the obsolete
+    // <SyncType> child is present in the fixture but must not be surfaced.
+    ASSERT_EQ(synchron.sm_configs.size(), 1u);
+    ASSERT_EQ(synchron.sm_configs[0].no,           3);
+    ASSERT_EQ(synchron.sm_configs[0].pdos.size(),  1u);
+    ASSERT_EQ(synchron.sm_configs[0].pdos[0].index, 0x1A00u);
+    ASSERT_TRUE(synchron.sm_configs[0].pdos[0].os_fac.has_value());
+    ASSERT_EQ(*synchron.sm_configs[0].pdos[0].os_fac, 2);
+
+    auto const& freerun = dc.op_modes[1];
+    ASSERT_EQ(freerun.name,            "FreeRun");
+    ASSERT_EQ(freerun.assign_activate, 0u);
+    ASSERT_FALSE(freerun.cycle_time[0].has_value());
+    ASSERT_TRUE(freerun.sm_configs.empty());
+}
+
+TEST(ESIParser, eeprom_dc_absent_when_blocks_missing)
+{
+    ESI::Parser parser;
+    ESI::Device device = parser.loadDevice("kickcat_esi_test_multi_device.xml");
+
+    ASSERT_FALSE(device.eeprom.has_value());
+    ASSERT_FALSE(device.dc.has_value());
 }
 
 TEST(ESIParser, throws_on_unknown_fmmu_text)
@@ -1034,6 +1254,573 @@ TEST(ESIParser, throws_on_unknown_fmmu_text)
     }
 }
 
+TEST(ESIParser, string_default_data_not_reversed)
+{
+    // <DefaultData>4B69636B43415421</DefaultData> is hex for "KickCAT!".
+    // The bytes must land in natural order (was reversed pre-fix).
+    ESI::Parser parser;
+    auto dictionary = parser.loadFile("kickcat_esi_test_basic.xml");
+    auto [object, entry] = findObject(dictionary, 0x1008, 0);
+    ASSERT_NE(object, nullptr);
+    ASSERT_EQ(entry->type, CoE::DataType::VISIBLE_STRING);
+    ASSERT_NE(entry->data, nullptr);
+    ASSERT_EQ(std::memcmp(entry->data, "KickCAT!", 8), 0);
+}
+
+TEST(ESIParser, x1C00_not_duplicated_when_explicit)
+{
+    // ESI declares 0x1C00 explicitly. The synthesised one must not appear.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes>
+                            <DataType><Name>USINT</Name><BitSize>8</BitSize></DataType>
+                            <DataType>
+                                <Name>SM_ARR</Name><BaseType>USINT</BaseType><BitSize>16</BitSize>
+                                <ArrayInfo><LBound>1</LBound><Elements>1</Elements></ArrayInfo>
+                            </DataType>
+                            <DataType>
+                                <Name>DT1C00</Name><BitSize>16</BitSize>
+                                <SubItem><SubIdx>0</SubIdx><Name>Count</Name><Type>USINT</Type><BitSize>8</BitSize><BitOffs>0</BitOffs></SubItem>
+                            </DataType>
+                        </DataTypes>
+                        <Objects>
+                            <Object><Index>#x1C00</Index><Name>Explicit SM types</Name><Type>DT1C00</Type><BitSize>16</BitSize></Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+                <Sm StartAddress="#x1000" ControlByte="#x26" Enable="1">MBoxOut</Sm>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    auto dictionary = parser.loadString(xml);
+    int count = 0;
+    for (auto const& o : dictionary)
+    {
+        if (o.index == 0x1C00) { ++count; }
+    }
+    ASSERT_EQ(count, 1);
+    auto [obj, _] = findObject(dictionary, 0x1C00, 0);
+    ASSERT_NE(obj, nullptr);
+    ASSERT_EQ(obj->name, "Explicit SM types");
+}
+
+TEST(ESIParser, array_with_255_elements_does_not_hang)
+{
+    // PR4 reviewer found: uint8_t loop counter wraps at elements=255 (real
+    // ETG examples have this). Pin the fix.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes>
+                            <DataType><Name>USINT</Name><BitSize>8</BitSize></DataType>
+                            <DataType>
+                                <Name>BigArr</Name><BaseType>USINT</BaseType><BitSize>2040</BitSize>
+                                <ArrayInfo><LBound>1</LBound><Elements>255</Elements></ArrayInfo>
+                            </DataType>
+                            <DataType>
+                                <Name>DT</Name><BitSize>2048</BitSize>
+                                <SubItem><SubIdx>0</SubIdx><Name>n</Name><Type>USINT</Type><BitSize>8</BitSize><BitOffs>0</BitOffs></SubItem>
+                                <SubItem><SubIdx>1</SubIdx><Name>arr</Name><Type>BigArr</Type><BitSize>2040</BitSize><BitOffs>8</BitOffs></SubItem>
+                            </DataType>
+                        </DataTypes>
+                        <Objects>
+                            <Object><Index>#x2000</Index><Name>BigRecord</Name><Type>DT</Type><BitSize>2048</BitSize></Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    auto dictionary = parser.loadString(xml);
+    auto [obj, _] = findObject(dictionary, 0x2000, 0);
+    ASSERT_NE(obj, nullptr);
+    // SubIndex 0 + 255 array elements
+    ASSERT_EQ(obj->entries.size(), 256u);
+}
+
+TEST(ESIParser, array_with_more_than_255_elements_throws)
+{
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes>
+                            <DataType><Name>USINT</Name><BitSize>8</BitSize></DataType>
+                            <DataType>
+                                <Name>TooBig</Name><BaseType>USINT</BaseType><BitSize>2048</BitSize>
+                                <ArrayInfo><LBound>1</LBound><Elements>256</Elements></ArrayInfo>
+                            </DataType>
+                            <DataType>
+                                <Name>DT</Name><BitSize>2056</BitSize>
+                                <SubItem><SubIdx>0</SubIdx><Name>n</Name><Type>USINT</Type><BitSize>8</BitSize><BitOffs>0</BitOffs></SubItem>
+                                <SubItem><SubIdx>1</SubIdx><Name>arr</Name><Type>TooBig</Type><BitSize>2048</BitSize><BitOffs>8</BitOffs></SubItem>
+                            </DataType>
+                        </DataTypes>
+                        <Objects>
+                            <Object><Index>#x2000</Index><Name>R</Name><Type>DT</Type><BitSize>2056</BitSize></Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    ASSERT_THROW((void) parser.loadString(xml), std::invalid_argument);
+}
+
+TEST(ESIParser, throws_on_odd_length_hex_binary)
+{
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes><DataType><Name>UDINT</Name><BitSize>32</BitSize></DataType></DataTypes>
+                        <Objects>
+                            <Object>
+                                <Index>#x1000</Index>
+                                <Name>X</Name>
+                                <Type>UDINT</Type>
+                                <BitSize>32</BitSize>
+                                <Info><DefaultData>012</DefaultData></Info>
+                            </Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    try
+    {
+        (void) parser.loadString(xml);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("odd length"), std::string::npos) << msg;
+    }
+}
+
+TEST(ESIParser, throws_on_numeric_overflow)
+{
+    // SubIndex is uint8_t; #xFF01 overflows -> must throw, not silently wrap.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes><DataType><Name>UDINT</Name><BitSize>32</BitSize></DataType></DataTypes>
+                        <Objects>
+                            <Object><Index>#x1000</Index><Name>X</Name><Type>UDINT</Type><BitSize>32</BitSize></Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+                <Mailbox>
+                    <CoE>
+                        <InitCmd>
+                            <Transition>PS</Transition>
+                            <Index>#x1000</Index>
+                            <SubIndex>#xFF01</SubIndex>
+                            <Data>00</Data>
+                        </InitCmd>
+                    </CoE>
+                </Mailbox>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    try
+    {
+        (void) parser.loadString(xml);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("out of range"), std::string::npos) << msg;
+    }
+}
+
+TEST(ESIParser, throws_on_missing_vendor_id)
+{
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes><DataType><Name>UDINT</Name><BitSize>32</BitSize></DataType></DataTypes>
+                        <Objects>
+                            <Object><Index>#x1000</Index><Name>X</Name><Type>UDINT</Type><BitSize>32</BitSize></Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    try
+    {
+        (void) parser.loadString(xml);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("Id"),     std::string::npos) << msg;
+        ASSERT_NE(msg.find("Vendor"), std::string::npos) << msg;
+    }
+}
+
+TEST(ESIParser, empty_vendor_id_element_tolerated)
+{
+    // <Id></Id> (present but empty) should default to vendor_id=0 — real
+    // vendor catalogs ship placeholder empty Id elements.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id></Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    ESI::Device device = parser.loadDeviceString(xml);
+    ASSERT_EQ(device.vendor_id, 0u);
+}
+
+TEST(ESIParser, throws_on_array_bitsize_not_divisible_by_elements)
+{
+    // BitSize=10, Elements=3 -> 10/3=3 truncates 1 bit silently if unchecked.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes>
+                            <DataType><Name>USINT</Name><BitSize>8</BitSize></DataType>
+                            <DataType>
+                                <Name>Odd</Name><BaseType>USINT</BaseType><BitSize>10</BitSize>
+                                <ArrayInfo><LBound>1</LBound><Elements>3</Elements></ArrayInfo>
+                            </DataType>
+                            <DataType>
+                                <Name>DT</Name><BitSize>18</BitSize>
+                                <SubItem><SubIdx>0</SubIdx><Name>n</Name><Type>USINT</Type><BitSize>8</BitSize><BitOffs>0</BitOffs></SubItem>
+                                <SubItem><SubIdx>1</SubIdx><Name>arr</Name><Type>Odd</Type><BitSize>10</BitSize><BitOffs>8</BitOffs></SubItem>
+                            </DataType>
+                        </DataTypes>
+                        <Objects>
+                            <Object><Index>#x2000</Index><Name>R</Name><Type>DT</Type><BitSize>18</BitSize></Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    try
+    {
+        (void) parser.loadString(xml);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("divisible"), std::string::npos) << msg;
+    }
+}
+
+TEST(ESIParser, throws_on_duplicate_rx_pdo_index)
+{
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <RxPdo Sm="2"><Index>#x1600</Index><Name>A</Name></RxPdo>
+                <RxPdo Sm="2"><Index>#x1600</Index><Name>B</Name></RxPdo>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    try
+    {
+        (void) parser.loadString(xml);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("duplicate"), std::string::npos) << msg;
+        ASSERT_NE(msg.find("0x1600"),    std::string::npos) << msg;
+    }
+}
+
+TEST(ESIParser, throws_on_eeprom_data_and_byte_size_both_present)
+{
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Eeprom>
+                    <Data>0102</Data>
+                    <ByteSize>2048</ByteSize>
+                </Eeprom>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    try
+    {
+        (void) parser.loadString(xml);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("mutually exclusive"), std::string::npos) << msg;
+    }
+}
+
+TEST(ESIParser, throws_on_dictionary_without_objects)
+{
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes><DataType><Name>UDINT</Name><BitSize>32</BitSize></DataType></DataTypes>
+                    </Dictionary>
+                </Profile>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    ASSERT_THROW((void) parser.loadString(xml), std::invalid_argument);
+}
+
+TEST(ESIParser, dtypes_missing_gives_contextual_error_for_non_basic_type)
+{
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <Objects>
+                            <Object><Index>#x2000</Index><Name>X</Name><Type>MyRecord</Type><BitSize>16</BitSize></Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    try
+    {
+        (void) parser.loadString(xml);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("DataTypes"),    std::string::npos) << msg;
+        ASSERT_NE(msg.find("Object 0x2000"), std::string::npos) << msg;
+    }
+}
+
+TEST(ESIParser, signed_type_accepts_unsigned_bit_pattern)
+{
+    // SoE InitCmd IDN is int32_t in the schema, but real ESIs use #xFFFFFFFF
+    // as a bit-pattern sentinel meaning -1. The narrower accepts this.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Mailbox>
+                    <SoE>
+                        <InitCmd>
+                            <Transition>PS</Transition>
+                            <IDN>#xFFFFFFFF</IDN>
+                            <Data>00</Data>
+                        </InitCmd>
+                    </SoE>
+                </Mailbox>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    ESI::Device device = parser.loadDeviceString(xml);
+    ASSERT_TRUE(device.mailbox.has_value());
+    ASSERT_TRUE(device.mailbox->soe.has_value());
+    ASSERT_EQ(device.mailbox->soe->init_cmds.size(), 1u);
+    ASSERT_EQ(device.mailbox->soe->init_cmds[0].idn, -1);
+}
+
+TEST(ESIParser, stoll_overflow_carries_esi_context)
+{
+    // A decimal number exceeding INT64_MAX must surface ESI context, not the
+    // raw std::out_of_range message.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>99999999999999999999999</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    try
+    {
+        (void) parser.loadString(xml);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("Vendor/Id"), std::string::npos) << msg;
+    }
+}
+
+TEST(ESIParser, non_hex_data_carries_esi_context)
+{
+    // <Data>GGGG</Data>: per-byte parse fails. Error must name the element
+    // and offending pair, not just raw "stoi".
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes><DataType><Name>UDINT</Name><BitSize>32</BitSize></DataType></DataTypes>
+                        <Objects>
+                            <Object>
+                                <Index>#x1000</Index><Name>X</Name><Type>UDINT</Type><BitSize>32</BitSize>
+                                <Info><DefaultData>GGGGGGGG</DefaultData></Info>
+                            </Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    try
+    {
+        (void) parser.loadString(xml);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("non-hex"),    std::string::npos) << msg;
+        ASSERT_NE(msg.find("DefaultData"), std::string::npos) << msg;
+    }
+}
+
+TEST(ESIParser, bypass_sites_now_throw_on_overflow)
+{
+    // ProfileNo > UINT16_MAX must throw via parseHexDec<uint16_t> now.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>#x10000</ProfileNo></Profile>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    try
+    {
+        (void) parser.loadString(xml);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("Profile/ProfileNo"), std::string::npos) << msg;
+        ASSERT_NE(msg.find("out of range"),       std::string::npos) << msg;
+    }
+}
+
+TEST(ESIParser, throws_on_empty_document)
+{
+    ESI::Parser parser;
+    ASSERT_THROW((void) parser.loadString("<?xml version=\"1.0\"?>\n<!-- nothing -->"),
+                 std::invalid_argument);
+}
+
+TEST(ESIParser, profile_no_reset_between_loads)
+{
+    ESI::Parser parser;
+    ESI::Device d1 = parser.loadDevice("kickcat_esi_test_basic.xml");
+    ASSERT_EQ(d1.profile_no, 5001u);
+
+    // Second device has no <Profile> — profile_no must NOT carry over.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">NoProfile</Type>
+                <Name>NoProfile</Name>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+    ESI::Device d2 = parser.loadDeviceString(xml);
+    ASSERT_EQ(d2.profile_no, 0u);
+    ASSERT_STREQ(parser.profile(), "");
+}
+
+TEST(ESIParser, device_without_profile_parses)
+{
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">SimpleIO</Type>
+                <Name>Simple IO Terminal</Name>
+                <Sm StartAddress="#x1000" ControlByte="#x64" Enable="1">Outputs</Sm>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    ESI::Device device = parser.loadDeviceString(xml);
+    ASSERT_EQ(device.sync_managers.size(), 1u);
+    // Synthesised 0x1C00 from the single <Sm> still appears
+    auto [obj, _] = findObject(device.dictionary, 0x1C00, 0);
+    ASSERT_NE(obj, nullptr);
+    ASSERT_EQ(obj->entries.size(), 2u);  // size + 1 SM
+}
+
 TEST(ESIParser, CoE_alias_is_backwards_compatible)
 {
     // The CoE::EsiParser alias must still resolve to ESI::Parser.
@@ -1041,4 +1828,164 @@ TEST(ESIParser, CoE_alias_is_backwards_compatible)
     auto dictionary = parser.loadFile("kickcat_esi_test_basic.xml");
     ASSERT_EQ(dictionary.size(), 9u);
     ASSERT_STREQ(parser.vendor(), "KickCAT");
+}
+
+TEST(ESIParser, buildMappingObject_throws_when_more_than_255_entries)
+{
+    ESI::Pdo pdo;
+    pdo.index = 0x1600;
+    pdo.name  = "Too many entries";
+    pdo.entries.resize(256);  // SubIndex space is a single byte
+
+    try
+    {
+        (void) ESI::Parser::buildMappingObject(pdo, true);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("255 entries"), std::string::npos) << msg;
+    }
+}
+
+TEST(ESIParser, buildAssignmentObject_throws_when_more_than_255_pdos)
+{
+    std::vector<ESI::Pdo> pdos(256);
+    for (std::size_t i = 0; i < pdos.size(); ++i)
+    {
+        pdos[i].index = static_cast<uint16_t>(0x1600 + i);
+    }
+
+    try
+    {
+        (void) ESI::Parser::buildAssignmentObject(pdos, 0x1C12, true);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("255 PDOs"), std::string::npos) << msg;
+    }
+}
+
+TEST(ESIParser, throws_on_eeprom_category_without_payload)
+{
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Eeprom>
+                    <ByteSize>2048</ByteSize>
+                    <ConfigData>05060708</ConfigData>
+                    <Category><CatNo>30</CatNo></Category>
+                </Eeprom>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    try
+    {
+        (void) parser.loadString(xml);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("missing payload"), std::string::npos) << msg;
+    }
+}
+
+TEST(ESIParser, eeprom_category_empty_datastring_is_empty_string)
+{
+    // <DataString/> is a valid (empty) xs:string per the schema: payload is
+    // selected by element presence, so the category parses with an empty value.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Eeprom>
+                    <ByteSize>2048</ByteSize>
+                    <ConfigData>05060708</ConfigData>
+                    <Category><CatNo>30</CatNo><DataString></DataString></Category>
+                </Eeprom>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    ESI::Device device = parser.loadDeviceString(xml);
+    ASSERT_TRUE(device.eeprom.has_value());
+    ASSERT_EQ(device.eeprom->categories.size(), 1u);
+    ASSERT_TRUE(device.eeprom->categories[0].data_string.has_value());
+    ASSERT_TRUE(device.eeprom->categories[0].data_string->empty());
+}
+
+TEST(ESIParser, throws_on_eeprom_category_empty_datauint)
+{
+    // A numeric payload still requires a value: empty <DataUINT/> must throw.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Eeprom>
+                    <ByteSize>2048</ByteSize>
+                    <ConfigData>05060708</ConfigData>
+                    <Category><CatNo>30</CatNo><DataUINT></DataUINT></Category>
+                </Eeprom>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    ASSERT_THROW((void) parser.loadDeviceString(xml), std::invalid_argument);
+}
+
+TEST(ESIParser, throws_on_dc_opmode_missing_mandatory_fields)
+{
+    char const* missing_name = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Dc><OpMode><AssignActivate>#x300</AssignActivate></OpMode></Dc>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    char const* missing_assign_activate = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Dc><OpMode><Name>Sync</Name></OpMode></Dc>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    char const* sm_missing_no = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Dc><OpMode>
+                    <Name>Sync</Name><AssignActivate>#x300</AssignActivate>
+                    <Sm><Pdo OSFac="2">#x1A00</Pdo></Sm>
+                </OpMode></Dc>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    ASSERT_THROW((void) parser.loadString(missing_name),            std::invalid_argument);
+    ASSERT_THROW((void) parser.loadString(missing_assign_activate), std::invalid_argument);
+
+    try
+    {
+        (void) parser.loadString(sm_missing_no);
+        FAIL() << "expected invalid_argument";
+    }
+    catch (std::invalid_argument const& e)
+    {
+        std::string msg = e.what();
+        ASSERT_NE(msg.find("@No"), std::string::npos) << msg;
+    }
 }


### PR DESCRIPTION
Parse <RxPdo>/<TxPdo> with <Entry> children and auto-generate 0x16xx/0x1Axx mapping and 0x1C12/0x1C13 assignment CoE objects into the legacy Dictionary (explicit declarations win). 
Add <Eeprom> (raw or structured with Categories) and <Dc>/<OpMode> (cycle/shift times) as std::optional aggregates on Device.