### PR TITLE
Compliance against all Beckhoff ESI

### DIFF
--- a/examples/master/load_esi/load_esi.cc
+++ b/examples/master/load_esi/load_esi.cc
@@ -36,7 +36,7 @@ int main(int argc, char const* argv[])
     printf("Profile: %s\n",        parser.profile());
 
 
-    printf("Load %ld object\n", coe_dict.size());
+    printf("Load %zu object\n", coe_dict.size());
     for (auto const& entry : coe_dict)
     {
         printf("%s\n", CoE::toString(entry).c_str());

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -62,6 +62,7 @@ endif()
 if (ENABLE_ESI_PARSER)
   find_package(tinyxml2 CONFIG REQUIRED)
   list(APPEND KICKCAT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/ESI/Parser.cc)
+  list(APPEND KICKCAT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/ESI/SIIBuilder.cc)
   list(APPEND OS_LIBRARIES tinyxml2::tinyxml2)
 endif()
 

--- a/lib/include/kickcat/CoE/OD.h
+++ b/lib/include/kickcat/CoE/OD.h
@@ -244,13 +244,24 @@ namespace kickcat::CoE
     ///        cyclic path. An empty result means the dictionary is safe to serve.
     std::vector<std::string> validateDictionary(Dictionary const& dict);
 
+    /// \brief Give every SDO-accessible entry (access != 0, bitlen > 0) zero-initialized backing
+    ///        storage if it has none. Backing storage is a structural requirement, distinct from an
+    ///        ESI <DefaultData>/<DefaultValue> (which, when present, has already filled it). Additive:
+    ///        entries that already own storage are left untouched, and missing entries are not
+    ///        fabricated - only existing entries gain storage.
+    void materializeStorage(Dictionary& dict);
+
     template<typename T>
     void addEntry(Object &object, uint8_t subindex, uint16_t bitlen, uint16_t bitoff,
                   uint16_t access, DataType type, std::string const& description, T data)
     {
         object.entries.emplace_back(subindex, bitlen, bitoff, access, type, description);
         auto& alloc = object.entries.back().data;
-        std::size_t size = bitlen / 8;
+        std::size_t size = (bitlen + 7) / 8;  // sub-byte entries (BOOL/bitN) still need 1 byte
+        if (size == 0)
+        {
+            size = 1;
+        }
         alloc = std::malloc(size);
 
         if constexpr(std::is_same_v<const char*, T>)

--- a/lib/include/kickcat/ESI/Device.h
+++ b/lib/include/kickcat/ESI/Device.h
@@ -211,7 +211,7 @@ namespace kickcat::ESI
 
         std::vector<uint8_t>     raw_data;        // <Data> at Eeprom level (raw image)
         std::optional<int32_t>   byte_size;
-        std::vector<uint8_t>     config_data;     // first 16 SII bytes
+        std::vector<uint8_t>     config_data;     // SII config area (words 0..6; CRC word excluded)
         std::vector<uint8_t>     config_data2;
         std::vector<uint8_t>     bootstrap;       // bootstrap mailbox config
         std::vector<Category>    categories;

--- a/lib/include/kickcat/ESI/Parser.h
+++ b/lib/include/kickcat/ESI/Parser.h
@@ -30,10 +30,18 @@ namespace kickcat::ESI
         Device loadDevice      (std::string const& file, DeviceFilter const& filter = {});
         Device loadDeviceString(std::string const& xml,  DeviceFilter const& filter = {});
 
+        // Build every <Device> in the file from a single parse. Devices that fail
+        // to parse are skipped; their type + error is appended to `errors` (if given).
+        std::vector<Device> loadAllDevices(std::string const& file, std::vector<std::string>* errors = nullptr);
+
         // Pure CoE-object synthesis from parsed PDO data (ETG.1000.6 layout),
         // independent of any XML/parser state. Exposed for direct unit testing.
         static CoE::Object buildMappingObject   (Pdo const& pdo, bool is_rx);
         static CoE::Object buildAssignmentObject(std::vector<Pdo> const& pdos, uint16_t index, bool is_rx);
+
+        // Map an ESI basic-type label ("BOOL", "UINT", ...) to its CoE::DataType,
+        // whose value is the ETG SII data-type code. nullopt for unknown labels.
+        static std::optional<CoE::DataType> coeTypeFromLabel(std::string const& label);
 
     private:
         static std::optional<uint32_t> readHexDecAttr(tinyxml2::XMLElement* node, char const* name);
@@ -44,6 +52,7 @@ namespace kickcat::ESI
 
         std::vector<DeviceSummary> listDevicesImpl();
         Device                     loadDeviceImpl(DeviceFilter const& filter);
+        Device                     buildDeviceFromElement(tinyxml2::XMLElement* device_node);
 
         tinyxml2::XMLElement* selectDevice(DeviceFilter const& filter);
         DeviceSummary         summarize   (tinyxml2::XMLElement* device);

--- a/lib/include/kickcat/ESI/SIIBuilder.h
+++ b/lib/include/kickcat/ESI/SIIBuilder.h
@@ -1,0 +1,22 @@
+#ifndef KICKCAT_ESI_SIIBUILDER_H
+#define KICKCAT_ESI_SIIBUILDER_H
+
+#include <cstdint>
+#include <vector>
+
+#include "kickcat/ESI/Device.h"
+#include "kickcat/SIIParser.h"
+
+namespace kickcat::ESI
+{
+    // Compile a parsed ESI device into an SII structure (ETG.2010): identity,
+    // strings, general, sync managers, FMMUs, Tx/Rx PDO mappings, and vendor
+    // categories. The DC category and image/order-code strings are not synthesized.
+    eeprom::SII buildSII(Device const& device);
+
+    // buildSII(device).serialize(), except a raw <Eeprom><Data> image is returned
+    // verbatim when the ESI shipped one.
+    std::vector<uint8_t> buildEepromImage(Device const& device);
+}
+
+#endif

--- a/lib/include/kickcat/protocol.h
+++ b/lib/include/kickcat/protocol.h
@@ -143,7 +143,7 @@ namespace kickcat
 
     enum StatusCode : uint16_t
     {
-        NO_ERROR                              = 0x0000,
+        ECAT_NO_ERROR                         = 0x0000,  // ECAT_ prefix: bare NO_ERROR collides with the Windows API macro (winerror.h)
         UNSPECIFIED_ERROR                     = 0x0001,
         NO_MEMORY                             = 0x0002,
         INVALID_REVISION                      = 0x0004,

--- a/lib/master/include/kickcat/SIIParser.h
+++ b/lib/master/include/kickcat/SIIParser.h
@@ -47,12 +47,17 @@ namespace kickcat::eeprom
 
         void parse(uint8_t const* data, std::size_t size);
 
-        /// \brief Resolve a 1-based SII string index (ETG.2010). Empty for index 0 or out-of-range.
+        /// \brief Resolve a 1-based SII string index (ETG.2010 Category STRINGS, Table 6:
+        ///        index 0 = empty string). strings[0] is that reserved placeholder.
         std::string_view getString(uint8_t index) const
         {
-            if ((index == 0) or (index > strings.size())) { return {}; }
-            return strings[index - 1];
+            if ((index == 0) or (index >= strings.size())) { return {}; }
+            return strings[index];
         }
+
+        /// \brief Add a string to the pool (deduplicated) and return its 1-based index.
+        ///        Empty text, or a full pool (255 strings), yields 0 (no string).
+        uint8_t registerString(std::string const& text);
 
         template<typename T>
         void parse(std::vector<T> const& data)

--- a/lib/master/src/helpers.cc
+++ b/lib/master/src/helpers.cc
@@ -79,15 +79,22 @@ namespace kickcat
 
         auto createSocket = [&](std::string& ifname, std::string const& tap_name) -> std::shared_ptr<AbstractSocket>
         {
-            if (ifname == "tap:server")
+            // "tap:server" / "tap:client" use the default shared-memory name; an
+            // optional ":<name>" suffix overrides it so independent server/client
+            // pairs can coexist (e.g. "tap:server:bench1").
+            std::pair<std::string, bool> const tap_kinds[] = {{"tap:server", true}, {"tap:client", false}};
+            for (auto const& [prefix, init] : tap_kinds)
             {
-                ifname = tap_name;
-                return std::make_shared<TapSocket>(true);
-            }
-            if (ifname == "tap:client")
-            {
-                ifname = tap_name;
-                return std::make_shared<TapSocket>(false);
+                if (ifname == prefix)
+                {
+                    ifname = tap_name;
+                    return std::make_shared<TapSocket>(init);
+                }
+                if (ifname.rfind(prefix + ":", 0) == 0)
+                {
+                    ifname = ifname.substr(prefix.size() + 1);
+                    return std::make_shared<TapSocket>(init);
+                }
             }
             if (ifname.empty())
             {

--- a/lib/slave/include/kickcat/ESC/EmulatedESC.h
+++ b/lib/slave/include/kickcat/ESC/EmulatedESC.h
@@ -25,6 +25,7 @@ namespace kickcat
         // Helpers to load the eeprom
         void loadEeprom(std::string const& eeprom_path);
         void loadEeprom(std::vector<uint16_t> const& eeprom_data);
+        void loadEeprom(std::vector<uint8_t> const& image);  // word-addressed; odd trailing byte zero-filled
 
         // Access from ECAT POV
         void processDatagram(DatagramHeader* header, void* data, uint16_t* wkc);

--- a/lib/slave/include/kickcat/ESM.h
+++ b/lib/slave/include/kickcat/ESM.h
@@ -41,9 +41,9 @@ namespace kickcat
                 return not(al_watchdog_process_data & 0x1);
             }
 
-            static Context build(uint8_t state, uint8_t statusCode = StatusCode::NO_ERROR)
+            static Context build(uint8_t state, uint8_t statusCode = StatusCode::ECAT_NO_ERROR)
             {
-                if (statusCode == NO_ERROR)
+                if (statusCode == StatusCode::ECAT_NO_ERROR)
                 {
                     return Context{state, statusCode, 0};
                 }

--- a/lib/slave/include/kickcat/PDO.h
+++ b/lib/slave/include/kickcat/PDO.h
@@ -26,6 +26,10 @@ namespace kickcat
 
         StatusCode configureMapping(CoE::Dictionary& dict);
 
+        // Meaningful only after configure().
+        bool hasInput()  const { return sm_input_.type  != SyncManager::Unused; }
+        bool hasOutput() const { return sm_output_.type != SyncManager::Unused; }
+
     private:
 
         std::vector<uint16_t> parseAssignment(CoE::Dictionary& dict, uint16_t assign_idx);

--- a/lib/slave/src/ESC/EmulatedESC.cc
+++ b/lib/slave/src/ESC/EmulatedESC.cc
@@ -53,16 +53,23 @@ namespace kickcat
         }
         int size = eeprom_file.tellg();
         eeprom_file.seekg (0, std::ios::beg);
-        eeprom_.resize(size / 2); // vector of uint16_t so / 2 since the size is in byte
-        eeprom_file.read((char*)eeprom_.data(), size);
+        std::vector<uint8_t> image(static_cast<std::size_t>(size));
+        eeprom_file.read(reinterpret_cast<char*>(image.data()), size);
         eeprom_file.close();
 
-        loadEeprom();
+        loadEeprom(image);
     }
 
     void EmulatedESC::loadEeprom(std::vector<uint16_t> const& eeprom_data)
     {
         eeprom_ = eeprom_data;
+        loadEeprom();
+    }
+
+    void EmulatedESC::loadEeprom(std::vector<uint8_t> const& image)
+    {
+        eeprom_.assign((image.size() + 1) / 2, 0);  // word-addressed; odd trailing byte zero-filled
+        std::memcpy(eeprom_.data(), image.data(), image.size());
         loadEeprom();
     }
 

--- a/lib/slave/src/ESMStates.cc
+++ b/lib/slave/src/ESMStates.cc
@@ -116,14 +116,14 @@ namespace kickcat::ESM
             if (mbx_)
             {
                 StatusCode mapping_rc = pdo_.configureMapping(mbx_->getDictionary());
-                if (mapping_rc != StatusCode::NO_ERROR)
+                if (mapping_rc != StatusCode::ECAT_NO_ERROR)
                 {
                     return Context::build(id_, mapping_rc);
                 }
             }
 
             StatusCode pdo_sm_config_status_code = pdo_.isConfigOk();
-            if (pdo_sm_config_status_code != StatusCode::NO_ERROR)
+            if (pdo_sm_config_status_code != StatusCode::ECAT_NO_ERROR)
             {
                 return Context::build(id_, pdo_sm_config_status_code);
             }
@@ -152,7 +152,7 @@ namespace kickcat::ESM
 
     void SafeOP::onEntry(Context oldStatus, Context newStatus)
     {
-        if (oldStatus.state() == State::OPERATIONAL and newStatus.al_status_code != StatusCode::NO_ERROR)
+        if (oldStatus.state() == State::OPERATIONAL and newStatus.al_status_code != StatusCode::ECAT_NO_ERROR)
         {
             pdo_.activateOutput(false);
         }
@@ -174,12 +174,14 @@ namespace kickcat::ESM
         }
 
         StatusCode pdo_sm_config_status_code = pdo_.isConfigOk();
-        if (pdo_sm_config_status_code != StatusCode::NO_ERROR)
+        if (pdo_sm_config_status_code != StatusCode::ECAT_NO_ERROR)
         {
             return Context::build(State::PRE_OP, pdo_sm_config_status_code);
         }
 
-        if (control.requestedState() == State::OPERATIONAL and currentStatus.is_valid_output_data)
+        // An input-only slave has no output data to validate, so it may still reach OP.
+        bool const outputs_valid = currentStatus.is_valid_output_data or not pdo_.hasOutput();
+        if (control.requestedState() == State::OPERATIONAL and outputs_valid)
         {
             return Context::build(State::OPERATIONAL);
         }
@@ -218,7 +220,7 @@ namespace kickcat::ESM
         }
 
         StatusCode pdo_sm_config_status_code = pdo_.isConfigOk();
-        if (pdo_sm_config_status_code != StatusCode::NO_ERROR)
+        if (pdo_sm_config_status_code != StatusCode::ECAT_NO_ERROR)
         {
             return Context::build(PRE_OP, pdo_sm_config_status_code);
         }

--- a/lib/slave/src/PDO.cc
+++ b/lib/slave/src/PDO.cc
@@ -8,32 +8,34 @@ namespace kickcat
 {
     int32_t PDO::configure()
     {
+        // A slave may have only inputs (e.g. a digital input terminal) or only
+        // outputs. findSm throws when a direction's SM is absent, so resolve each
+        // direction independently and leave the missing one Unused.
+        sm_input_  = SyncManagerConfig{0, 0, 0, 0, SyncManager::Unused};
+        sm_output_ = SyncManagerConfig{0, 0, 0, 0, SyncManager::Unused};
+
         try
         {
-            auto [indexIn, pdoIn]   = esc_->findSm(SM_CONTROL_MODE_BUFFERED | SM_CONTROL_DIRECTION_READ);
-            auto [indexOut, pdoOut] = esc_->findSm(SM_CONTROL_MODE_BUFFERED | SM_CONTROL_DIRECTION_WRITE);
-            
+            auto [indexIn, pdoIn] = esc_->findSm(SM_CONTROL_MODE_BUFFERED | SM_CONTROL_DIRECTION_READ);
             if (pdoIn.length > 0)
             {
                 sm_input_ = SYNC_MANAGER_PI_IN(indexIn, pdoIn.start_address, pdoIn.length);
             }
-            else
-            {
-                sm_input_ = SyncManagerConfig{indexIn, 0, 0, 0, SyncManager::Unused};
-            }
+        }
+        catch (std::exception const&)
+        {
+        }
 
-            if(pdoOut.length > 0)
+        try
+        {
+            auto [indexOut, pdoOut] = esc_->findSm(SM_CONTROL_MODE_BUFFERED | SM_CONTROL_DIRECTION_WRITE);
+            if (pdoOut.length > 0)
             {
                 sm_output_ = SYNC_MANAGER_PI_OUT(indexOut, pdoOut.start_address, pdoOut.length);
             }
-            else
-            {
-                sm_output_ = SyncManagerConfig{indexOut, 0, 0, 0, SyncManager::Unused};
-            }
         }
-        catch (std::exception const& e)
+        catch (std::exception const&)
         {
-            return -EINVAL;
         }
 
         return 0;
@@ -50,7 +52,7 @@ namespace kickcat
             return StatusCode::INVALID_OUTPUT_CONFIGURATION;
         }
 
-        return StatusCode::NO_ERROR;
+        return StatusCode::ECAT_NO_ERROR;
     }
 
     void PDO::activateOutput(bool is_activated)
@@ -164,6 +166,13 @@ namespace kickcat
                 return false;
             }
 
+            // ETG.1000.6 Tables 74/75: index 0 is a gap (no mapped object).
+            if (index == 0)
+            {
+                bit_offset += bits;
+                continue;
+            }
+
             auto [od_obj, od_entry] = CoE::findObject(dict, index, sub);
             if (not od_entry)
             {
@@ -177,11 +186,11 @@ namespace kickcat
             uint8_t* new_ptr = static_cast<uint8_t*>(buffer) + (bit_offset / 8);
 
             od_entry->data = new_ptr;
-            od_entry->is_mapped = true; // data has been remapped/aliased
+            od_entry->is_mapped = true;  // now aliases the process image; dtor must not free it
 
             if (old_data)
             {
-                std::memcpy(new_ptr, old_data, bits / 8);
+                std::memcpy(new_ptr, old_data, (bits + 7) / 8);  // sub-byte entries occupy 1 byte
 
                 if (not old_is_mapped) // if the old data was not mapped, we allocated it, so free it
                 {
@@ -223,6 +232,6 @@ namespace kickcat
             }
         }
 
-        return StatusCode::NO_ERROR;
+        return StatusCode::ECAT_NO_ERROR;
     }
 }

--- a/lib/src/CoE/OD.cc
+++ b/lib/src/CoE/OD.cc
@@ -356,4 +356,39 @@ namespace kickcat::CoE
 
         return problems;
     }
+
+    void materializeStorage(Dictionary& dict)
+    {
+        auto ensure = [](Entry& entry)
+        {
+            if ((entry.data != nullptr) or (entry.bitlen == 0))
+            {
+                return;
+            }
+            std::size_t size = (entry.bitlen + 7) / 8;
+            if (size == 0)
+            {
+                size = 1;
+            }
+            entry.data = std::calloc(1, size);
+        };
+
+        for (auto& object : dict)
+        {
+            bool const is_complex = (object.code == ObjectCode::ARRAY) or (object.code == ObjectCode::RECORD);
+            // Complete access dereferences subindex 0 regardless of its access bits.
+            if (is_complex and not object.entries.empty())
+            {
+                ensure(object.entries.front());
+            }
+
+            for (auto& entry : object.entries)
+            {
+                if ((entry.access & (Access::READ | Access::WRITE)) != 0)
+                {
+                    ensure(entry);
+                }
+            }
+        }
+    }
 }

--- a/lib/src/CoE/mailbox/request.cc
+++ b/lib/src/CoE/mailbox/request.cc
@@ -493,6 +493,14 @@ namespace kickcat::mailbox::request
             auto const* coe = pointData<CoE::Header>(header);
             if (coe->service == CoE::Service::SDO_REQUEST)
             {
+                // An "Abort SDO Transfer" is itself an SDO_REQUEST (ETG.1000.6
+                // Table 40); it terminates a pending transfer, so leave it for
+                // that SDOMessage rather than swallowing it here.
+                auto const* sdo = pointData<CoE::ServiceData>(coe);
+                if (sdo->command == CoE::SDO::request::ABORT)
+                {
+                    return ProcessingResult::NOOP;
+                }
                 auto repr = CoE::toString(coe);
                 coe_warning("WARNING: slave is trying to do an SDO request -> dropping\n");
                 coe_warning("%s\n", repr.c_str());

--- a/lib/src/ESI/Parser.cc
+++ b/lib/src/ESI/Parser.cc
@@ -332,6 +332,16 @@ std::optional<uint32_t> Parser::readHexDecAttr(XMLElement* node, char const* nam
     return parseHexDec<uint32_t>(raw, std::string{"@"} + name);
 }
 
+std::optional<CoE::DataType> Parser::coeTypeFromLabel(std::string const& label)
+{
+    auto it = BASIC_TYPES.find(label);
+    if (it == BASIC_TYPES.end())
+    {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
 void Parser::openFile(std::string const& file)
 {
     XMLError result = doc_.LoadFile(file.c_str());
@@ -472,8 +482,38 @@ Device Parser::loadDeviceString(std::string const& xml, DeviceFilter const& filt
 
 Device Parser::loadDeviceImpl(DeviceFilter const& filter)
 {
-    auto* device_node = selectDevice(filter);
+    return buildDeviceFromElement(selectDevice(filter));
+}
 
+std::vector<Device> Parser::loadAllDevices(std::string const& file, std::vector<std::string>* errors)
+{
+    openFile(file);
+    std::vector<Device> out;
+    std::size_t index = 0;
+    for (auto* d = devices_->FirstChildElement("Device"); d != nullptr; d = d->NextSiblingElement("Device"), ++index)
+    {
+        try
+        {
+            out.push_back(buildDeviceFromElement(d));
+        }
+        catch (std::exception const& e)
+        {
+            if (errors != nullptr)
+            {
+                std::string msg = "device[" + std::to_string(index) + "] (";
+                msg += textOrEmpty(d->FirstChildElement("Type"));
+                msg += "): ";
+                msg += e.what();
+                errors->push_back(std::move(msg));
+            }
+        }
+    }
+    return out;
+}
+
+Device Parser::buildDeviceFromElement(XMLElement* device_node)
+{
+    profile_no_.clear();  // per-device: don't leak a prior device's value via profile()
     Device device;
     device.vendor_name = vendor_name_;
     // <Vendor>/<Id> is mandatory per ETG.2000 in spirit, but real vendor ESI
@@ -720,6 +760,13 @@ void Parser::parsePdos(XMLElement* device, char const* element_name, std::vector
         Pdo pdo;
 
         std::string where = element_name;
+        // Legacy aggregate catalogs declare PDOs by template reference
+        // (<RxPdo Ref="...">) with no inline <Index>; skip those rather than
+        // rejecting the whole device (the part is defined fully elsewhere).
+        if (findText(pdo_node, "Index") == nullptr)
+        {
+            continue;
+        }
         // <Index>/@DependOnSlot/@DependOnSlotGroup are modular-device attributes
         // and are not read.
         pdo.index = requireNumber<uint16_t>(pdo_node, "Index", where);
@@ -914,37 +961,192 @@ CoE::Object Parser::buildAssignmentObject(std::vector<Pdo> const& pdos, uint16_t
 
 void Parser::synthesizePdoMappingObjects(Device& device)
 {
-    // Per-PDO mapping objects (0x16xx, 0x1Axx) — only add when the slave's
-    // <Dictionary> doesn't already declare them explicitly. Explicit wins.
-    for (auto const& pdo : device.rx_pdos)
+    // ETG.2010 Table 15: PDO mapping (0x16xx/0x1Axx) is defined by <Pdo>/<Entry>,
+    // authoritative over an explicit <Object> of the same index. Override only on a
+    // genuine conflict, so consistent slaves keep the explicit object's metadata; an
+    // unrepresentable PDO is skipped rather than failing the slave.
+    auto mappingsAgree = [](CoE::Object const& lhs, CoE::Object const& rhs)
     {
-        if (not dictionaryContains(device.dictionary, pdo.index))
+        if (lhs.entries.size() != rhs.entries.size())
         {
-            device.dictionary.push_back(buildMappingObject(pdo, true));
+            return false;
         }
-    }
-    for (auto const& pdo : device.tx_pdos)
-    {
-        if (not dictionaryContains(device.dictionary, pdo.index))
+        for (std::size_t i = 1; i < rhs.entries.size(); ++i)
         {
-            device.dictionary.push_back(buildMappingObject(pdo, false));
+            if ((lhs.entries[i].bitlen != 32) or (rhs.entries[i].bitlen != 32)
+                or (lhs.entries[i].data == nullptr) or (rhs.entries[i].data == nullptr))
+            {
+                return false;
+            }
+            uint32_t a;
+            uint32_t b;
+            std::memcpy(&a, lhs.entries[i].data, sizeof(uint32_t));
+            std::memcpy(&b, rhs.entries[i].data, sizeof(uint32_t));
+            if (a != b)
+            {
+                return false;
+            }
         }
-    }
+        return true;
+    };
 
-    // SM assignment objects 0x1C12 (RxPDO) and 0x1C13 (TxPDO). Per ETG.1000.6
-    // these list the indexes of mapping objects assigned to the master->slave
-    // and slave->master SyncManagers respectively. NOTE: we lump ALL rx_pdos
-    // under 0x1C12 and ALL tx_pdos under 0x1C13 regardless of each Pdo's @Sm
-    // attribute. Modular devices using non-default SMs (e.g. Sm=4 for RxPDO)
-    // are misrepresented by this synthesis — the per-SM correct form would be
-    // one assignment object per unique pdo.sm value at 0x1C10 + sm_index.
-    if (not device.rx_pdos.empty() and not dictionaryContains(device.dictionary, 0x1C12))
+    auto synthesize = [&](std::vector<Pdo> const& pdos, bool is_rx)
     {
-        device.dictionary.push_back(buildAssignmentObject(device.rx_pdos, 0x1C12, true));
-    }
-    if (not device.tx_pdos.empty() and not dictionaryContains(device.dictionary, 0x1C13))
+        for (auto const& pdo : pdos)
+        {
+            try
+            {
+                auto obj = buildMappingObject(pdo, is_rx);
+                CoE::Object* existing = nullptr;
+                for (auto& o : device.dictionary)
+                {
+                    if (o.index == pdo.index) { existing = &o; break; }
+                }
+                if (existing == nullptr)
+                {
+                    device.dictionary.push_back(std::move(obj));
+                }
+                else if (not pdo.entries.empty() and not mappingsAgree(*existing, obj))
+                {
+                    *existing = std::move(obj);
+                }
+            }
+            catch (std::exception const& e)
+            {
+                esi_warning("Skipping PDO mapping 0x%04x: %s\n", pdo.index, e.what());
+            }
+        }
+    };
+    synthesize(device.rx_pdos, true);
+    synthesize(device.tx_pdos, false);
+
+    // ETG.2010 Table 14: only PDOs "mapped by default" (carrying @Sm) belong to a
+    // SyncManager's assignment, at 0x1C10 + SM index. @Sm is authoritative; override
+    // an explicit assignment object only when it disagrees (e.g. an over-assigning
+    // shared dictionary).
+    auto assignmentsAgree = [](CoE::Object const& lhs, CoE::Object const& rhs)
     {
-        device.dictionary.push_back(buildAssignmentObject(device.tx_pdos, 0x1C13, false));
+        if (lhs.entries.size() != rhs.entries.size())
+        {
+            return false;
+        }
+        for (std::size_t i = 1; i < rhs.entries.size(); ++i)
+        {
+            if ((lhs.entries[i].data == nullptr) or (rhs.entries[i].data == nullptr))
+            {
+                return false;
+            }
+            uint16_t a;
+            uint16_t b;
+            std::memcpy(&a, lhs.entries[i].data, sizeof(uint16_t));
+            std::memcpy(&b, rhs.entries[i].data, sizeof(uint16_t));
+            if (a != b)
+            {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    auto synthesizeAssignment = [&](std::vector<Pdo> const& pdos, bool is_rx)
+    {
+        std::vector<int32_t> sms;
+        for (auto const& pdo : pdos)
+        {
+            if (pdo.sm.has_value() and std::find(sms.begin(), sms.end(), *pdo.sm) == sms.end())
+            {
+                sms.push_back(*pdo.sm);
+            }
+        }
+        for (int32_t sm : sms)
+        {
+            std::vector<Pdo> group;
+            for (auto const& pdo : pdos)
+            {
+                if (pdo.sm.has_value() and *pdo.sm == sm)
+                {
+                    group.push_back(pdo);
+                }
+            }
+            uint16_t obj_index = static_cast<uint16_t>(0x1C10 + sm);
+            auto obj = buildAssignmentObject(group, obj_index, is_rx);
+            CoE::Object* existing = nullptr;
+            for (auto& o : device.dictionary)
+            {
+                if (o.index == obj_index) { existing = &o; break; }
+            }
+            if (existing == nullptr)
+            {
+                device.dictionary.push_back(std::move(obj));
+            }
+            else if (not assignmentsAgree(*existing, obj))
+            {
+                *existing = std::move(obj);
+            }
+        }
+    };
+    synthesizeAssignment(device.rx_pdos, true);
+    synthesizeAssignment(device.tx_pdos, false);
+
+    // ETG.1000.6 Tables 74/75: a mapping entry references object:subindex. Vendor
+    // ESI sometimes names a subindex absent from the target object's DataType while
+    // the value lives at another (e.g. EL4004 maps 0x7000:17, but later revisions
+    // declare the value at 0x7000:1). The object dictionary is the structural
+    // authority, so retarget a dangling reference to the object's unique entry of
+    // matching bit length.
+    for (auto& obj : device.dictionary)
+    {
+        bool const is_mapping = (obj.index >= 0x1600 and obj.index <= 0x17FF)
+                             or (obj.index >= 0x1A00 and obj.index <= 0x1BFF);
+        if (not is_mapping)
+        {
+            continue;
+        }
+        for (auto& entry : obj.entries)
+        {
+            if (entry.subindex == 0 or entry.data == nullptr or entry.bitlen != 32)
+            {
+                continue;
+            }
+            uint32_t mapping;
+            std::memcpy(&mapping, entry.data, sizeof(uint32_t));
+            uint16_t index = static_cast<uint16_t>(mapping >> 16);
+            uint8_t  sub   = static_cast<uint8_t>(mapping >> 8);
+            uint8_t  bits  = static_cast<uint8_t>(mapping);
+            if (index == 0)
+            {
+                continue;  // padding gap
+            }
+
+            auto [target_obj, target_entry] = CoE::findObject(device.dictionary, index, sub);
+            if (target_entry != nullptr or target_obj == nullptr)
+            {
+                continue;  // already resolves, or the whole object is absent
+            }
+
+            int found_sub = -1;
+            int matches    = 0;
+            for (auto const& te : target_obj->entries)
+            {
+                bool const is_data_sub = (te.subindex >= 1) or (target_obj->code == CoE::ObjectCode::VAR);
+                if (is_data_sub and te.bitlen == bits)
+                {
+                    matches++;
+                    found_sub = te.subindex;
+                }
+            }
+            if (matches != 1)
+            {
+                continue;
+            }
+
+            uint32_t fixed = (static_cast<uint32_t>(index) << 16)
+                           | (static_cast<uint32_t>(found_sub) << 8)
+                           | bits;
+            std::memcpy(entry.data, &fixed, sizeof(uint32_t));
+            esi_warning("PDO 0x%04x: retargeted mapping 0x%04x:%u -> 0x%04x:%d (object declares data there)\n",
+                obj.index, index, sub, index, found_sub);
+        }
     }
 }
 
@@ -1300,6 +1502,10 @@ std::vector<uint8_t> Parser::loadHexBinary(XMLElement* node)
         return {};
     }
     std::string field = raw;
+    // Real ESI files wrap long hex payloads (e.g. <ConfigData>) across lines, so
+    // strip embedded whitespace before pairing nibbles.
+    field.erase(std::remove_if(field.begin(), field.end(),
+        [](unsigned char c){ return std::isspace(c) != 0; }), field.end());
     if (field.size() % 2 != 0)
     {
         throw std::invalid_argument("ESI: hex binary <" + std::string{node->Value()}
@@ -1346,7 +1552,7 @@ void Parser::loadDefaultData(XMLNode* node, CoE::Object& obj, CoE::Entry& entry)
         // order (ASCII bytes for strings, little-endian for numerics).
         std::vector<uint8_t> data = loadHexBinary(node_default_data);
 
-        if (data.size() != (entry.bitlen / 8))
+        if (data.size() != ((entry.bitlen + 7u) / 8u))
         {
             esi_warning("Cannot load default data for 0x%04x.%d, expected size mismatch.\n"
                     "-> Got %ld bits, expected: %d bit\n"
@@ -1366,7 +1572,7 @@ void Parser::loadDefaultData(XMLNode* node, CoE::Object& obj, CoE::Entry& entry)
 
     if (char const* default_value = findText(node_info, "DefaultValue"))
     {
-        uint32_t size = entry.bitlen / 8;
+        uint32_t size = (entry.bitlen + 7u) / 8u;  // sub-byte entries occupy 1 byte
         if (size == 0)
         {
             return;
@@ -1679,43 +1885,44 @@ CoE::Object Parser::createObject(XMLNode* node)
                 // <Elements>255</Elements> (real ETG examples have this), the
                 // post-increment wraps 255 -> 0 and the loop never terminates.
                 uint16_t elements = requireNumber<uint16_t>(node_array_info, "Elements", sub_where);
-                if (elements == 0)
-                {
-                    throw std::invalid_argument("ESI: <Elements> is zero in " + sub_where);
-                }
                 if (elements > 0xFF)
                 {
                     throw std::invalid_argument("ESI: <Elements> > 255 exceeds CoE SubIndex space in " + sub_where);
                 }
-                uint16_t total_bitlen   = requireNumber<uint16_t>(node_subitem, "BitSize", sub_where);
-                uint16_t element_bitoff = requireNumber<uint16_t>(node_subitem, "BitOffs", sub_where);
-                if (total_bitlen % elements != 0)
+                // An empty array (<Elements>0</Elements>) is degenerate but shipped
+                // by real vendors; emit no element entries rather than rejecting.
+                if (elements != 0)
                 {
-                    throw std::invalid_argument("ESI: array <BitSize> " + std::to_string(total_bitlen)
-                        + " not divisible by <Elements> " + std::to_string(elements) + " in " + sub_where);
-                }
-                uint16_t element_bitlen = static_cast<uint16_t>(total_bitlen / elements);
-
-                for (uint16_t i = 1; i <= elements; ++i)
-                {
-                    // Use uint32_t for the intermediate offset arithmetic to
-                    // detect the (degenerate but reachable) case where the
-                    // final offset exceeds the uint16_t range.
-                    uint32_t offset = static_cast<uint32_t>(element_bitoff)
-                                    + static_cast<uint32_t>(element_bitlen) * (i - 1);
-                    if (offset > 0xFFFF)
+                    uint16_t total_bitlen   = requireNumber<uint16_t>(node_subitem, "BitSize", sub_where);
+                    uint16_t element_bitoff = requireNumber<uint16_t>(node_subitem, "BitOffs", sub_where);
+                    if (total_bitlen % elements != 0)
                     {
-                        throw std::invalid_argument("ESI: array element bitoff " + std::to_string(offset)
-                            + " exceeds uint16 range in " + sub_where);
+                        throw std::invalid_argument("ESI: array <BitSize> " + std::to_string(total_bitlen)
+                            + " not divisible by <Elements> " + std::to_string(elements) + " in " + sub_where);
                     }
-                    CoE::Entry e;
-                    e.type        = entry.type;
-                    e.access      = entry.access;
-                    e.description = entry.description;
-                    e.bitlen      = element_bitlen;
-                    e.bitoff      = static_cast<uint16_t>(offset);
-                    e.subindex    = static_cast<uint8_t>(i);
-                    object.entries.push_back(std::move(e));
+                    uint16_t element_bitlen = static_cast<uint16_t>(total_bitlen / elements);
+
+                    for (uint16_t i = 1; i <= elements; ++i)
+                    {
+                        // Use uint32_t for the intermediate offset arithmetic to
+                        // detect the (degenerate but reachable) case where the
+                        // final offset exceeds the uint16_t range.
+                        uint32_t offset = static_cast<uint32_t>(element_bitoff)
+                                        + static_cast<uint32_t>(element_bitlen) * (i - 1);
+                        if (offset > 0xFFFF)
+                        {
+                            throw std::invalid_argument("ESI: array element bitoff " + std::to_string(offset)
+                                + " exceeds uint16 range in " + sub_where);
+                        }
+                        CoE::Entry e;
+                        e.type        = entry.type;
+                        e.access      = entry.access;
+                        e.description = entry.description;
+                        e.bitlen      = element_bitlen;
+                        e.bitoff      = static_cast<uint16_t>(offset);
+                        e.subindex    = static_cast<uint8_t>(i);
+                        object.entries.push_back(std::move(e));
+                    }
                 }
             }
         }

--- a/lib/src/ESI/SIIBuilder.cc
+++ b/lib/src/ESI/SIIBuilder.cc
@@ -1,0 +1,255 @@
+#include "kickcat/ESI/SIIBuilder.h"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+
+#include "kickcat/debug.h"
+#include "kickcat/ESI/Parser.h"
+
+namespace kickcat::ESI
+{
+namespace
+{
+    // buildMappings stays here (not an SII method): it consumes ESI::Pdo, and
+    // eeprom::SII must not depend on the ESI layer.
+    void buildMappings(eeprom::SII& sii, std::vector<Pdo> const& pdos, std::vector<eeprom::PDOMapping>& out)
+    {
+        for (auto const& pdo : pdos)
+        {
+            eeprom::PDOMapping mapping{};
+            mapping.index = pdo.index;
+            if (pdo.sm)
+            {
+                mapping.sync_manager = static_cast<uint8_t>(*pdo.sm);
+            }
+            else
+            {
+                mapping.sync_manager = 0xFF;  // unassigned
+            }
+            mapping.synchronization = 0;
+            mapping.name_index      = sii.registerString(pdo.name);
+            mapping.flags           = 0;
+
+            for (auto const& entry : pdo.entries)
+            {
+                eeprom::PDOEntry pe{};
+                pe.index     = entry.index;
+                pe.subindex  = entry.subindex;
+                pe.name      = sii.registerString(entry.name);
+                pe.data_type = 0;
+                if (entry.index != 0)  // index 0 is a padding gap: no type/name
+                {
+                    auto type = Parser::coeTypeFromLabel(entry.data_type);
+                    if (type)
+                    {
+                        pe.data_type = static_cast<uint8_t>(*type);
+                    }
+                }
+                if (entry.bit_len > 0xFF)
+                {
+                    esi_warning("SII: PDO 0x%04x entry bit_len %u > 255, truncated\n", pdo.index, entry.bit_len);
+                }
+                pe.bitlen = static_cast<uint8_t>(entry.bit_len);
+                pe.flags  = 0;
+                mapping.entries.push_back(pe);
+            }
+            out.push_back(std::move(mapping));
+        }
+    }
+}
+
+eeprom::SII buildSII(Device const& device)
+{
+    eeprom::SII sii;
+    sii.strings.push_back(std::string{});  // index 0 is the reserved empty string
+
+    // ---- Info area (first 16 bytes) ----
+    if (device.eeprom and not device.eeprom->config_data.empty())
+    {
+        // config_data holds words 0..6 (PDI control/config, alias, ...). Word 7
+        // is the CRC, recomputed by SII::serialize(), so never copy past byte 14.
+        std::size_t n = std::min<std::size_t>(device.eeprom->config_data.size(), 14);
+        std::memcpy(&sii.info, device.eeprom->config_data.data(), n);
+    }
+    sii.info.crc = 0;
+
+    sii.info.vendor_id       = device.vendor_id;
+    sii.info.product_code    = device.product_code;
+    sii.info.revision_number = device.revision_no;
+    sii.info.serial_number   = device.serial_no;
+
+    for (auto const& sm : device.sync_managers)
+    {
+        if (sm.type == SyncManager::MailboxOut)
+        {
+            sii.info.standard_recv_mbx_offset = sm.start_address;
+            sii.info.standard_recv_mbx_size   = sm.default_size;
+        }
+        else if (sm.type == SyncManager::MailboxIn)
+        {
+            sii.info.standard_send_mbx_offset = sm.start_address;
+            sii.info.standard_send_mbx_size   = sm.default_size;
+        }
+    }
+
+    if (device.eeprom and device.eeprom->bootstrap.size() >= 8)
+    {
+        auto const& b = device.eeprom->bootstrap;
+        sii.info.bootstrap_recv_mbx_offset = static_cast<uint16_t>(b[0] | (b[1] << 8));
+        sii.info.bootstrap_recv_mbx_size   = static_cast<uint16_t>(b[2] | (b[3] << 8));
+        sii.info.bootstrap_send_mbx_offset = static_cast<uint16_t>(b[4] | (b[5] << 8));
+        sii.info.bootstrap_send_mbx_size   = static_cast<uint16_t>(b[6] | (b[7] << 8));
+    }
+
+    if (device.mailbox)
+    {
+        auto const& mb = *device.mailbox;
+        uint16_t protocol = 0;
+        if (mb.aoe) { protocol |= eeprom::MailboxProtocol::AoE; }
+        if (mb.eoe) { protocol |= eeprom::MailboxProtocol::EoE; }
+        if (mb.coe) { protocol |= eeprom::MailboxProtocol::CoE; }
+        if (mb.foe) { protocol |= eeprom::MailboxProtocol::FoE; }
+        if (mb.soe) { protocol |= eeprom::MailboxProtocol::SoE; }
+        sii.info.mailbox_protocol = protocol;
+    }
+
+    uint16_t size_word = 0x000F;  // default 2 KiB when byte_size is unknown
+    if (device.eeprom and device.eeprom->byte_size and (*device.eeprom->byte_size >= 128))
+    {
+        size_word = static_cast<uint16_t>(*device.eeprom->byte_size / 128 - 1);
+    }
+    sii.info.size    = size_word;
+    sii.info.version = 1;
+
+    // ---- General + strings ----
+    std::string device_name = device.name;
+    if (device_name.empty())
+    {
+        device_name = device.type;
+    }
+    sii.general.device_name_id    = sii.registerString(device_name);
+    sii.general.group_info_id     = sii.registerString(device.group_type);
+    sii.general.group_info_id_dup = sii.general.group_info_id;
+    sii.general.device_order_id   = sii.registerString(device.type);  // order code not surfaced; type stands in
+
+    if (device.mailbox)
+    {
+        auto const& mb = *device.mailbox;
+        if (mb.coe)
+        {
+            sii.general.SDO_set             = 1;
+            sii.general.SDO_info            = mb.coe->sdo_info;
+            sii.general.PDO_assign          = mb.coe->pdo_assign;
+            sii.general.PDO_configuration   = mb.coe->pdo_config;
+            sii.general.PDO_upload          = mb.coe->pdo_upload;
+            sii.general.SDO_complete_access = mb.coe->complete_access;
+        }
+        if (mb.foe) { sii.general.FoE_details  = 1; }
+        if (mb.eoe) { sii.general.EoE_details  = 1; }
+        if (mb.soe) { sii.general.SoE_channels = 1; }
+    }
+
+    // ---- FMMU ----
+    for (auto const& fmmu : device.fmmus)
+    {
+        sii.fmmus.push_back(static_cast<uint8_t>(fmmu.type));
+    }
+
+    // ---- SyncManager ----
+    for (auto const& sm : device.sync_managers)
+    {
+        eeprom::SyncManagerEntry entry{};
+        entry.start_address    = sm.start_address;
+        entry.length           = sm.default_size;
+        entry.control_register = sm.control_byte;
+        entry.status_register  = 0;
+        entry.enable           = sm.enable;
+        entry.type             = static_cast<uint8_t>(sm.type);
+        sii.syncManagers.push_back(entry);
+    }
+
+    // ---- PDO mappings ----
+    buildMappings(sii, device.tx_pdos, sii.TxPDO);
+    buildMappings(sii, device.rx_pdos, sii.RxPDO);
+
+    // ---- DC category (ETG.2010 Table 12): one 24-byte element per OpMode ----
+    if (device.dc)
+    {
+        for (auto const& op : device.dc->op_modes)
+        {
+            std::array<uint8_t, 24> el{};  // reserved + absent fields stay zero
+            auto put32 = [&](std::size_t off, uint32_t v)
+            {
+                el[off]     = static_cast<uint8_t>(v & 0xFF);
+                el[off + 1] = static_cast<uint8_t>((v >> 8) & 0xFF);
+                el[off + 2] = static_cast<uint8_t>((v >> 16) & 0xFF);
+                el[off + 3] = static_cast<uint8_t>((v >> 24) & 0xFF);
+            };
+            auto put16 = [&](std::size_t off, uint16_t v)
+            {
+                el[off]     = static_cast<uint8_t>(v & 0xFF);
+                el[off + 1] = static_cast<uint8_t>((v >> 8) & 0xFF);
+            };
+
+            if (op.cycle_time[0]) { put32(0x00, static_cast<uint32_t>(op.cycle_time[0]->value)); }
+            if (op.shift_time[0]) { put32(0x04, static_cast<uint32_t>(op.shift_time[0]->value)); }
+            if (op.shift_time[1]) { put32(0x08, static_cast<uint32_t>(op.shift_time[1]->value)); }
+            if (op.cycle_time[1] and op.cycle_time[1]->factor)
+            {
+                put16(0x0C, static_cast<uint16_t>(*op.cycle_time[1]->factor));
+            }
+            put16(0x0E, static_cast<uint16_t>(op.assign_activate));
+            if (op.cycle_time[0] and op.cycle_time[0]->factor)
+            {
+                put16(0x10, static_cast<uint16_t>(*op.cycle_time[0]->factor));
+            }
+            el[0x12] = sii.registerString(op.name);
+            el[0x13] = sii.registerString(op.desc);
+
+            sii.dc.insert(sii.dc.end(), el.begin(), el.end());
+        }
+    }
+
+    // ---- vendor categories (preserved verbatim) ----
+    if (device.eeprom)
+    {
+        for (auto const& cat : device.eeprom->categories)
+        {
+            eeprom::RawCategory raw;
+            raw.type = static_cast<uint16_t>(cat.cat_no);
+            if (not cat.data.empty())
+            {
+                raw.data = cat.data;
+            }
+            else if (cat.data_string)
+            {
+                raw.data.assign(cat.data_string->begin(), cat.data_string->end());
+            }
+            else if (cat.data_uint)
+            {
+                uint16_t v = static_cast<uint16_t>(*cat.data_uint);
+                raw.data = { static_cast<uint8_t>(v & 0xFF), static_cast<uint8_t>((v >> 8) & 0xFF) };
+            }
+            else if (cat.data_udint)
+            {
+                uint32_t v = static_cast<uint32_t>(*cat.data_udint);
+                raw.data = { static_cast<uint8_t>(v & 0xFF),         static_cast<uint8_t>((v >> 8) & 0xFF),
+                             static_cast<uint8_t>((v >> 16) & 0xFF), static_cast<uint8_t>((v >> 24) & 0xFF) };
+            }
+            sii.unknownCategories.push_back(std::move(raw));
+        }
+    }
+
+    return sii;
+}
+
+std::vector<uint8_t> buildEepromImage(Device const& device)
+{
+    if (device.eeprom and not device.eeprom->raw_data.empty())
+    {
+        return device.eeprom->raw_data;  // ESI already shipped a full image
+    }
+    return buildSII(device).serialize();
+}
+}

--- a/lib/src/Mailbox.cc
+++ b/lib/src/Mailbox.cc
@@ -204,7 +204,11 @@ namespace kickcat::mailbox::request
     AbstractMessage::AbstractMessage(uint16_t mailbox_size, nanoseconds timeout)
         : timeout_{timeout}
     {
-        data_.resize(mailbox_size);
+        // A slave may advertise a mailbox protocol yet a zero (or sub-header) mailbox
+        // size in its SII (seen in the wild, e.g. Beckhoff AMP8805-A000). The buffer
+        // must still hold a header, otherwise data() is null and the writes below
+        // dereference it.
+        data_.resize(std::max<std::size_t>(mailbox_size, sizeof(mailbox::Header)));
         header_ = reinterpret_cast<mailbox::Header*>(data_.data());
         header_->address  = 0;            // Default: local processing address
         status_ = MessageStatus::RUNNING; // Default mode is running to send the msg on the bus

--- a/lib/src/SIIParser.cc
+++ b/lib/src/SIIParser.cc
@@ -1,6 +1,7 @@
 #include "SIIParser.h"
 #include "debug.h"
 
+#include <algorithm>
 #include <cstring>
 
 namespace kickcat::eeprom
@@ -336,6 +337,31 @@ namespace kickcat::eeprom
         return out;
     }
 
+
+    uint8_t SII::registerString(std::string const& text)
+    {
+        if (strings.empty())
+        {
+            strings.emplace_back();   // reserved index 0 (empty string)
+        }
+        if (text.empty())
+        {
+            return 0;
+        }
+        for (std::size_t i = 1; i < strings.size(); ++i)
+        {
+            if (strings[i] == text)
+            {
+                return static_cast<uint8_t>(i);
+            }
+        }
+        if (strings.size() > 0xFF)
+        {
+            return 0;
+        }
+        strings.push_back(text);
+        return static_cast<uint8_t>(strings.size() - 1);
+    }
 
     uint16_t computeInfoCRC(InfoEntry const& info)
     {

--- a/lib/src/protocol.cc
+++ b/lib/src/protocol.cc
@@ -240,6 +240,9 @@ namespace kickcat
             if (text == "MBoxIn")  { out = MailboxIn;  return; }
             if (text == "Outputs") { out = Output;     return; }
             if (text == "Inputs")  { out = Input;      return; }
+            // ETG.2000 <Sm> values: process data over a Dynamic Process Data Channel.
+            if (text == "DynamicOutputs") { out = Output; return; }
+            if (text == "DynamicInputs")  { out = Input;  return; }
 
             std::string what = "SyncManager::Type: unknown text '";
             what.append(text);
@@ -267,6 +270,9 @@ namespace kickcat
             if (text == "Outputs")   { out = Outputs;   return; }
             if (text == "Inputs")    { out = Inputs;    return; }
             if (text == "MBoxState") { out = MBoxState; return; }
+            // ETG.2000 <Fmmu> values: Rx/TxPDO over a Dynamic Process Data Channel.
+            if (text == "DynamicOutputs") { out = Outputs; return; }
+            if (text == "DynamicInputs")  { out = Inputs;  return; }
 
             std::string what = "fmmu::Type: unknown text '";
             what.append(text);

--- a/simulation/network_simulator.cc
+++ b/simulation/network_simulator.cc
@@ -1,12 +1,16 @@
 #include <algorithm>
 #include <argparse/argparse.hpp>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <numeric>
+#include <optional>
 
+#include "kickcat/CoE/OD.h"
 #include "kickcat/ESI/Parser.h"
+#include "kickcat/ESI/SIIBuilder.h"
 #include "kickcat/CoE/mailbox/response.h"
 #include "kickcat/ESC/EmulatedESC.h"
 #include "kickcat/Frame.h"
@@ -61,7 +65,7 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-        std::vector<std::string> expanded_slave_configs;
+    std::vector<std::string> expanded_slave_configs;
 
     if (slave_number > 0)
     {
@@ -82,7 +86,7 @@ int main(int argc, char* argv[])
         expanded_slave_configs = slave_configs;
     }
 
-	if (slave_configs.empty())
+    if (expanded_slave_configs.empty())
     {
         std::cerr << "No slave configuration files provided" << std::endl;
         std::cerr << program;
@@ -130,19 +134,59 @@ int main(int argc, char* argv[])
             return 1;
         }
 
-        if (not config.contains("eeprom"))
+        std::unique_ptr<EmulatedESC> esc;
+        std::optional<CoE::Dictionary> esi_coe;  // CoE dictionary derived from the ESI device, if any
+
+        if (config.contains("esi"))
         {
-            std::cerr << "Config file " << config_path << " missing 'eeprom' field" << std::endl;
+            // Build the EEPROM image (and CoE dictionary) from a selected ESI device.
+            fs::path esi_full_path = config_dir / config["esi"].get<std::string>();
+            ESI::DeviceFilter filter;
+            if (config.contains("device_type"))  { filter.type         = config["device_type"].get<std::string>(); }
+            if (config.contains("product_code")) { filter.product_code = config["product_code"].get<uint32_t>();    }
+            if (config.contains("revision_no"))  { filter.revision_no  = config["revision_no"].get<uint32_t>();     }
+
+            try
+            {
+                ESI::Device dev = parser.loadDevice(esi_full_path.string(), filter);
+                CoE::materializeStorage(dev.dictionary);
+
+                esc = std::make_unique<EmulatedESC>();
+                esc->loadEeprom(ESI::buildEepromImage(dev));
+
+                if (dev.mailbox and dev.mailbox->coe)
+                {
+                    esi_coe = std::move(dev.dictionary);
+                }
+            }
+            catch (std::exception const& e)
+            {
+                std::cerr << "Failed to build EEPROM from ESI " << esi_full_path << ": " << e.what() << std::endl;
+                return 1;
+            }
+        }
+        else if (config.contains("eeprom"))
+        {
+            fs::path eeprom_full_path = config_dir / config["eeprom"].get<std::string>();
+            esc = std::make_unique<EmulatedESC>(eeprom_full_path.string().c_str());
+        }
+        else
+        {
+            std::cerr << "Config file " << config_path << " missing 'eeprom' or 'esi' field" << std::endl;
             return 1;
         }
 
-        std::string eeprom_path = config["eeprom"];
-        fs::path eeprom_full_path = config_dir / eeprom_path;
-        auto esc = std::make_unique<EmulatedESC>(eeprom_full_path.string().c_str());
         auto pdo = std::make_unique<PDO>(esc.get());
         auto slave = std::make_unique<Slave>(esc.get(), pdo.get());
 
-        if (config.contains("coe_xml"))
+        if (esi_coe)
+        {
+            auto mbx = std::make_unique<mailbox::response::Mailbox>(esc.get(), 1024);
+            mbx->enableCoE(std::move(*esi_coe));
+            slave->setMailbox(mbx.get());
+            mailboxes.push_back(std::move(mbx));
+        }
+        else if (config.contains("coe_xml"))
         {
             std::string coe_xml_path = config["coe_xml"];
             fs::path coe_xml_full_path = config_dir / coe_xml_path;
@@ -230,6 +274,7 @@ int main(int argc, char* argv[])
             slaves[i]->routine();
             if (slaves[i]->state() == State::SAFE_OP)
             {
+                // input-only slaves reach OP without this (handled slave-side in SafeOP)
                 if (output_pdo[i][1] != 0xFF)
                 {
                     slaves[i]->validateOutputData();

--- a/test/integration/bench/CMakeLists.txt
+++ b/test/integration/bench/CMakeLists.txt
@@ -1,3 +1,9 @@
 add_executable(hw_test_bench hw_test_bench.cc)
 target_link_libraries(hw_test_bench PRIVATE kickcat argparse::argparse)
 install(TARGETS hw_test_bench RUNTIME DESTINATION bin)
+
+add_executable(esi_validate esi_validate.cc)
+target_link_libraries(esi_validate PRIVATE kickcat)
+
+add_executable(esi_boot esi_boot.cc)
+target_link_libraries(esi_boot PRIVATE kickcat argparse::argparse)

--- a/test/integration/bench/esi_boot.cc
+++ b/test/integration/bench/esi_boot.cc
@@ -1,0 +1,368 @@
+// Rigorous catalog boot test: for each ESI device, build the EEPROM + CoE
+// dictionary, instantiate an emulated slave (EmulatedESC + Slave + optional CoE
+// mailbox), connect a real master Bus through an in-process loopback, and drive
+// the EtherCAT state machine INIT -> PRE_OP -> SAFE_OP -> OPERATIONAL. Unlike
+// esi_validate (a static mapping-resolution check), this actually transitions
+// the slave, so reaching OPERATIONAL is the real proof of bootability.
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <functional>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <argparse/argparse.hpp>
+
+#include "kickcat/OS/Mutex.h"
+
+#include "kickcat/CoE/OD.h"
+#include "kickcat/ESI/Parser.h"
+#include "kickcat/ESI/SIIBuilder.h"
+#include "kickcat/CoE/mailbox/response.h"
+#include "kickcat/ESC/EmulatedESC.h"
+#include "kickcat/Frame.h"
+#include "kickcat/PDO.h"
+#include "kickcat/slave/Slave.h"
+#include "kickcat/Bus.h"
+#include "kickcat/Link.h"
+#include "kickcat/SocketNull.h"
+
+using namespace kickcat;
+namespace fs = std::filesystem;
+
+// Master frames are processed in place by the emulated slave, then the slave's
+// ESM is ticked once. One writeThenRead == one simulator iteration.
+class LoopbackSocket final : public AbstractSocket
+{
+public:
+    LoopbackSocket(std::vector<EmulatedESC*> escs, std::function<void()> tick)
+        : escs_(std::move(escs)), tick_(std::move(tick)) {}
+
+    void open(std::string const&) override {}
+    void setTimeout(nanoseconds) override {}
+    void close() noexcept override {}
+
+    int32_t write(void const* data, int32_t size) override
+    {
+        Frame frame;
+        std::memcpy(frame.data(), data, static_cast<size_t>(size));
+        while (true)
+        {
+            auto [header, payload, wkc] = frame.peekDatagram();
+            if (header == nullptr)
+            {
+                break;
+            }
+            for (auto* esc : escs_)
+            {
+                esc->processDatagram(header, payload, wkc);
+            }
+        }
+        tick_();
+        std::memcpy(buffer_, frame.data(), static_cast<size_t>(size));
+        size_ = size;
+        pending_ = true;
+        return size;
+    }
+
+    int32_t read(void* data, int32_t) override
+    {
+        if (not pending_)
+        {
+            return 0;
+        }
+        std::memcpy(data, buffer_, static_cast<size_t>(size_));
+        pending_ = false;
+        return size_;
+    }
+
+private:
+    std::vector<EmulatedESC*> escs_;
+    std::function<void()> tick_;
+    uint8_t buffer_[ETH_MAX_SIZE];
+    int32_t size_    = 0;
+    bool    pending_ = false;
+};
+
+enum class Reached { INIT_FAIL, INIT, PRE_OP, SAFE_OP, OP };
+
+static Reached bootDevice(ESI::Device& dev, nanoseconds wait_timeout)
+{
+    // Catalog-wide: a slave's process data can be far larger than the 32-byte
+    // toy buffers used for hand-written sim configs. Size for a full frame so
+    // updateInput/updateOutput (which copy the SM length) can't overflow.
+    constexpr uint32_t PDO_MAX_SIZE = 4096;
+
+    CoE::materializeStorage(dev.dictionary);
+    auto esc = std::make_unique<EmulatedESC>();
+    esc->loadEeprom(ESI::buildEepromImage(dev));
+
+    auto pdo = std::make_unique<PDO>(esc.get());
+    auto sl  = std::make_unique<slave::Slave>(esc.get(), pdo.get());
+
+    std::unique_ptr<mailbox::response::Mailbox> mbx;
+    if (dev.mailbox and dev.mailbox->coe)
+    {
+        mbx = std::make_unique<mailbox::response::Mailbox>(esc.get(), 1024);
+        mbx->enableCoE(std::move(dev.dictionary));
+        sl->setMailbox(mbx.get());
+    }
+
+    std::vector<uint8_t> input_pdo(PDO_MAX_SIZE);
+    std::iota(input_pdo.begin(), input_pdo.end(), 0);
+    std::vector<uint8_t> output_pdo(PDO_MAX_SIZE, 0xFF);
+    pdo->setInput(input_pdo.data(), PDO_MAX_SIZE);
+    pdo->setOutput(output_pdo.data(), PDO_MAX_SIZE);
+
+    uint16_t dl_status = (1 << 4) | (1 << 9);  // single slave: only port0 connected
+    esc->write(reg::ESC_DL_STATUS, &dl_status, sizeof(dl_status));
+    sl->start();
+
+    // Once the master is driving process data (OP phase), a slave with outputs
+    // needs its output data declared valid to leave SAFE_OP. Keyed on the phase,
+    // not a buffer byte (which never changes for <=1-byte outputs like EL2008).
+    bool op_phase = false;
+    auto tick = [&]()
+    {
+        sl->routine();
+        if (op_phase and sl->state() == State::SAFE_OP)
+        {
+            sl->validateOutputData();
+        }
+    };
+
+    std::vector<EmulatedESC*> escs{esc.get()};
+    auto sock_nominal = std::make_shared<LoopbackSocket>(escs, tick);
+    auto sock_redundancy = std::make_shared<SocketNull>();
+    auto link = std::make_shared<Link>(sock_nominal, sock_redundancy, [](){});
+    link->setTimeout(2ms);
+
+    Bus bus(link);
+
+    std::vector<uint8_t> io_buffer(16384);
+    try
+    {
+        bus.init(100ms);
+        if (bus.slaves().size() != 1)
+        {
+            return Reached::INIT_FAIL;
+        }
+        bus.createMapping(io_buffer.data(), io_buffer.size());
+    }
+    catch (std::exception const&)
+    {
+        return Reached::INIT_FAIL;
+    }
+
+    Reached reached = Reached::PRE_OP;
+
+    auto noop = [](DatagramState const&) {};
+    auto cyclic = [&]()
+    {
+        bus.processDataRead(noop);
+        bus.processDataWrite(noop);
+    };
+
+    try
+    {
+        bus.requestState(State::SAFE_OP);
+        bus.waitForState(State::SAFE_OP, wait_timeout);
+    }
+    catch (std::exception const&)
+    {
+    }
+    if (sl->state() != State::SAFE_OP and sl->state() != State::OPERATIONAL)
+    {
+        return reached;
+    }
+    reached = Reached::SAFE_OP;
+
+    for (auto& s : bus.slaves())
+    {
+        for (int32_t i = 0; i < s.output.bsize; ++i)
+        {
+            s.output.data[i] = 0xBB;
+        }
+    }
+    try
+    {
+        cyclic();
+    }
+    catch (std::exception const&)
+    {
+    }
+
+    op_phase = true;
+    try
+    {
+        bus.requestState(State::OPERATIONAL);
+        bus.waitForState(State::OPERATIONAL, wait_timeout, cyclic);
+    }
+    catch (std::exception const&)
+    {
+    }
+    if (sl->state() == State::OPERATIONAL)
+    {
+        reached = Reached::OP;
+    }
+    return reached;
+}
+
+struct Counts
+{
+    int op         = 0;
+    int safe_op    = 0;
+    int pre_op     = 0;
+    int init_fail  = 0;
+    int build_fail = 0;
+    int total      = 0;
+};
+
+int main(int argc, char** argv)
+{
+    argparse::ArgumentParser program("esi_boot");
+
+    std::string path_arg;
+    program.add_argument("path")
+        .help("ESI XML file or directory to sweep")
+        .store_into(path_arg);
+
+    int timeout_ms = 200;
+    program.add_argument("-t", "--timeout")
+        .help("per-state wait timeout (ms)")
+        .default_value(200)
+        .scan<'i', int>()
+        .store_into(timeout_ms);
+
+    int default_threads = static_cast<int>(std::thread::hardware_concurrency());
+    int num_threads = default_threads;
+    program.add_argument("-j", "--threads")
+        .help("worker threads")
+        .default_value(default_threads)
+        .scan<'i', int>()
+        .store_into(num_threads);
+
+    int max_devices = -1;
+    program.add_argument("-n", "--max-devices")
+        .help("stop after roughly N devices (-1 = all)")
+        .default_value(-1)
+        .scan<'i', int>()
+        .store_into(max_devices);
+
+    try
+    {
+        program.parse_args(argc, argv);
+    }
+    catch (std::exception const& e)
+    {
+        std::cerr << e.what() << std::endl << program;
+        return 2;
+    }
+
+    fs::path root = path_arg;
+    if (num_threads < 1) { num_threads = 1; }
+
+    setvbuf(stdout, nullptr, _IONBF, 0);
+
+    std::vector<fs::path> xmls;
+    if (fs::is_directory(root))
+    {
+        for (auto& e : fs::recursive_directory_iterator(root))
+        {
+            if (e.path().extension() == ".xml") { xmls.push_back(e.path()); }
+        }
+        std::sort(xmls.begin(), xmls.end());
+    }
+    else
+    {
+        xmls.push_back(root);
+    }
+
+    // Each device is fully independent (own ESC/Bus/loopback), so files are
+    // dispatched to a worker pool. The mutex guards the work index and the merge
+    // of per-file results; max_devices is a soft cap (overshoots by in-flight files).
+    Mutex mutex;
+    std::size_t next_file = 0;
+    Counts global;
+
+    auto worker = [&]()
+    {
+        while (true)
+        {
+            std::size_t idx;
+            {
+                LockGuard lock(mutex);
+                if (next_file >= xmls.size() or (max_devices >= 0 and global.total >= max_devices))
+                {
+                    return;
+                }
+                idx = next_file++;
+            }
+
+            ESI::Parser parser;
+            std::vector<std::string> errs;
+            std::vector<ESI::Device> devs;
+            try
+            {
+                devs = parser.loadAllDevices(xmls[idx].string(), &errs);
+            }
+            catch (std::exception&)
+            {
+                continue;
+            }
+
+            Counts local;
+            std::string failures;
+            std::string fname = xmls[idx].filename().string();
+            for (auto& dev : devs)
+            {
+                local.total++;
+                Reached r;
+                try
+                {
+                    r = bootDevice(dev, timeout_ms * 1ms);
+                }
+                catch (std::exception&)
+                {
+                    local.build_fail++;
+                    continue;
+                }
+
+                switch (r)
+                {
+                    case Reached::OP:        { local.op++;        break; }
+                    case Reached::SAFE_OP:   { local.safe_op++;   failures += "SAFE_OP-ONLY " + fname + " | " + dev.type + "\n"; break; }
+                    case Reached::PRE_OP:    { local.pre_op++;    failures += "PRE_OP-ONLY  " + fname + " | " + dev.type + "\n"; break; }
+                    case Reached::INIT_FAIL: { local.init_fail++; failures += "INIT-FAIL    " + fname + " | " + dev.type + "\n"; break; }
+                }
+            }
+
+            LockGuard lock(mutex);
+            global.op         += local.op;
+            global.safe_op    += local.safe_op;
+            global.pre_op     += local.pre_op;
+            global.init_fail  += local.init_fail;
+            global.build_fail += local.build_fail;
+            global.total      += local.total;
+            fputs(failures.c_str(), stdout);
+        }
+    };
+
+    std::vector<std::thread> pool;
+    for (int i = 0; i < num_threads; ++i)
+    {
+        pool.emplace_back(worker);
+    }
+    for (auto& t : pool)
+    {
+        t.join();
+    }
+
+    printf("\n=== BOOT SUMMARY (%d threads) ===\ndevices=%d OP=%d SAFE_OP=%d PRE_OP=%d INIT_FAIL=%d build_fail=%d\n",
+           num_threads, global.total, global.op, global.safe_op, global.pre_op, global.init_fail, global.build_fail);
+    return 0;
+}

--- a/test/integration/bench/esi_validate.cc
+++ b/test/integration/bench/esi_validate.cc
@@ -1,0 +1,127 @@
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "kickcat/ESI/Parser.h"
+#include "kickcat/ESI/SIIBuilder.h"
+#include "kickcat/SIIParser.h"
+#include "kickcat/CoE/OD.h"
+#include "kickcat/CoE/protocol.h"
+
+using namespace kickcat;
+namespace fs = std::filesystem;
+
+// Replicates the slave-side SAFE_OP mapping resolution (PDO::parseAssignment +
+// parsePdoMap, ETG.1000.6 Tables 74/75): every PDO in a SyncManager assignment
+// must reference a mapping object whose entries all resolve to a dictionary entry.
+static bool resolveAssignment(CoE::Dictionary& dict, uint16_t assign_idx, std::string& fail)
+{
+    auto [obj0, e0] = CoE::findObject(dict, assign_idx, 0);
+    if (e0 == nullptr or e0->data == nullptr) { return true; }  // no such assignment
+
+    uint8_t pdo_count = *static_cast<uint8_t*>(e0->data);
+    char buf[64];
+    for (uint8_t i = 1; i <= pdo_count; ++i)
+    {
+        auto [ao, ae] = CoE::findObject(dict, assign_idx, i);
+        if (ae == nullptr or ae->data == nullptr) { fail = "assignment sub-index missing"; return false; }
+        uint16_t pdo_idx = *static_cast<uint16_t*>(ae->data);
+
+        auto [mo, me] = CoE::findObject(dict, pdo_idx, 0);
+        if (me == nullptr or me->data == nullptr)
+        {
+            snprintf(buf, sizeof(buf), "mapping object 0x%04x missing", pdo_idx);
+            fail = buf;
+            return false;
+        }
+        uint8_t entry_count = *static_cast<uint8_t*>(me->data);
+        for (uint8_t j = 1; j <= entry_count; ++j)
+        {
+            auto [eo, ee] = CoE::findObject(dict, pdo_idx, j);
+            if (ee == nullptr or ee->data == nullptr) { fail = "mapping entry missing"; return false; }
+            uint32_t m = *static_cast<uint32_t*>(ee->data);
+            uint16_t index = (m & CoE::PDO::MAPPING_INDEX_MASK) >> CoE::PDO::MAPPING_INDEX_SHIFT;
+            uint8_t  sub   = (m & CoE::PDO::MAPPING_SUB_MASK) >> CoE::PDO::MAPPING_SUB_SHIFT;
+            if (index == 0) { continue; }  // padding gap
+            auto [to, te] = CoE::findObject(dict, index, sub);
+            if (te == nullptr)
+            {
+                snprintf(buf, sizeof(buf), "0x%04x -> 0x%04x:%u unresolved", pdo_idx, index, sub);
+                fail = buf;
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    fs::path dir = argv[1];
+    int files = 0, total = 0, built = 0, build_fail = 0, sii_ok = 0, sii_fail = 0;
+    int map_ok = 0, map_fail = 0;
+
+    setvbuf(stdout, nullptr, _IONBF, 0);  // unbuffered: survive a crash mid-run
+    auto heartbeat = [](std::string const& s)
+    {
+        FILE* hb = std::fopen("/tmp/esi_cur.txt", "w");
+        if (hb) { std::fputs(s.c_str(), hb); std::fclose(hb); }
+    };
+
+    std::vector<fs::path> xmls;
+    for (auto& e : fs::recursive_directory_iterator(dir))
+    {
+        if (e.path().extension() == ".xml") { xmls.push_back(e.path()); }
+    }
+    std::sort(xmls.begin(), xmls.end());
+
+    for (auto& path : xmls)
+    {
+        files++;
+        heartbeat("PARSING " + path.filename().string());
+        ESI::Parser p;
+        std::vector<std::string> errs;
+        std::vector<ESI::Device> devs;
+        try { devs = p.loadAllDevices(path.string(), &errs); }
+        catch (std::exception& ex) { printf("FILE-FAIL %s : %s\n", path.filename().string().c_str(), ex.what()); continue; }
+
+        total += (int)devs.size() + (int)errs.size();
+        built += (int)devs.size();
+        build_fail += (int)errs.size();
+        for (auto& er : errs) { printf("BUILD-FAIL %s | %s\n", path.filename().string().c_str(), er.c_str()); }
+
+        for (auto& d : devs)
+        {
+            heartbeat(path.filename().string() + " | " + d.type);
+            try
+            {
+                auto img = ESI::buildEepromImage(d);
+                eeprom::SII s;
+                s.parse(img.data(), img.size());
+                bool ok = (img.size() >= 16)
+                       && (s.info.product_code == d.product_code)
+                       && (eeprom::computeInfoCRC(s.info) == s.info.crc);
+                if (ok) { sii_ok++; }
+                else { sii_fail++; printf("SII-BAD  %s | %s pc=0x%08x\n", path.filename().string().c_str(), d.type.c_str(), d.product_code); }
+
+                CoE::materializeStorage(d.dictionary);
+                std::string mfail;
+                bool mok = resolveAssignment(d.dictionary, 0x1C12, mfail)
+                        && resolveAssignment(d.dictionary, 0x1C13, mfail);
+                if (mok) { map_ok++; }
+                else { map_fail++; printf("MAP-FAIL %s | %s rev=0x%x : %s\n", path.filename().string().c_str(), d.type.c_str(), d.revision_no, mfail.c_str()); }
+            }
+            catch (std::exception& ex)
+            {
+                sii_fail++;
+                printf("SII-THROW %s | %s : %s\n", path.filename().string().c_str(), d.type.c_str(), ex.what());
+            }
+        }
+    }
+
+    printf("\n=== SUMMARY ===\nfiles=%d devices=%d built=%d build_fail=%d sii_ok=%d sii_fail=%d map_ok=%d map_fail=%d\n",
+           files, total, built, build_fail, sii_ok, sii_fail, map_ok, map_fail);
+    return (build_fail == 0 && sii_fail == 0 && map_fail == 0) ? 0 : 1;
+}

--- a/tools/eeprom.cc
+++ b/tools/eeprom.cc
@@ -237,7 +237,7 @@ int main(int argc, char* argv[])
             {
                 printf("!!! WARNING !!!\n");
                 printf("Current EEPROM addressing scheme is one byte: max EEPROM size is 16Kbit (2KiB)\n");
-                printf("but the given EEPROM file size is %ldB which exceed the maximum possible target size\n", size);
+                printf("but the given EEPROM file size is %zuB which exceed the maximum possible target size\n", size);
                 printf("If you wish to continue, the written size will be truncated to 2KiB\n");
 
                 if (not askContinue())
@@ -251,7 +251,7 @@ int main(int argc, char* argv[])
         for (uint32_t i = 0; i < buffer.size(); i++)
         {
             bus.writeEeprom(slave, i, static_cast<void*>(&buffer[i]), 2);
-            printf("\r Updating: %d/%lu", i + 1, buffer.size());
+            printf("\r Updating: %d/%zu", i + 1, buffer.size());
             fflush(stdout);
         }
         printf("\n");

--- a/tools/od_generator.cc
+++ b/tools/od_generator.cc
@@ -265,6 +265,10 @@ int main(int argc, char *argv[])
 
     auto dictionary = loadOD(esi_file);
 
+    // Backing storage is structural, separate from ESI default values: give every
+    // SDO-accessible entry zero-initialized storage when the ESI declared no default.
+    CoE::materializeStorage(dictionary);
+
     auto problems = CoE::validateDictionary(dictionary);
     if (not problems.empty())
     {
@@ -275,8 +279,7 @@ int main(int argc, char *argv[])
             std::cerr << "  - " << problem << "\n";
         }
         std::cerr << problems.size() << " problem(s) found; refusing to generate "
-                  << OD_POPULATOR_FILE << ".\n"
-                  << "Every readable/writable object needs a value (ESI <DefaultData>/<DefaultValue>).\n";
+                  << OD_POPULATOR_FILE << ".\n";
         return 2;
     }
 

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(kickcat_unit src/adler32_sum-t.cc
                             src/CoE/protocol-t.cc
                             src/CoE/OD-t.cc
                             src/ESI/Parser-t.cc
+                            src/ESI/SIIBuilder-t.cc
                             src/CoE/DS402StateMachine-t.cc
                             src/CoE/DS402Drive-t.cc
                             src/mailbox/request-t.cc

--- a/unit/mocks/ESMStateTest.h
+++ b/unit/mocks/ESMStateTest.h
@@ -61,9 +61,9 @@ public:
         pdo_.configure();
     }
 
-    void expectAlStatus(Context context, State state, StatusCode statusCode = StatusCode::NO_ERROR)
+    void expectAlStatus(Context context, State state, StatusCode statusCode = StatusCode::ECAT_NO_ERROR)
     {
-        if (statusCode == StatusCode::NO_ERROR)
+        if (statusCode == StatusCode::ECAT_NO_ERROR)
         {
             EXPECT_EQ(context.al_status, state);
         }

--- a/unit/src/CoE/OD-t.cc
+++ b/unit/src/CoE/OD-t.cc
@@ -258,3 +258,59 @@ TEST(OD, validate_dictionary_ignores_inaccessible_entry_with_null_data)
     auto problems = validateDictionary(dict);
     ASSERT_TRUE(problems.empty());
 }
+
+TEST(OD, materialize_storage_allocates_accessible_entries_zeroed)
+{
+    Dictionary dict;
+    {
+        CoE::Object object{0x6000, CoE::ObjectCode::VAR, "Input", {}};
+        CoE::addEntry(object, 0, 1,  0, Access::READ,  DataType::BOOLEAN,    "bit",  nullptr);
+        CoE::addEntry(object, 1, 16, 8, Access::WRITE, DataType::UNSIGNED16, "word", nullptr);
+        dict.push_back(std::move(object));
+    }
+
+    ASSERT_FALSE(validateDictionary(dict).empty());  // null data before materialization
+
+    materializeStorage(dict);
+
+    auto& entries = dict.front().entries;
+    ASSERT_NE(entries[0].data, nullptr);  // BOOL (bitlen 1) gets 1 byte, not 0
+    ASSERT_NE(entries[1].data, nullptr);
+    ASSERT_EQ(*static_cast<uint8_t const*>(entries[0].data),  0);  // zero-initialized
+    ASSERT_EQ(*static_cast<uint16_t const*>(entries[1].data), 0);
+    ASSERT_TRUE(validateDictionary(dict).empty());
+}
+
+TEST(OD, materialize_storage_preserves_existing_data_and_skips_inaccessible)
+{
+    Dictionary dict;
+    {
+        CoE::Object object{0x1018, CoE::ObjectCode::VAR, "Identity", {}};
+        CoE::addEntry<uint32_t>(object, 0, 32, 0, Access::READ, DataType::UNSIGNED32, "has value", 0xCAFEu);
+        CoE::addEntry(object, 1, 16, 32, 0, DataType::UNSIGNED16, "padding", nullptr);  // access == 0
+        dict.push_back(std::move(object));
+    }
+
+    void const* existing = dict.front().entries[0].data;
+    materializeStorage(dict);
+
+    ASSERT_EQ(dict.front().entries[0].data, existing);                 // untouched
+    ASSERT_EQ(*static_cast<uint32_t const*>(dict.front().entries[0].data), 0xCAFEu);
+    ASSERT_EQ(dict.front().entries[1].data, nullptr);                  // inaccessible: left null
+}
+
+TEST(OD, materialize_storage_allocates_complex_subindex0)
+{
+    Dictionary dict;
+    {
+        // ARRAY whose count (subindex 0) has access 0: complete access still dereferences it.
+        CoE::Object object{0x1C12, CoE::ObjectCode::ARRAY, "RxPDO assign", {}};
+        CoE::addEntry(object, 0, 8, 0, 0, DataType::UNSIGNED8, "count", nullptr);
+        dict.push_back(std::move(object));
+    }
+
+    materializeStorage(dict);
+
+    ASSERT_NE(dict.front().entries.front().data, nullptr);
+    ASSERT_TRUE(validateDictionary(dict).empty());
+}

--- a/unit/src/ESI/Parser-t.cc
+++ b/unit/src/ESI/Parser-t.cc
@@ -1072,10 +1072,13 @@ TEST(ESIParser, pdos_synthesize_legacy_mapping_objects)
     ASSERT_EQ(assigned_tx, 0x1A00u);
 }
 
-TEST(ESIParser, pdos_do_not_overwrite_explicit_dictionary_objects)
+TEST(ESIParser, pdo_entry_is_authoritative_over_explicit_mapping_object)
 {
-    // If the slave's <Dictionary> already declares 0x1600, our auto-generated
-    // mapping object must not displace it.
+    // ETG.2010 Tables 14/15: the PDO mapping is defined by <Pdo>/<Entry>, so for a
+    // mapping-object index (0x16xx/0x1Axx) the <Entry>-derived mapping is
+    // authoritative over a conflicting explicit <Object> (whose DefaultData may be
+    // a vendor typo, e.g. Beckhoff EL4004). The explicit object here is a stand-in
+    // that must be replaced by the <Entry> version.
     char const* xml = R"(<?xml version="1.0"?>
         <EtherCATInfo>
             <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
@@ -1107,7 +1110,123 @@ TEST(ESIParser, pdos_do_not_overwrite_explicit_dictionary_objects)
     auto dictionary = parser.loadString(xml);
     auto [obj, _] = findObject(dictionary, 0x1600, 0);
     ASSERT_NE(obj, nullptr);
-    ASSERT_EQ(obj->name, "Explicit RxPDO map");  // explicit declaration wins
+    ASSERT_EQ(obj->name, "Auto-generated map");          // <Entry>-derived object replaced the explicit one
+    ASSERT_EQ(obj->code, CoE::ObjectCode::RECORD);
+
+    auto [_o, entry1] = findObject(dictionary, 0x1600, 1);
+    ASSERT_NE(entry1, nullptr);
+    uint32_t packed;
+    std::memcpy(&packed, entry1->data, 4);
+    ASSERT_EQ(packed, (0x7000u << 16) | (1u << 8) | 16u);  // mapping from <Entry>
+}
+
+TEST(ESIParser, sm_assignment_is_authoritative_over_explicit_over_assignment)
+{
+    // ETG.2010 Table 14: only PDOs "mapped by default" (those carrying @Sm) belong
+    // to a SyncManager's default assignment, at 0x1C10 + SM index. When an explicit
+    // 0x1C12 over-assigns a phantom PDO with no <RxPdo> (e.g. the shared dictionary
+    // in Beckhoff EL4004), the @Sm-derived assignment replaces it.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes>
+                            <DataType><Name>USINT</Name><BitSize>8</BitSize></DataType>
+                            <DataType><Name>UINT</Name><BitSize>16</BitSize></DataType>
+                            <DataType>
+                                <Name>UINT_ARR2</Name><BaseType>UINT</BaseType><BitSize>32</BitSize>
+                                <ArrayInfo><LBound>1</LBound><Elements>2</Elements></ArrayInfo>
+                            </DataType>
+                            <DataType>
+                                <Name>DT1C12</Name><BitSize>48</BitSize>
+                                <SubItem><SubIdx>0</SubIdx><Name>Count</Name><Type>USINT</Type><BitSize>8</BitSize><BitOffs>0</BitOffs></SubItem>
+                                <SubItem><Name>Elements</Name><Type>UINT_ARR2</Type><BitSize>32</BitSize><BitOffs>16</BitOffs></SubItem>
+                            </DataType>
+                        </DataTypes>
+                        <Objects>
+                            <Object>
+                                <Index>#x1C12</Index>
+                                <Name>Explicit over-assignment</Name>
+                                <Type>DT1C12</Type>
+                                <BitSize>48</BitSize>
+                                <Info>
+                                    <SubItem><Name>Count</Name><Info><DefaultData>02</DefaultData></Info></SubItem>
+                                    <SubItem><Name>E1</Name><Info><DefaultData>0016</DefaultData></Info></SubItem>
+                                    <SubItem><Name>E2</Name><Info><DefaultData>0116</DefaultData></Info></SubItem>
+                                </Info>
+                            </Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+                <RxPdo Sm="2">
+                    <Index>#x1600</Index>
+                    <Name>Outputs</Name>
+                    <Entry><Index>#x7000</Index><SubIndex>1</SubIndex><BitLen>16</BitLen></Entry>
+                </RxPdo>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    auto dictionary = parser.loadString(xml);
+
+    auto [obj, e0] = findObject(dictionary, 0x1C12, 0);
+    ASSERT_NE(obj, nullptr);
+    ASSERT_EQ(obj->name, "RxPDO assign");        // @Sm-derived object replaced the explicit one
+    ASSERT_EQ(obj->entries.size(), 2u);          // count + 1 assigned PDO (phantom 0x1601 dropped)
+    uint8_t count;
+    std::memcpy(&count, e0->data, 1);
+    ASSERT_EQ(count, 1u);
+    uint16_t assigned;
+    std::memcpy(&assigned, obj->entries[1].data, 2);
+    ASSERT_EQ(assigned, 0x1600u);
+}
+
+TEST(ESIParser, mapping_target_subindex_reconciled_against_object)
+{
+    // ETG.1000.6 Tables 74/75: a mapping entry references object:subindex. Here the
+    // <Entry> names 0x7000:17 (a vendor typo, as in EL4004 rev>=0x13) but object
+    // 0x7000 declares its 16-bit value at sub 1. The object dictionary is the
+    // authority, so the mapping must be retargeted to the resolvable sub 1.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes>
+                            <DataType><Name>USINT</Name><BitSize>8</BitSize></DataType>
+                            <DataType><Name>UINT</Name><BitSize>16</BitSize></DataType>
+                            <DataType>
+                                <Name>DT7000</Name><BitSize>24</BitSize>
+                                <SubItem><SubIdx>0</SubIdx><Name>Max</Name><Type>USINT</Type><BitSize>8</BitSize><BitOffs>0</BitOffs></SubItem>
+                                <SubItem><SubIdx>1</SubIdx><Name>Value</Name><Type>UINT</Type><BitSize>16</BitSize><BitOffs>8</BitOffs></SubItem>
+                            </DataType>
+                        </DataTypes>
+                        <Objects>
+                            <Object><Index>#x7000</Index><Name>AO</Name><Type>DT7000</Type><BitSize>24</BitSize></Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+                <RxPdo Sm="2">
+                    <Index>#x1600</Index>
+                    <Name>Outputs</Name>
+                    <Entry><Index>#x7000</Index><SubIndex>17</SubIndex><BitLen>16</BitLen></Entry>
+                </RxPdo>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    auto dictionary = parser.loadString(xml);
+
+    auto [obj, entry1] = findObject(dictionary, 0x1600, 1);
+    ASSERT_NE(entry1, nullptr);
+    uint32_t packed;
+    std::memcpy(&packed, entry1->data, 4);
+    ASSERT_EQ(packed, (0x7000u << 16) | (1u << 8) | 16u);  // retargeted 0x7000:17 -> 0x7000:1
 }
 
 TEST(ESIParser, loadDevice_parses_eeprom)

--- a/unit/src/ESI/SIIBuilder-t.cc
+++ b/unit/src/ESI/SIIBuilder-t.cc
@@ -1,0 +1,244 @@
+#include <gtest/gtest.h>
+
+#include "kickcat/ESI/SIIBuilder.h"
+#include "kickcat/ESI/Parser.h"
+#include "kickcat/SIIParser.h"
+
+using namespace kickcat;
+
+namespace
+{
+    // Minimal Input terminal (no mailbox): one Input SM, one Inputs FMMU, one
+    // TxPDO with a BOOL entry. Mirrors an EL1xxx-style digital input.
+    ESI::Device makeInputDevice()
+    {
+        ESI::Device d;
+        d.type          = "EL0001";
+        d.name          = "Test input";
+        d.vendor_id     = 0x2;
+        d.product_code  = 0x1234;
+        d.revision_no   = 0x10;
+        d.serial_no     = 0;
+
+        ESI::SmInfo sm;
+        sm.type          = SyncManager::Input;
+        sm.start_address = 0x1000;
+        sm.default_size  = 1;
+        sm.control_byte  = 0x00;
+        sm.enable        = 1;
+        d.sync_managers.push_back(sm);
+
+        ESI::Fmmu fmmu;
+        fmmu.type = fmmu::Inputs;
+        d.fmmus.push_back(fmmu);
+
+        ESI::Pdo pdo;
+        pdo.index = 0x1A00;
+        pdo.name  = "Channel 1";
+        pdo.sm    = 0;
+        ESI::PdoEntry e;
+        e.index = 0x6000; e.subindex = 1; e.bit_len = 1; e.name = "Input"; e.data_type = "BOOL";
+        pdo.entries.push_back(e);
+        d.tx_pdos.push_back(pdo);
+
+        ESI::Eeprom eep;
+        eep.byte_size   = 2048;
+        eep.config_data = {0x04, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};  // 8 bytes (EL1008-like)
+        d.eeprom        = eep;
+        return d;
+    }
+}
+
+TEST(SIIBuilder, maps_parsed_device_to_sii_struct)
+{
+    ESI::Parser parser;
+    ESI::Device dev = parser.loadDevice("kickcat_esi_test_sm_fmmu.xml");
+    eeprom::SII sii = ESI::buildSII(dev);
+
+    // Identity
+    ASSERT_EQ(sii.info.vendor_id,       0x0CAFEu);
+    ASSERT_EQ(sii.info.product_code,    0x00005555u);
+    ASSERT_EQ(sii.info.revision_number, 0x1u);
+    ASSERT_EQ(sii.info.size,            15u);  // 2048 / 128 - 1
+    ASSERT_EQ(sii.info.version,         1u);
+
+    // Mailbox words derived from the mailbox SyncManagers
+    ASSERT_EQ(sii.info.standard_recv_mbx_offset, 0x1000u);
+    ASSERT_EQ(sii.info.standard_recv_mbx_size,   128u);
+    ASSERT_EQ(sii.info.standard_send_mbx_offset, 0x1400u);
+    ASSERT_EQ(sii.info.standard_send_mbx_size,   128u);
+    // Bootstrap (0010800010108000 -> recv off/size, send off/size)
+    ASSERT_EQ(sii.info.bootstrap_recv_mbx_offset, 0x1000u);
+    ASSERT_EQ(sii.info.bootstrap_recv_mbx_size,   0x0080u);
+    ASSERT_EQ(sii.info.bootstrap_send_mbx_offset, 0x1010u);
+    ASSERT_EQ(sii.info.bootstrap_send_mbx_size,   0x0080u);
+    // CoE/EoE/AoE/FoE/SoE present in the fixture (VoE has no protocol bit)
+    ASSERT_EQ(sii.info.mailbox_protocol,
+              eeprom::MailboxProtocol::AoE | eeprom::MailboxProtocol::EoE | eeprom::MailboxProtocol::CoE
+            | eeprom::MailboxProtocol::FoE | eeprom::MailboxProtocol::SoE);
+
+    // SyncManagers
+    ASSERT_EQ(sii.syncManagers.size(), 4u);
+    ASSERT_EQ(sii.syncManagers[0].type,            SyncManager::MailboxOut);
+    ASSERT_EQ(sii.syncManagers[1].type,            SyncManager::MailboxIn);
+    ASSERT_EQ(sii.syncManagers[2].type,            SyncManager::Output);
+    ASSERT_EQ(sii.syncManagers[2].start_address,   0x1800u);
+    ASSERT_EQ(sii.syncManagers[2].length,          40u);
+    ASSERT_EQ(sii.syncManagers[2].control_register, 0x64u);
+    ASSERT_EQ(sii.syncManagers[2].enable,          1u);
+    ASSERT_EQ(sii.syncManagers[3].type,            SyncManager::Input);
+
+    // FMMUs
+    ASSERT_EQ(sii.fmmus.size(), 3u);
+    ASSERT_EQ(sii.fmmus[0], fmmu::Outputs);
+    ASSERT_EQ(sii.fmmus[1], fmmu::Inputs);
+    ASSERT_EQ(sii.fmmus[2], fmmu::MBoxState);
+
+    // General CoE detail bits
+    ASSERT_EQ(sii.general.SDO_set,             1u);
+    ASSERT_EQ(sii.general.SDO_info,            1u);
+    ASSERT_EQ(sii.general.PDO_assign,          1u);
+    ASSERT_EQ(sii.general.PDO_configuration,   1u);
+    ASSERT_EQ(sii.general.SDO_complete_access, 1u);
+    ASSERT_EQ(sii.general.PDO_upload,          0u);
+    ASSERT_EQ(sii.general.FoE_details,         1u);
+    ASSERT_EQ(sii.general.EoE_details,         1u);
+    ASSERT_EQ(sii.general.SoE_channels,        1u);
+    ASSERT_EQ(sii.strings.at(sii.general.device_name_id), "KickCAT ESI Test Sm/Fmmu/Su");
+
+    // PDOs
+    ASSERT_EQ(sii.RxPDO.size(), 1u);
+    ASSERT_EQ(sii.RxPDO[0].index,        0x1600u);
+    ASSERT_EQ(sii.RxPDO[0].sync_manager, 2u);
+    ASSERT_EQ(sii.strings.at(sii.RxPDO[0].name_index), "Outputs");
+    ASSERT_EQ(sii.RxPDO[0].entries.at(0).data_type, static_cast<uint8_t>(CoE::DataType::UNSIGNED16));
+
+    ASSERT_EQ(sii.TxPDO.size(), 1u);
+    ASSERT_EQ(sii.TxPDO[0].index, 0x1A00u);
+    ASSERT_EQ(sii.TxPDO[0].entries.size(), 2u);
+    ASSERT_EQ(sii.strings.at(sii.TxPDO[0].entries.at(1).name), "Status");
+    ASSERT_EQ(sii.TxPDO[0].entries.at(0).data_type, static_cast<uint8_t>(CoE::DataType::UNSIGNED16));
+    ASSERT_EQ(sii.TxPDO[0].entries.at(1).data_type, static_cast<uint8_t>(CoE::DataType::UNSIGNED8));
+    ASSERT_EQ(sii.TxPDO[0].entries.at(1).bitlen, 8u);
+
+    // Vendor categories preserved (fixture uses CatNo 30/40 as opaque values here)
+    ASSERT_EQ(sii.unknownCategories.size(), 2u);
+}
+
+TEST(SIIBuilder, synthesizes_dc_category)
+{
+    ESI::Parser parser;
+    ESI::Device dev = parser.loadDevice("kickcat_esi_test_sm_fmmu.xml");
+    eeprom::SII sii = ESI::buildSII(dev);
+
+    // Fixture has 2 OpModes (Synchron, FreeRun); ETG.2010 Table 12 = 24 bytes each.
+    ASSERT_EQ(sii.dc.size(), 2u * 24u);
+
+    auto rd32 = [&](std::size_t o)
+    {
+        return static_cast<uint32_t>(sii.dc[o] | (sii.dc[o + 1] << 8) | (sii.dc[o + 2] << 16)
+                                     | (static_cast<uint32_t>(sii.dc[o + 3]) << 24));
+    };
+    auto rd16 = [&](std::size_t o) { return static_cast<uint16_t>(sii.dc[o] | (sii.dc[o + 1] << 8)); };
+
+    // Synchron: CycleTimeSync0=1000000 (Factor 1), ShiftTimeSync0=100, AssignActivate=0x300
+    ASSERT_EQ(rd32(0x00), 1000000u);                  // cycleTime0
+    ASSERT_EQ(rd32(0x04), 100u);                      // shiftTime0
+    ASSERT_EQ(rd16(0x0E), 0x300u);                    // assignActivate
+    ASSERT_EQ(rd16(0x10), 1u);                        // sync0CycleFactor
+    ASSERT_EQ(sii.strings.at(sii.dc[0x12]), "Synchron");   // nameIdx
+    ASSERT_EQ(sii.strings.at(sii.dc[0x13]), "SM-Synchron");// descIdx
+
+    // FreeRun (second element): AssignActivate=0
+    ASSERT_EQ(rd16(0x18 + 0x0E), 0u);
+}
+
+TEST(SIIBuilder, round_trips_through_serialize_and_parse)
+{
+    ESI::Device dev = makeInputDevice();
+    auto bytes = ESI::buildSII(dev).serialize();
+
+    eeprom::SII parsed;
+    parsed.parse(bytes.data(), bytes.size());
+
+    ASSERT_EQ(parsed.info.vendor_id,       0x2u);
+    ASSERT_EQ(parsed.info.product_code,    0x1234u);
+    ASSERT_EQ(parsed.info.revision_number, 0x10u);
+    ASSERT_EQ(parsed.syncManagers.size(),  1u);
+    ASSERT_EQ(parsed.syncManagers[0].type, SyncManager::Input);
+    ASSERT_FALSE(parsed.fmmus.empty());        // serialize pads an odd count with a trailing 0 byte
+    ASSERT_EQ(parsed.fmmus[0],             fmmu::Inputs);
+    ASSERT_EQ(parsed.TxPDO.size(),         1u);
+    ASSERT_EQ(parsed.TxPDO[0].index,       0x1A00u);
+    ASSERT_EQ(parsed.TxPDO[0].entries.at(0).data_type, static_cast<uint8_t>(CoE::DataType::BOOLEAN));
+    ASSERT_EQ(parsed.strings.at(parsed.TxPDO[0].entries.at(0).name), "Input");
+
+    // No mailbox -> all mailbox words and the protocol mask are zero.
+    ASSERT_EQ(parsed.info.mailbox_protocol,          0u);
+    ASSERT_EQ(parsed.info.standard_recv_mbx_offset,  0u);
+    ASSERT_EQ(parsed.info.standard_send_mbx_offset,  0u);
+
+    // serialize() recomputed the InfoEntry CRC; it must validate after parse.
+    ASSERT_EQ(eeprom::computeInfoCRC(parsed.info), parsed.info.crc);
+}
+
+TEST(SIIBuilder, maps_pdo_entry_data_types_and_padding)
+{
+    ESI::Device dev = makeInputDevice();
+    dev.tx_pdos.clear();
+
+    ESI::Pdo pdo;
+    pdo.index = 0x1A01;
+    pdo.name  = "Mixed";
+    pdo.sm    = 0;
+    auto add = [&](uint16_t index, uint8_t sub, uint16_t bits, std::string name, std::string type)
+    {
+        ESI::PdoEntry e;
+        e.index = index; e.subindex = sub; e.bit_len = bits; e.name = std::move(name); e.data_type = std::move(type);
+        pdo.entries.push_back(e);
+    };
+    add(0x7000, 1, 1,  "b",   "BOOL");
+    add(0x7000, 2, 16, "u16", "UINT");
+    add(0x7000, 3, 32, "u32", "UDINT");
+    add(0,      0, 4,  "",    "");      // padding gap
+    dev.tx_pdos.push_back(pdo);
+
+    eeprom::SII sii = ESI::buildSII(dev);
+    auto const& entries = sii.TxPDO.at(0).entries;
+    ASSERT_EQ(entries.at(0).data_type, static_cast<uint8_t>(CoE::DataType::BOOLEAN));
+    ASSERT_EQ(entries.at(1).data_type, static_cast<uint8_t>(CoE::DataType::UNSIGNED16));
+    ASSERT_EQ(entries.at(2).data_type, static_cast<uint8_t>(CoE::DataType::UNSIGNED32));
+    ASSERT_EQ(entries.at(3).data_type, 0u);   // padding: no type
+    ASSERT_EQ(entries.at(3).name,      0u);   // padding: no name
+}
+
+TEST(SIIBuilder, sii_registerString_dedups_and_is_one_based)
+{
+    eeprom::SII sii;
+    ASSERT_EQ(sii.registerString(""), 0);            // empty -> no string
+    uint8_t a = sii.registerString("alpha");
+    uint8_t b = sii.registerString("beta");
+    ASSERT_EQ(a, 1);
+    ASSERT_EQ(b, 2);
+    ASSERT_EQ(sii.registerString("alpha"), a);       // deduplicated
+    ASSERT_EQ(sii.getString(a), "alpha");          // round-trips with getString
+    ASSERT_EQ(sii.getString(b), "beta");
+}
+
+TEST(SIIBuilder, getString_resolves_one_based_index)
+{
+    eeprom::SII sii;
+    sii.strings = {"", "first", "second"};  // strings[0] reserved; SII index i -> strings[i]
+    ASSERT_EQ(sii.getString(0), "");        // 0 means "no string"
+    ASSERT_EQ(sii.getString(1), "first");
+    ASSERT_EQ(sii.getString(2), "second");
+    ASSERT_EQ(sii.getString(3), "");        // out of range
+}
+
+TEST(SIIBuilder, raw_eeprom_image_is_returned_verbatim)
+{
+    ESI::Device dev = makeInputDevice();
+    dev.eeprom->raw_data = {0xDE, 0xAD, 0xBE, 0xEF};
+    auto image = ESI::buildEepromImage(dev);
+    ASSERT_EQ(image, (std::vector<uint8_t>{0xDE, 0xAD, 0xBE, 0xEF}));
+}

--- a/unit/src/ESMStateInit-t.cc
+++ b/unit/src/ESMStateInit-t.cc
@@ -41,7 +41,7 @@ TEST_F(ESMStateInitTest, 2B_ErrInit_to_Init)
                                        ALControl{State::INIT | State::ERROR_ACK});
 
     EXPECT_EQ(newContext.al_status, State::INIT);
-    EXPECT_EQ(newContext.al_status_code, StatusCode::NO_ERROR);
+    EXPECT_EQ(newContext.al_status_code, StatusCode::ECAT_NO_ERROR);
 }
 
 TEST_F(ESMStateInitTest, 3A_Init_to_PreOP)

--- a/unit/src/ESMStateSafeOP-t.cc
+++ b/unit/src/ESMStateSafeOP-t.cc
@@ -237,5 +237,5 @@ TEST_F(ESMStateSafeOPTest, xx_SafeOP_to_Op)
     context.is_valid_output_data = true;
     Context newContext = safeop.routine(context, ALControl{State::OPERATIONAL});
 
-    expectAlStatus(newContext, State::OPERATIONAL, StatusCode::NO_ERROR);
+    expectAlStatus(newContext, State::OPERATIONAL, StatusCode::ECAT_NO_ERROR);
 }

--- a/unit/src/mailbox/CoE/request-t.cc
+++ b/unit/src/mailbox/CoE/request-t.cc
@@ -85,6 +85,31 @@ TEST_F(CoE_Request, emergency_callback_not_related_message)
     ASSERT_EQ(0, mailbox.emergencies.size());
 }
 
+TEST_F(CoE_Request, SDO_abort_reaches_pending_request_not_check_message)
+{
+    // Bus::init seeds a CheckMessage ahead of any SDO. An "Abort SDO Transfer"
+    // is itself an SDO_REQUEST (ETG.1000.6 Table 40); it must reach the pending
+    // SDO transfer rather than being swallowed by CheckMessage.
+    mailbox.to_process.push_back(std::make_shared<CheckMessage>(mailbox));
+
+    int32_t data = 0;
+    uint32_t data_size = sizeof(data);
+    mailbox.createSDO(0x1c13, 0, false, CoE::SDO::request::UPLOAD, &data, &data_size);
+    auto sdoMsg = mailbox.send();   // appended after the CheckMessage
+
+    header->address = 0;
+    header->type    = mailbox::Type::CoE;
+    coe->service    = CoE::Service::SDO_REQUEST;
+    sdo->command    = CoE::SDO::request::ABORT;
+    sdo->index      = 0x1c13;
+    sdo->subindex   = 0;
+    *static_cast<uint32_t*>(payload) = CoE::SDO::abort::OBJECT_DOES_NOT_EXIST;
+
+    ASSERT_TRUE(mailbox.receive(raw_message));
+    ASSERT_NE(MessageStatus::RUNNING, sdoMsg->status());  // not left hanging by CheckMessage
+    ASSERT_NE(MessageStatus::SUCCESS, sdoMsg->status());  // terminated as an abort
+}
+
 TEST_F(CoE_Request, SDO_inactive_mailbox)
 {
     mailbox.recv_size = 0;

--- a/unit/src/masterOD-t.cc
+++ b/unit/src/masterOD-t.cc
@@ -415,7 +415,7 @@ TEST(MasterODPopulate, optional_subindices_exist_with_defaults)
 
     std::vector<Slave> slaves(1);
     slaves[0].address = 0x1001;
-    slaves[0].sii.strings = {"AD-4242"};
+    slaves[0].sii.strings = {"", "AD-4242"};  // strings[0] is the reserved empty; index 1 is the first real string
     slaves[0].sii.general.device_order_id = 1;
     slaves[0].sii.general.port_0 = 1;   // MII
     slaves[0].sii.general.port_1 = 2;   // EBUS
@@ -474,7 +474,8 @@ TEST(MasterODPopulate, mandatory_subindices_from_spec)
 
     std::vector<Slave> slaves(1);
     // Point device_name_id at the first SII string (1-based index per ETG.2010).
-    slaves[0].sii.strings = {"Acme Drive"};
+    // strings[0] is the reserved empty placeholder, matching parseStrings()/serialize().
+    slaves[0].sii.strings = {"", "Acme Drive"};
     slaves[0].sii.general.device_name_id = 1;
     slaves[0].sii.info.mailbox_protocol = eeprom::MailboxProtocol::CoE | eeprom::MailboxProtocol::FoE;
 

--- a/unit/src/slave/PDO-t.cc
+++ b/unit/src/slave/PDO-t.cc
@@ -109,9 +109,10 @@ TEST_F(PDOTest, configure_success)
     ASSERT_EQ(0, pdo_.configure());
 }
 
-TEST_F(PDOTest, configure_failure_no_buffered_sm)
+TEST_F(PDOTest, configure_mailbox_only_leaves_both_unused)
 {
-    // Replace all SMs with mailbox-only (control=0x02), so findSm(BUFFERED) throws
+    // Only mailbox SMs, no process data: a mailbox-only slave is valid. configure
+    // tolerates it (returns 0) and leaves both directions Unused.
     SyncManager::Register mbx{};
     mbx.control = SM_CONTROL_MODE_MAILBOX | SM_CONTROL_DIRECTION_READ;
     for (int i = 0; i < 5; ++i)
@@ -122,7 +123,27 @@ TEST_F(PDOTest, configure_failure_no_buffered_sm)
                        { std::memcpy(ptr, &mbx, sizeof(SyncManager::Register)); }),
                 Return(sizeof(SyncManager::Register))));
     }
-    ASSERT_EQ(-EINVAL, pdo_.configure());
+    ASSERT_EQ(0, pdo_.configure());
+    ASSERT_EQ(StatusCode::ECAT_NO_ERROR, pdo_.isConfigOk());
+}
+
+TEST_F(PDOTest, configure_input_only_leaves_output_unused)
+{
+    // Input-only terminal (e.g. a digital input like EL1008): no buffered-write SM.
+    // configure must still succeed; the output direction stays Unused.
+    SyncManager::Register empty{};  // index 3 (output) replaced by an empty SM
+    ON_CALL(esc_, read(static_cast<uint16_t>(reg::SYNC_MANAGER + sizeof(SyncManager::Register) * 3), _, sizeof(SyncManager::Register)))
+        .WillByDefault(DoAll(
+            Invoke([empty](uint16_t, void *ptr, uint16_t)
+                   { std::memcpy(ptr, &empty, sizeof(SyncManager::Register)); }),
+            Return(sizeof(SyncManager::Register))));
+
+    ASSERT_EQ(0, pdo_.configure());
+    ASSERT_EQ(StatusCode::ECAT_NO_ERROR, pdo_.isConfigOk());
+
+    // Output is Unused -> activating it touches no ESC register; input still does.
+    EXPECT_CALL(esc_, write(_, _, _)).Times(0);
+    pdo_.activateOutput(true);
 }
 
 // ---- isConfigOk() ----
@@ -130,7 +151,7 @@ TEST_F(PDOTest, configure_failure_no_buffered_sm)
 TEST_F(PDOTest, isConfigOk_no_error)
 {
     configurePdo();
-    ASSERT_EQ(StatusCode::NO_ERROR, pdo_.isConfigOk());
+    ASSERT_EQ(StatusCode::ECAT_NO_ERROR, pdo_.isConfigOk());
 }
 
 TEST_F(PDOTest, isConfigOk_invalid_input_length_mismatch)
@@ -310,13 +331,73 @@ static CoE::Dictionary createMappingDict(bool with_input_assign, bool with_outpu
 TEST_F(PDOTest, configureMapping_no_assignments_returns_ok)
 {
     CoE::Dictionary dict = createMappingDict(false, false);
-    ASSERT_EQ(StatusCode::NO_ERROR, pdo_.configureMapping(dict));
+    ASSERT_EQ(StatusCode::ECAT_NO_ERROR, pdo_.configureMapping(dict));
+}
+
+TEST_F(PDOTest, configureMapping_copies_sub_byte_default_into_buffer)
+{
+    // A BOOL entry (bitlen 1) occupies 1 byte; its default must be copied into the
+    // process image. With a bits/8 sizing the copy would be 0 bytes (default lost).
+    CoE::Dictionary dict;
+    {
+        CoE::Object obj{0x6000, CoE::ObjectCode::VAR, "Input bit", {}};
+        CoE::addEntry<uint8_t>(obj, 0, 1, 0, CoE::Access::READ | CoE::Access::WRITE,
+                               CoE::DataType::BOOLEAN, "bit", uint8_t{1});
+        dict.push_back(std::move(obj));
+    }
+    {
+        CoE::Object obj{0x1A00, CoE::ObjectCode::RECORD, "TxPDO map", {}};
+        CoE::addEntry<uint8_t> (obj, 0, 8,  0, CoE::Access::READ, CoE::DataType::UNSIGNED8,  "Count", uint8_t{1});
+        CoE::addEntry<uint32_t>(obj, 1, 32, 8, CoE::Access::READ, CoE::DataType::UNSIGNED32, "M1",
+                                makeMappingEntry(0x6000, 0, 1));
+        dict.push_back(std::move(obj));
+    }
+    {
+        CoE::Object obj{0x1C13, CoE::ObjectCode::RECORD, "TxPDO assign", {}};
+        CoE::addEntry<uint8_t> (obj, 0, 8,  0, CoE::Access::READ, CoE::DataType::UNSIGNED8,  "Count", uint8_t{1});
+        CoE::addEntry<uint16_t>(obj, 1, 16, 8, CoE::Access::READ, CoE::DataType::UNSIGNED16, "PDO 1", uint16_t{0x1A00});
+        dict.push_back(std::move(obj));
+    }
+
+    input_[0] = 0;
+    ASSERT_EQ(StatusCode::ECAT_NO_ERROR, pdo_.configureMapping(dict));
+    ASSERT_EQ(input_[0], 1);  // BOOL default copied, not zero bytes
+}
+
+TEST_F(PDOTest, configureMapping_skips_padding_gap_entry)
+{
+    // A mapping entry with index 0 is an alignment gap: it reserves bits but maps
+    // to no object. It must be skipped, not looked up (which would fail). Common
+    // in analog terminals (e.g. Beckhoff EL30xx) that pad before the real value.
+    CoE::Dictionary dict;
+    {
+        CoE::Object obj{0x6000, CoE::ObjectCode::VAR, "Input", {}};
+        CoE::addEntry<uint16_t>(obj, 0, 16, 0, CoE::Access::READ | CoE::Access::WRITE,
+                                CoE::DataType::UNSIGNED16, "Val", uint16_t{0});
+        dict.push_back(std::move(obj));
+    }
+    {
+        CoE::Object obj{0x1A00, CoE::ObjectCode::RECORD, "TxPDO map", {}};
+        CoE::addEntry<uint8_t> (obj, 0, 8,  0,  CoE::Access::READ, CoE::DataType::UNSIGNED8,  "Count", uint8_t{2});
+        CoE::addEntry<uint32_t>(obj, 1, 32, 8,  CoE::Access::READ, CoE::DataType::UNSIGNED32, "pad",
+                                makeMappingEntry(0, 0, 4));            // gap: index 0
+        CoE::addEntry<uint32_t>(obj, 2, 32, 40, CoE::Access::READ, CoE::DataType::UNSIGNED32, "M1",
+                                makeMappingEntry(0x6000, 0, 16));
+        dict.push_back(std::move(obj));
+    }
+    {
+        CoE::Object obj{0x1C13, CoE::ObjectCode::RECORD, "TxPDO assign", {}};
+        CoE::addEntry<uint8_t> (obj, 0, 8,  0, CoE::Access::READ, CoE::DataType::UNSIGNED8,  "Count", uint8_t{1});
+        CoE::addEntry<uint16_t>(obj, 1, 16, 8, CoE::Access::READ, CoE::DataType::UNSIGNED16, "PDO 1", uint16_t{0x1A00});
+        dict.push_back(std::move(obj));
+    }
+    ASSERT_EQ(StatusCode::ECAT_NO_ERROR, pdo_.configureMapping(dict));
 }
 
 TEST_F(PDOTest, configureMapping_input_aliases_entry_to_buffer)
 {
     CoE::Dictionary dict = createMappingDict(true, false);
-    ASSERT_EQ(StatusCode::NO_ERROR, pdo_.configureMapping(dict));
+    ASSERT_EQ(StatusCode::ECAT_NO_ERROR, pdo_.configureMapping(dict));
 
     auto [obj, entry] = CoE::findObject(dict, 0x6000, 0);
     ASSERT_NE(nullptr, entry);
@@ -328,7 +409,7 @@ TEST_F(PDOTest, configureMapping_input_aliases_entry_to_buffer)
 TEST_F(PDOTest, configureMapping_output_aliases_entry_to_buffer)
 {
     CoE::Dictionary dict = createMappingDict(false, true);
-    ASSERT_EQ(StatusCode::NO_ERROR, pdo_.configureMapping(dict));
+    ASSERT_EQ(StatusCode::ECAT_NO_ERROR, pdo_.configureMapping(dict));
 
     auto [obj, entry] = CoE::findObject(dict, 0x7000, 0);
     ASSERT_NE(nullptr, entry);
@@ -340,7 +421,7 @@ TEST_F(PDOTest, configureMapping_output_aliases_entry_to_buffer)
 TEST_F(PDOTest, configureMapping_both_assignments_succeed)
 {
     CoE::Dictionary dict = createMappingDict(true, true);
-    ASSERT_EQ(StatusCode::NO_ERROR, pdo_.configureMapping(dict));
+    ASSERT_EQ(StatusCode::ECAT_NO_ERROR, pdo_.configureMapping(dict));
 }
 
 TEST_F(PDOTest, configureMapping_input_pdo_map_missing_returns_invalid_input)
@@ -462,7 +543,7 @@ TEST_F(PDOTest, configureMapping_already_mapped_entry_is_not_freed)
     CoE::addEntry<uint16_t>(assign, 1, 16, 8, CoE::Access::READ, CoE::DataType::UNSIGNED16, "PDO 1", uint16_t{0x1A00});
     dict.push_back(std::move(assign));
 
-    ASSERT_EQ(StatusCode::NO_ERROR, pdo_.configureMapping(dict));
+    ASSERT_EQ(StatusCode::ECAT_NO_ERROR, pdo_.configureMapping(dict));
 
     auto [obj, entry] = CoE::findObject(dict, 0x6000, 0);
     ASSERT_NE(nullptr, entry);
@@ -491,7 +572,7 @@ TEST_F(PDOTest, configureMapping_null_old_data_no_memcpy)
     CoE::addEntry<uint16_t>(assign, 1, 16, 8, CoE::Access::READ, CoE::DataType::UNSIGNED16, "PDO 1", uint16_t{0x1A00});
     dict.push_back(std::move(assign));
 
-    ASSERT_EQ(StatusCode::NO_ERROR, pdo_.configureMapping(dict));
+    ASSERT_EQ(StatusCode::ECAT_NO_ERROR, pdo_.configureMapping(dict));
 
     auto [obj, entry] = CoE::findObject(dict, 0x6000, 0);
     ASSERT_NE(nullptr, entry);


### PR DESCRIPTION
Fixes and improvements against the whole ESI packages from Beckhoff (4295 slaves):

Parse + SII image generation: 4288/4295
Map PDO: 3256/4288

1032 non resolved root causes:
- SoE kind: 227
- PdoUpload tag: 286 
- unsupported diagnostic objects (0x1xxx/0xFxxx): 415
- A few real cases to dig more: 73
- legacy devices that doe snot declare the OD inside the ESI: 24

2832/4288 (66%) boot to OPERATIONAL -> cannot do more without a real application behind

NO_ERROR renamed ECAT_NO_ERROR to avoid collision with Windows NO_ERROR macro