### PR TITLE
Emulator FMMU engine + OD in app

### DIFF
--- a/examples/master/simulated_bus/simulated_bus.cc
+++ b/examples/master/simulated_bus/simulated_bus.cc
@@ -94,8 +94,9 @@ int main(int argc, char** argv)
     if (dev.mailbox and dev.mailbox->coe)
     {
         mbx = std::make_unique<mailbox::response::Mailbox>(&esc, 1024);
-        mbx->enableCoE(std::move(dev.dictionary));
+        mbx->enableCoE(dev.dictionary);     // dev owns the OD; injected into both
         sl.setMailbox(mbx.get());
+        sl.setDictionary(&dev.dictionary);
     }
 
     constexpr uint32_t PDO_SIZE = 4096;  // a full frame: never overflow on large PDOs

--- a/examples/slave/nuttx/lan9252/freedom-k64f/main.cc
+++ b/examples/slave/nuttx/lan9252/freedom-k64f/main.cc
@@ -50,9 +50,10 @@ int main(int argc, char *argv[])
 
     mailbox::response::Mailbox mbx(&esc, 1024);
     auto dictionary = CoE::createOD();
-    mbx.enableCoE(std::move(dictionary));
+    mbx.enableCoE(dictionary);          // the firmware owns the OD; the mailbox references it
 
     slave.setMailbox(&mbx);
+    slave.setDictionary(&dictionary);   // and the slave uses it for bind / PDO mapping
     pdo.setInput(buffer_in, PDO_MAX_SIZE);
     pdo.setOutput(buffer_out, PDO_MAX_SIZE);
 

--- a/examples/slave/nuttx/xmc4800/main_foot.cc
+++ b/examples/slave/nuttx/xmc4800/main_foot.cc
@@ -66,9 +66,10 @@ int main(int, char *[])
 
     mailbox::response::Mailbox mbx(&esc, 1024);
     auto dictionary = CoE::createOD();
-    mbx.enableCoE(std::move(dictionary));
+    mbx.enableCoE(dictionary);          // the firmware owns the OD; the mailbox references it
 
     slave.setMailbox(&mbx);
+    slave.setDictionary(&dictionary);   // and the slave uses it for bind / PDO mapping
     pdo.setInput(&input_PDO, sizeof(input_PDO));
     pdo.setOutput(&output_PDO, sizeof(output_PDO));
 

--- a/examples/slave/nuttx/xmc4800/main_relax.cc
+++ b/examples/slave/nuttx/xmc4800/main_relax.cc
@@ -41,9 +41,10 @@ int main(int, char*[])
 
     mailbox::response::Mailbox mbx(&esc, 1024);
     auto dictionary = CoE::createOD();
-    mbx.enableCoE(std::move(dictionary));
+    mbx.enableCoE(dictionary);          // the firmware owns the OD; the mailbox references it
 
     slave.setMailbox(&mbx);
+    slave.setDictionary(&dictionary);   // and the slave uses it for bind / PDO mapping
     pdo.setInput(buffer_in, PDO_MAX_SIZE);
     pdo.setOutput(buffer_out, PDO_MAX_SIZE);
     

--- a/examples/slave/rpi/lan9252/main.cc
+++ b/examples/slave/rpi/lan9252/main.cc
@@ -46,9 +46,10 @@ int main(int argc, char *argv[])
 
     mailbox::response::Mailbox mbx(&esc, 1024);
     auto dictionary = CoE::createOD();
-    mbx.enableCoE(std::move(dictionary));
+    mbx.enableCoE(dictionary);          // the firmware owns the OD; the mailbox references it
 
     slave.setMailbox(&mbx);
+    slave.setDictionary(&dictionary);   // and the slave uses it for bind / PDO mapping
     pdo.setInput(buffer_in, PDO_MAX_SIZE);
     pdo.setOutput(buffer_out, PDO_MAX_SIZE);
 

--- a/lib/include/kickcat/Mailbox.h
+++ b/lib/include/kickcat/Mailbox.h
@@ -191,8 +191,7 @@ namespace kickcat::mailbox::response
 
         ~Mailbox() = default;
 
-        // References an application-owned dictionary (injected into the slave too): the OD
-        // belongs to the application, never to the mailbox transport. It must outlive the mailbox.
+        // Non-owning: references an application-owned dictionary that must outlive the mailbox.
         void enableCoE(CoE::Dictionary& dictionary);
         CoE::Dictionary& getDictionary(){return *dictionary_;}
 

--- a/lib/include/kickcat/Mailbox.h
+++ b/lib/include/kickcat/Mailbox.h
@@ -191,8 +191,10 @@ namespace kickcat::mailbox::response
 
         ~Mailbox() = default;
 
-        void enableCoE(CoE::Dictionary&& dictionary);
-        CoE::Dictionary& getDictionary(){return dictionary_;}
+        // References an application-owned dictionary (injected into the slave too): the OD
+        // belongs to the application, never to the mailbox transport. It must outlive the mailbox.
+        void enableCoE(CoE::Dictionary& dictionary);
+        CoE::Dictionary& getDictionary(){return *dictionary_;}
 
         // --- ESC-coupled methods (requires to pass the ESC to the constructor) ---
         int32_t configure();
@@ -238,7 +240,7 @@ namespace kickcat::mailbox::response
         uint16_t max_msgs_;
 
         std::vector<std::function<std::shared_ptr<AbstractMessage>(Mailbox*, std::vector<uint8_t>&&)>> factories_;
-        CoE::Dictionary dictionary_;
+        CoE::Dictionary* dictionary_{nullptr};         // application-owned, set by enableCoE
 
         std::list<std::shared_ptr<AbstractMessage>> to_process_;    /// Received messages, waiting to be processed
         std::queue<std::vector<uint8_t>> to_send_;                  /// Messages to send (replies from a received messages)

--- a/lib/slave/include/kickcat/ESC/EmulatedESC.h
+++ b/lib/slave/include/kickcat/ESC/EmulatedESC.h
@@ -170,14 +170,18 @@ namespace kickcat
         };
         std::vector<SM> syncs_;
 
-        struct PDO
+        // physical is a flat offset into the ESC memory map, so one FMMU list covers
+        // both process-data RAM and register space (e.g. an SM mailbox-status bit).
+        struct Fmmu
         {
             uint32_t logical_address;
-            uint8_t* physical_address;
-            uint16_t size;
+            uint8_t* physical;
+            uint32_t bit_length;
+            uint8_t  logical_start_bit;
+            uint8_t  physical_start_bit;
+            bool     is_input;          // FMMU type 1: slave -> master
         };
-        std::vector<PDO> rx_pdos_;
-        std::vector<PDO> tx_pdos_;
+        std::vector<Fmmu> fmmus_;
 
         void loadEeprom();
 
@@ -194,13 +198,14 @@ namespace kickcat
         void processLRD(DatagramHeader* header, void* data, uint16_t* wkc);
         void processLWR(DatagramHeader* header, void* data, uint16_t* wkc);
         void processLRW(DatagramHeader* header, void* data, uint16_t* wkc);
-        uint16_t processPDO(std::vector<PDO> const& pdos, bool read, DatagramHeader* header, void* data);
+        // Return true if any FMMU's logical range fell inside this datagram.
+        bool processFmmus(bool read, DatagramHeader const* header, void* frame);
+        bool copyFmmu(Fmmu const& fmmu, bool read, DatagramHeader const* header, void* frame);
 
         void configureSMs();
-        void configurePDOs();
+        void configureFmmus();
 
         int32_t computeInternalMemoryAccess(uint16_t address, void* buffer, uint16_t size, Access access);
-        std::tuple<uint8_t*, uint8_t*, uint16_t> computeLogicalIntersection(DatagramHeader const* header, void* data, PDO const& pdo);
 
         nanoseconds pdiWatchdog();  // Get configured PDI watchdog
         nanoseconds pdoWatchdog();  // Get configured PDO watchdog

--- a/lib/slave/include/kickcat/ESC/EmulatedESC.h
+++ b/lib/slave/include/kickcat/ESC/EmulatedESC.h
@@ -182,6 +182,7 @@ namespace kickcat
             bool     is_input;          // FMMU type 1: slave -> master
         };
         std::vector<Fmmu> fmmus_;
+        bool has_output_fmmu_{false};   // process-data watchdog only applies when outputs exist
 
         void loadEeprom();
 

--- a/lib/slave/include/kickcat/ESM.h
+++ b/lib/slave/include/kickcat/ESM.h
@@ -61,6 +61,7 @@ namespace kickcat
         public:
             AbstractState(uint8_t id, AbstractESC& esc, PDO& pdo);
             void setMailbox(mailbox::response::Mailbox* mbx);
+            void setDictionary(CoE::Dictionary* dictionary);
             virtual Context routine(Context currentStatus, ALControl alControl);
             virtual void onEntry(Context oldStatus, Context newStatus);
 
@@ -69,6 +70,7 @@ namespace kickcat
             AbstractESC& esc_;
             PDO& pdo_;
             mailbox::response::Mailbox* mbx_{};
+            CoE::Dictionary* dictionary_{};
 
             virtual Context routineInternal(Context currentStatus, ALControl alControl) = 0;
 

--- a/lib/slave/include/kickcat/slave/Slave.h
+++ b/lib/slave/include/kickcat/slave/Slave.h
@@ -19,9 +19,8 @@ namespace kickcat::slave
 
         void setMailbox(mailbox::response::Mailbox* mbx);
 
-        // Object dictionary used for PDO mapping and bind(). A CoE slave gets it from its
-        // mailbox automatically (setMailbox), a mailboxless terminal sets it directly here;
-        // either way the OD belongs to the slave, not the mailbox transport.
+        // Object dictionary for PDO mapping and bind(), owned by the application and injected
+        // here (a mailboxless terminal has one too); it must outlive the slave.
         void setDictionary(CoE::Dictionary* dictionary);
 
         void start();

--- a/lib/slave/include/kickcat/slave/Slave.h
+++ b/lib/slave/include/kickcat/slave/Slave.h
@@ -18,6 +18,12 @@ namespace kickcat::slave
         Slave(AbstractESC* esc, PDO* pdo);
 
         void setMailbox(mailbox::response::Mailbox* mbx);
+
+        // Object dictionary used for PDO mapping and bind(). A CoE slave gets it from its
+        // mailbox automatically (setMailbox), a mailboxless terminal sets it directly here;
+        // either way the OD belongs to the slave, not the mailbox transport.
+        void setDictionary(CoE::Dictionary* dictionary);
+
         void start();
         void routine();
         State state();
@@ -26,10 +32,9 @@ namespace kickcat::slave
         template<typename T>
         void bind(uint16_t idx, T*& ptr, uint8_t subindex = 0)
         {
-            if (mbx_)
+            if (dictionary_)
             {
-                auto& dict = mbx_->getDictionary();
-                auto [obj, entry] = kickcat::CoE::findObject(dict, idx, subindex);
+                auto [obj, entry] = kickcat::CoE::findObject(*dictionary_, idx, subindex);
                 if (entry)
                 {
                     ptr = static_cast<std::remove_reference_t<decltype(*ptr)> *>(entry->data);
@@ -40,6 +45,7 @@ namespace kickcat::slave
     private:
         AbstractESC* esc_;
         mailbox::response::Mailbox* mbx_{nullptr};
+        CoE::Dictionary* dictionary_{nullptr};
         PDO* pdo_;
 
         ESM::Init init_{*esc_, *pdo_};

--- a/lib/slave/src/ESC/EmulatedESC.cc
+++ b/lib/slave/src/ESC/EmulatedESC.cc
@@ -151,11 +151,13 @@ namespace kickcat
                 }
             }
 
+            // PDI reads the output image and writes the input image; a sub-byte/register
+            // FMMU has a zero-byte span, so it never matches a process-data access here.
             if (access & Access::PDI_READ)
             {
-                for (auto& pdo : rx_pdos_)
+                for (auto& fmmu : fmmus_)
                 {
-                    if ((pos < pdo.physical_address) or ((pos + to_copy) > (pdo.physical_address + pdo.size)))
+                    if (fmmu.is_input or (pos < fmmu.physical) or ((pos + to_copy) > (fmmu.physical + fmmu.bit_length / 8)))
                     {
                         continue;
                     }
@@ -166,9 +168,9 @@ namespace kickcat
 
             if (access & Access::PDI_WRITE)
             {
-                for (auto& pdo : tx_pdos_)
+                for (auto& fmmu : fmmus_)
                 {
-                    if ((pos < pdo.physical_address) or ((pos + to_copy) > (pdo.physical_address + pdo.size)))
+                    if ((not fmmu.is_input) or (pos < fmmu.physical) or ((pos + to_copy) > (fmmu.physical + fmmu.bit_length / 8)))
                     {
                         continue;
                     }
@@ -221,40 +223,100 @@ namespace kickcat
     }
 
 
-    uint16_t EmulatedESC::processPDO(std::vector<PDO> const& pdos, bool read, DatagramHeader* header, void* data)
+    bool EmulatedESC::copyFmmu(Fmmu const& fmmu, bool read, DatagramHeader const* header, void* frame)
     {
-        int wkc = 0;
-        for (auto const& pdo : pdos)
-        {
-            auto[frame, internal, to_copy] = computeLogicalIntersection(header, data, pdo);
-            if (to_copy == 0)
-            {
-                continue;
-            }
+        uint32_t const start = header->address;
+        uint32_t const end   = start + header->len;
 
+        // Byte-aligned fast path; sub-byte mappings fall through to the bit loop below.
+        if ((fmmu.logical_start_bit == 0) and (fmmu.physical_start_bit == 0) and ((fmmu.bit_length % 8) == 0))
+        {
+            uint32_t const size = fmmu.bit_length / 8;
+            uint32_t const min  = std::max(start, fmmu.logical_address);
+            uint32_t const max  = std::min(end,   fmmu.logical_address + size);
+            if (max <= min)
+            {
+                return false;
+            }
+            uint32_t const to_copy = max - min;
+            uint8_t* frame_p = static_cast<uint8_t*>(frame) + (min - start);
+            uint8_t* phys_p  = fmmu.physical + (min - fmmu.logical_address);
             if (read)
             {
-                std::memcpy(frame, internal, to_copy);
+                std::memcpy(frame_p, phys_p, to_copy);
             }
             else
             {
-                std::memcpy(internal, frame, to_copy);
+                std::memcpy(phys_p, frame_p, to_copy);
                 lastLogicalWrite_ = since_epoch();   // update watchdog
             }
-            ++wkc;
+            return true;
         }
-        return wkc;
+
+        bool hit   = false;
+        bool wrote = false;
+        for (uint32_t b = 0; b < fmmu.bit_length; ++b)
+        {
+            uint32_t const logical_bit  = fmmu.logical_start_bit + b;
+            uint32_t const logical_byte = fmmu.logical_address + (logical_bit / 8);
+            if ((logical_byte < start) or (logical_byte >= end))
+            {
+                continue;
+            }
+            uint8_t* frame_byte = static_cast<uint8_t*>(frame) + (logical_byte - start);
+            uint8_t const  loff = logical_bit % 8;
+            uint32_t const physical_bit = fmmu.physical_start_bit + b;
+            uint8_t* phys_byte = fmmu.physical + (physical_bit / 8);
+            uint8_t const  poff = physical_bit % 8;
+            if (read)
+            {
+                uint8_t const bit = (*phys_byte >> poff) & 1u;
+                *frame_byte = static_cast<uint8_t>((*frame_byte & ~(1u << loff)) | (bit << loff));
+            }
+            else
+            {
+                uint8_t const bit = (*frame_byte >> loff) & 1u;
+                *phys_byte = static_cast<uint8_t>((*phys_byte & ~(1u << poff)) | (bit << poff));
+                wrote = true;
+            }
+            hit = true;
+        }
+        if (wrote)
+        {
+            lastLogicalWrite_ = since_epoch();   // update watchdog
+        }
+        return hit;
+    }
+
+    bool EmulatedESC::processFmmus(bool read, DatagramHeader const* header, void* frame)
+    {
+        bool hit = false;
+        for (auto const& fmmu : fmmus_)
+        {
+            if (fmmu.is_input != read)   // read direction serves input FMMUs, write serves outputs
+            {
+                continue;
+            }
+            hit |= copyFmmu(fmmu, read, header, frame);
+        }
+        return hit;
     }
 
 
     void EmulatedESC::processLRD(DatagramHeader* header, void* data, uint16_t* wkc)
     {
-        *wkc += processPDO(tx_pdos_, true, header, data);
+        if (processFmmus(true, header, data))   // ETG.1000.4: one increment per direction, not per FMMU
+        {
+            *wkc += 1;
+        }
     }
 
     void EmulatedESC::processLWR(DatagramHeader* header, void* data, uint16_t* wkc)
     {
-        *wkc += processPDO(rx_pdos_, false, header, data);
+        if (processFmmus(false, header, data))
+        {
+            *wkc += 1;
+        }
     }
 
     void EmulatedESC::processLRW(DatagramHeader* header, void* data, uint16_t* wkc)
@@ -262,8 +324,16 @@ namespace kickcat
         uint8_t swap[MAX_ETHERCAT_PAYLOAD_SIZE];
         std::memcpy(swap, data, header->len);
 
-        *wkc += processPDO(tx_pdos_, true,  header, data);      // read directly in the frame
-        *wkc += processPDO(rx_pdos_, false, header, swap) * 2;  // write from the swap
+        bool const read  = processFmmus(true,  header, data);   // read directly into the frame
+        bool const write = processFmmus(false, header, swap);   // write from the pre-read copy
+        if (read)
+        {
+            *wkc += 1;
+        }
+        if (write)
+        {
+            *wkc += 2;
+        }
     }
 
 
@@ -420,7 +490,7 @@ namespace kickcat
                 {
                     if (before == State::PRE_OP)
                     {
-                        configurePDOs();
+                        configureFmmus();
                     }
                     break;
                 }
@@ -577,10 +647,9 @@ namespace kickcat
     }
 
 
-    void EmulatedESC::configurePDOs()
+    void EmulatedESC::configureFmmus()
     {
-        tx_pdos_.clear();
-        rx_pdos_.clear();
+        fmmus_.clear();
         for (int i = 0; i < 16; ++i)
         {
             auto const& fmmu = memory_.fmmu[i];
@@ -588,53 +657,27 @@ namespace kickcat
             {
                 continue;
             }
-
-            // A malformed FMMU (physical address below the process-data RAM window, or a
-            // region that runs past its 0xf000-byte end) must not produce a pointer that
-            // reads/writes out of bounds during logical access. Skip it.
-            if (fmmu.physical_address < 0x1000
-                or static_cast<std::size_t>(fmmu.physical_address - 0x1000) + fmmu.length > sizeof(memory_.process_data_ram))
+            if ((fmmu.type != 1) and (fmmu.type != 2))
             {
                 continue;
             }
 
-            PDO pdo;
-            pdo.size = fmmu.length;
-            pdo.logical_address = fmmu.logical_address;
-            pdo.physical_address = memory_.process_data_ram + (fmmu.physical_address - 0x1000);
-
-            if (fmmu.type == 1)
-            {
-                tx_pdos_.push_back(pdo);
-            }
-            else if (fmmu.type == 2)
-            {
-                rx_pdos_.push_back(pdo);
-            }
-            else
+            // Reject a span that runs past the flat memory map, else logical access
+            // would dereference out of bounds.
+            if (static_cast<std::size_t>(fmmu.physical_address) + fmmu.length > sizeof(memory_))
             {
                 continue;
             }
+
+            Fmmu f;
+            f.logical_address    = fmmu.logical_address;
+            f.physical           = reinterpret_cast<uint8_t*>(&memory_) + fmmu.physical_address;
+            f.bit_length         = (fmmu.length - 1u) * 8u + (fmmu.logical_stop_bit - fmmu.logical_start_bit + 1u);
+            f.logical_start_bit  = fmmu.logical_start_bit;
+            f.physical_start_bit = fmmu.physical_start_bit;
+            f.is_input           = (fmmu.type == 1);
+            fmmus_.push_back(f);
         }
-    }
-
-
-    std::tuple<uint8_t*, uint8_t*, uint16_t> EmulatedESC::computeLogicalIntersection(DatagramHeader const* header, void* data, PDO const& pdo)
-    {
-        uint32_t start_logical_address = header->address;
-        uint32_t end_logical_address = header->address + header->len;
-
-        uint32_t address_min = std::max(start_logical_address, pdo.logical_address);
-        uint32_t address_max = std::min(end_logical_address, pdo.logical_address + pdo.size);
-        if (address_max < address_min)
-        {
-            return {nullptr, nullptr, 0};
-        }
-        uint32_t to_copy = address_max - address_min;
-        uint32_t phys_offset = address_min - pdo.logical_address;
-        uint32_t frame_offset = address_min - start_logical_address;
-
-        return {static_cast<uint8_t*>(data) + frame_offset, pdo.physical_address + phys_offset, to_copy};
     }
 
 

--- a/lib/slave/src/ESC/EmulatedESC.cc
+++ b/lib/slave/src/ESC/EmulatedESC.cc
@@ -650,6 +650,7 @@ namespace kickcat
     void EmulatedESC::configureFmmus()
     {
         fmmus_.clear();
+        has_output_fmmu_ = false;
         for (int i = 0; i < 16; ++i)
         {
             auto const& fmmu = memory_.fmmu[i];
@@ -661,10 +662,17 @@ namespace kickcat
             {
                 continue;
             }
+            if (fmmu.logical_stop_bit < fmmu.logical_start_bit)
+            {
+                continue;  // malformed: the unsigned span below would wrap to a huge bit_length
+            }
 
-            // Reject a span that runs past the flat memory map, else logical access
-            // would dereference out of bounds.
-            if (static_cast<std::size_t>(fmmu.physical_address) + fmmu.length > sizeof(memory_))
+            uint32_t const bit_length = (fmmu.length - 1u) * 8u + (fmmu.logical_stop_bit - fmmu.logical_start_bit + 1u);
+
+            // Reject a span that runs past the flat memory map (a non-zero physical start bit
+            // can push the last byte one past `length`), else logical access dereferences OOB.
+            uint32_t const physical_bytes = (fmmu.physical_start_bit + bit_length + 7u) / 8u;
+            if (static_cast<std::size_t>(fmmu.physical_address) + physical_bytes > sizeof(memory_))
             {
                 continue;
             }
@@ -672,12 +680,17 @@ namespace kickcat
             Fmmu f;
             f.logical_address    = fmmu.logical_address;
             f.physical           = reinterpret_cast<uint8_t*>(&memory_) + fmmu.physical_address;
-            f.bit_length         = (fmmu.length - 1u) * 8u + (fmmu.logical_stop_bit - fmmu.logical_start_bit + 1u);
+            f.bit_length         = bit_length;
             f.logical_start_bit  = fmmu.logical_start_bit;
             f.physical_start_bit = fmmu.physical_start_bit;
             f.is_input           = (fmmu.type == 1);
+            if (not f.is_input)
+            {
+                has_output_fmmu_ = true;
+            }
             fmmus_.push_back(f);
         }
+        lastLogicalWrite_ = since_epoch();  // restart the output watchdog window at PDO (re)config
     }
 
 
@@ -697,6 +710,10 @@ namespace kickcat
 
     void EmulatedESC::checkWatchdog()
     {
+        if (not has_output_fmmu_)
+        {
+            return; // no outputs: the process-data watchdog has nothing to monitor
+        }
         nanoseconds delay = pdoWatchdog();
         if (delay == 0ns)
         {

--- a/lib/slave/src/ESM.cc
+++ b/lib/slave/src/ESM.cc
@@ -16,6 +16,11 @@ namespace kickcat::ESM
         mbx_ = mbx;
     }
 
+    void AbstractState::setDictionary(CoE::Dictionary* dictionary)
+    {
+        dictionary_ = dictionary;
+    }
+
     void AbstractState::onEntry(Context, Context) {};
 
     uint8_t AbstractState::id()

--- a/lib/slave/src/ESMStates.cc
+++ b/lib/slave/src/ESMStates.cc
@@ -14,7 +14,7 @@ namespace kickcat::ESM
     {
         if (mbx_)
         {
-            mbx_->activate(false); // reset dictionary here?
+            mbx_->activate(false);
         }
         pdo_.activateInput(false);
         pdo_.activateOutput(false);
@@ -113,9 +113,9 @@ namespace kickcat::ESM
                 return Context::build(id_, StatusCode::INVALID_SYNC_MANAGER_CONFIGURATION);
             }
 
-            if (mbx_)
+            if (dictionary_)
             {
-                StatusCode mapping_rc = pdo_.configureMapping(mbx_->getDictionary());
+                StatusCode mapping_rc = pdo_.configureMapping(*dictionary_);
                 if (mapping_rc != StatusCode::ECAT_NO_ERROR)
                 {
                     return Context::build(id_, mapping_rc);

--- a/lib/slave/src/PDO.cc
+++ b/lib/slave/src/PDO.cc
@@ -206,11 +206,13 @@ namespace kickcat
 
     StatusCode PDO::configureMapping(CoE::Dictionary& dict)
     {
+        // Assignment object is 0x1C10 + SM index (ETG.1000.6), not a fixed SM2/SM3:
+        // a mailboxless terminal carries process data on SM0/SM1.
+        if (hasInput())
         {
             uint16_t bit_offset = 0;
-            std::vector<uint16_t> pdo_indices = parseAssignment(dict, 0x1C13);
-
-            for (auto pdo : pdo_indices)
+            uint16_t assign_idx = static_cast<uint16_t>(0x1C10 + sm_input_.index);
+            for (auto pdo : parseAssignment(dict, assign_idx))
             {
                 if (not parsePdoMap(dict, pdo, input_, bit_offset, input_size_))
                 {
@@ -219,11 +221,11 @@ namespace kickcat
             }
         }
 
+        if (hasOutput())
         {
             uint16_t bit_offset = 0;
-            std::vector<uint16_t> pdo_indices = parseAssignment(dict, 0x1C12);
-
-            for (auto pdo : pdo_indices)
+            uint16_t assign_idx = static_cast<uint16_t>(0x1C10 + sm_output_.index);
+            for (auto pdo : parseAssignment(dict, assign_idx))
             {
                 if (not parsePdoMap(dict, pdo, output_, bit_offset, output_size_))
                 {

--- a/lib/slave/src/slave/Slave.cc
+++ b/lib/slave/src/slave/Slave.cc
@@ -17,6 +17,15 @@ namespace kickcat::slave
         OP_.setMailbox(mbx);
     }
 
+    void Slave::setDictionary(CoE::Dictionary* dictionary)
+    {
+        dictionary_ = dictionary;
+        init_.setDictionary(dictionary);
+        preOp_.setDictionary(dictionary);
+        safeOP_.setDictionary(dictionary);
+        OP_.setDictionary(dictionary);
+    }
+
     void Slave::start()
     {
         stateMachine_.start();

--- a/lib/src/Mailbox.cc
+++ b/lib/src/Mailbox.cc
@@ -556,10 +556,9 @@ namespace kickcat::mailbox::response
         }
     }
 
-    void Mailbox::enableCoE(CoE::Dictionary&& dictionary)
+    void Mailbox::enableCoE(CoE::Dictionary& dictionary)
     {
-        //TODO: take the factory instead to be able to reset the dictionary when going back to init
-        dictionary_ = std::move(dictionary);
+        dictionary_ = &dictionary;
         factories_.push_back(&createSDOMessage);
     }
 

--- a/simulation/network_simulator.cc
+++ b/simulation/network_simulator.cc
@@ -105,6 +105,7 @@ int main(int argc, char* argv[])
     std::vector<std::unique_ptr<PDO>> pdos;
     std::vector<std::unique_ptr<Slave>> slaves;
     std::vector<std::unique_ptr<mailbox::response::Mailbox>> mailboxes;
+    std::vector<std::unique_ptr<CoE::Dictionary>> dictionaries;  // application owns the ODs
     std::vector<std::vector<uint8_t>> input_pdo;
     std::vector<std::vector<uint8_t>> output_pdo;
 
@@ -112,6 +113,7 @@ int main(int argc, char* argv[])
     pdos.reserve(slave_count);
     slaves.reserve(slave_count);
     mailboxes.reserve(slave_count);
+    dictionaries.reserve(slave_count);
     input_pdo.reserve(slave_count);
     output_pdo.reserve(slave_count);
 
@@ -146,6 +148,7 @@ int main(int argc, char* argv[])
 
         std::unique_ptr<EmulatedESC> esc;
         std::optional<CoE::Dictionary> esi_coe;  // CoE dictionary derived from the ESI device, if any
+        bool esi_coe_advertised = false;         // true => device declares a CoE mailbox (SDO on the wire)
 
         if (config.contains("esi"))
         {
@@ -169,9 +172,12 @@ int main(int argc, char* argv[])
                 esc = std::make_unique<EmulatedESC>();
                 esc->loadEeprom(ESI::buildEepromImage(dev));
 
-                if (dev.mailbox and dev.mailbox->coe)
+                if (not dev.dictionary.empty())
                 {
                     esi_coe = std::move(dev.dictionary);
+                    // A mailboxless terminal (e.g. a digital I/O like EL1004) still gets its OD,
+                    // but only a device that declares a CoE mailbox is reachable by SDO.
+                    esi_coe_advertised = (dev.mailbox and dev.mailbox->coe);
                 }
             }
             catch (std::exception const& e)
@@ -199,12 +205,20 @@ int main(int argc, char* argv[])
         auto pdo = std::make_unique<PDO>(esc.get());
         auto slave = std::make_unique<Slave>(esc.get(), pdo.get());
 
+        // The application owns the OD; it is injected into the slave (for bind / PDO mapping)
+        // and, only when the device advertises a CoE mailbox, into the mailbox transport too.
         if (esi_coe)
         {
-            auto mbx = std::make_unique<mailbox::response::Mailbox>(esc.get(), 1024);
-            mbx->enableCoE(std::move(*esi_coe));
-            slave->setMailbox(mbx.get());
-            mailboxes.push_back(std::move(mbx));
+            dictionaries.push_back(std::make_unique<CoE::Dictionary>(std::move(*esi_coe)));
+            CoE::Dictionary* dictionary = dictionaries.back().get();
+            slave->setDictionary(dictionary);
+            if (esi_coe_advertised)
+            {
+                auto mbx = std::make_unique<mailbox::response::Mailbox>(esc.get(), 1024);
+                mbx->enableCoE(*dictionary);
+                slave->setMailbox(mbx.get());
+                mailboxes.push_back(std::move(mbx));
+            }
         }
         else if (config.contains("coe_xml"))
         {
@@ -215,9 +229,11 @@ int main(int argc, char* argv[])
                 std::cerr << "CoE XML file not found: " << coe_xml_full_path << std::endl;
                 return 1;
             }
+            dictionaries.push_back(std::make_unique<CoE::Dictionary>(parser.loadFile(coe_xml_full_path.string())));
+            CoE::Dictionary* dictionary = dictionaries.back().get();
             auto mbx = std::make_unique<mailbox::response::Mailbox>(esc.get(), 1024);
-            auto dictionary = parser.loadFile(coe_xml_full_path.string());
-            mbx->enableCoE(std::move(dictionary));
+            mbx->enableCoE(*dictionary);
+            slave->setDictionary(dictionary);
             slave->setMailbox(mbx.get());
             mailboxes.push_back(std::move(mbx));
         }

--- a/simulation/network_simulator.cc
+++ b/simulation/network_simulator.cc
@@ -205,8 +205,8 @@ int main(int argc, char* argv[])
         auto pdo = std::make_unique<PDO>(esc.get());
         auto slave = std::make_unique<Slave>(esc.get(), pdo.get());
 
-        // The application owns the OD; it is injected into the slave (for bind / PDO mapping)
-        // and, only when the device advertises a CoE mailbox, into the mailbox transport too.
+        // The OD (owned here in `dictionaries`) is injected into the slave always, and into a
+        // mailbox only if the device advertises CoE - so a mailboxless terminal still maps PDOs.
         if (esi_coe)
         {
             dictionaries.push_back(std::make_unique<CoE::Dictionary>(std::move(*esi_coe)));

--- a/test/integration/bench/esi_boot.cc
+++ b/test/integration/bench/esi_boot.cc
@@ -55,8 +55,9 @@ static Reached bootDevice(ESI::Device& dev, nanoseconds wait_timeout)
     if (dev.mailbox and dev.mailbox->coe)
     {
         mbx = std::make_unique<mailbox::response::Mailbox>(esc.get(), 1024);
-        mbx->enableCoE(std::move(dev.dictionary));
+        mbx->enableCoE(dev.dictionary);     // dev owns the OD; injected into both
         sl->setMailbox(mbx.get());
+        sl->setDictionary(&dev.dictionary);
     }
 
     std::vector<uint8_t> input_pdo(PDO_MAX_SIZE);
@@ -93,7 +94,9 @@ static Reached bootDevice(ESI::Device& dev, nanoseconds wait_timeout)
     std::vector<uint8_t> io_buffer(16384);
     try
     {
-        bus.init(100ms);
+        bus.init(0ms);  // disable the process-data watchdog: this harness tests bootability,
+                        // not watchdog timing, and a wall-clock watchdog makes OP non-deterministic
+                        // under parallel CPU contention (slaves bounce OP->SAFE_OP).
         if (bus.slaves().size() != 1)
         {
             return Reached::INIT_FAIL;

--- a/test/integration/bench/esi_boot.cc
+++ b/test/integration/bench/esi_boot.cc
@@ -94,9 +94,8 @@ static Reached bootDevice(ESI::Device& dev, nanoseconds wait_timeout)
     std::vector<uint8_t> io_buffer(16384);
     try
     {
-        bus.init(0ms);  // disable the process-data watchdog: this harness tests bootability,
-                        // not watchdog timing, and a wall-clock watchdog makes OP non-deterministic
-                        // under parallel CPU contention (slaves bounce OP->SAFE_OP).
+        bus.init(100ms);  // process-data watchdog enabled and now deterministic: it only monitors
+                          // slaves that have outputs, so input-only terminals no longer bounce.
         if (bus.slaves().size() != 1)
         {
             return Reached::INIT_FAIL;

--- a/unit/src/EmulatedESC-t.cc
+++ b/unit/src/EmulatedESC-t.cc
@@ -329,7 +329,7 @@ TEST(EmulatedESC, ecat_fmmu_out_of_bounds_is_skipped)
     fmmu.logical_address  = 0x2000;
     fmmu.length           = 16;
     fmmu.logical_stop_bit = 0x7;
-    fmmu.physical_address = 0x0800;   // below the process-data RAM window -> invalid
+    fmmu.physical_address = 0xFFF8;   // 0xFFF8 + 16 runs past the 0x10000 memory map
     fmmu.activate         = 1;
     esc.write(reg::FMMU + 0x00, &fmmu, sizeof(fmmu::Register));
 
@@ -345,6 +345,61 @@ TEST(EmulatedESC, ecat_fmmu_out_of_bounds_is_skipped)
     wkc = 0;
     esc.processDatagram(&header, &buf, &wkc);
     ASSERT_EQ(wkc, 0);
+}
+
+TEST(EmulatedESC, ecat_fmmu_maps_register_bit)
+{
+    // A single-bit FMMU into register space (physical < 0x1000) is how a master maps
+    // an SM mailbox-status bit into the logical image; the generic engine handles it
+    // with no dedicated path.
+    EmulatedESC esc;
+
+    uint8_t current = State::PRE_OP;
+    esc.write(reg::AL_STATUS, &current, 1);
+    uint8_t next = State::SAFE_OP;
+    esc.write(reg::AL_CONTROL, &next, 1);
+
+    fmmu::Register fmmu;
+    memset(&fmmu, 0, sizeof(fmmu::Register));
+    fmmu.type  = 1;                 // read access (slave -> master)
+    fmmu.logical_address    = 0x2000;
+    fmmu.length             = 1;
+    fmmu.logical_start_bit  = 2;    // land the bit at logical bit 2
+    fmmu.logical_stop_bit   = 2;
+    fmmu.physical_address   = reg::SYNC_MANAGER_1 + reg::SM_STATS;
+    fmmu.physical_start_bit = 3;    // SM mailbox-full status bit
+    fmmu.activate           = 1;
+    esc.write(reg::FMMU + 0x00, &fmmu, sizeof(fmmu::Register));
+
+    DatagramHeader header{Command::BRD, 0, 0, sizeof(uint64_t), 0, 0, 0, 0};
+    uint64_t buf = 0;
+    uint16_t wkc = 0;
+    esc.processDatagram(&header, &buf, &wkc);
+
+    // Set the source register bit, then read it through the FMMU.
+    uint8_t status = 0;
+    esc.read(reg::SYNC_MANAGER_1 + reg::SM_STATS, &status, 1);
+    status |= (1 << 3);
+    esc.write(reg::SYNC_MANAGER_1 + reg::SM_STATS, &status, 1);
+
+    uint8_t frame = 0x00;
+    header.command = Command::LRD;
+    header.address = 0x2000;
+    header.len     = 1;
+    wkc = 0;
+    esc.processDatagram(&header, &frame, &wkc);
+    ASSERT_EQ(wkc, 1);
+    ASSERT_EQ(frame & (1 << 2), (1 << 2));   // register bit 3 -> logical bit 2
+
+    // Clear it and confirm the mapped bit follows.
+    status &= ~(1 << 3);
+    esc.write(reg::SYNC_MANAGER_1 + reg::SM_STATS, &status, 1);
+    frame = 0xFF;
+    header.address = 0x2000;
+    wkc = 0;
+    esc.processDatagram(&header, &frame, &wkc);
+    ASSERT_EQ(wkc, 1);
+    ASSERT_EQ(frame & (1 << 2), 0);
 }
 
 TEST(EmulatedESC, ecat_frmw_reads_reference_clock)

--- a/unit/src/EmulatedESC-t.cc
+++ b/unit/src/EmulatedESC-t.cc
@@ -480,33 +480,51 @@ TEST(LoopbackSocket, runs_frame_through_slave_and_ticks)
     ASSERT_EQ(*wkc, 1);
 }
 
+static void configureOutputFmmuAndEnterSafeOP(EmulatedESC& esc, uint8_t fmmu_type)
+{
+    uint8_t pre_op = State::PRE_OP;
+    esc.write(reg::AL_STATUS, &pre_op, 1);
+    uint8_t safe_op = State::SAFE_OP;
+    esc.write(reg::AL_CONTROL, &safe_op, 1);
+
+    fmmu::Register fmmu;
+    memset(&fmmu, 0, sizeof(fmmu::Register));
+    fmmu.type             = fmmu_type;   // 2 = output (master->slave), 1 = input
+    fmmu.logical_address  = 0x2000;
+    fmmu.length           = 1;
+    fmmu.logical_stop_bit = 0x7;
+    fmmu.physical_address = 0x1000;
+    fmmu.activate         = 1;
+    esc.write(reg::FMMU + 0x00, &fmmu, sizeof(fmmu::Register));
+}
+
 TEST(EmulatedESC, watchdog)
 {
     EmulatedESC esc;
     uint16_t wkc = 0;
     DatagramHeader header{Command::NOP, 0, 0, 0, 0, 0, 0, 0};
 
-    // Configure Watchdog
-    // Divider: 100us (2498 + 2) * 40ns = 2500 * 40ns = 100,000ns = 100us
+    // The process-data watchdog monitors outputs, so an output FMMU must be configured (and
+    // the PRE_OP->SAFE_OP transition run) before it is armed.
+    configureOutputFmmuAndEnterSafeOP(esc, 2);
+
+    // Divider: (2498 + 2) * 40ns = 100us. Watchdog Time PDO: 100 * 100us = 10ms.
     uint16_t divider = 2498;
     esc.write(reg::WDG_DIVIDER, &divider, 2);
-
-    // Watchdog Time PDO: 100 units of 100us = 10ms
     uint16_t wdg_time = 100;
     esc.write(reg::WDG_TIME_PDO, &wdg_time, 2);
 
-    // Trigger processInternalLogic
-    esc.processDatagram(&header, nullptr, &wkc);
+    esc.processDatagram(&header, nullptr, &wkc);  // runs configureFmmus + arms the watchdog
+
+    uint8_t safe_op = State::SAFE_OP;             // settle AL_STATUS so configureFmmus runs only once
+    esc.write(reg::AL_STATUS, &safe_op, 1);
 
     uint16_t status = 0;
     esc.read(reg::WDOG_STATUS, &status, 2);
+    EXPECT_EQ(status & 0x01, 1);  // SPEC: bit 0 of 0x0440 is 1 if OK, 0 if expired
 
-    // SPEC: Bit 0 of 0x0440 is 1 if OK, 0 if expired.
-    EXPECT_EQ(status & 0x01, 1);
-
-    // Advance time beyond 10ms
-    // since_epoch() increments by 1ms per call in unit tests.
-    for(int i = 0; i < 20; ++i)
+    // since_epoch() advances 1ms per call in unit tests; 20 cycles exceeds the 10ms window.
+    for (int i = 0; i < 20; ++i)
     {
         esc.processDatagram(&header, nullptr, &wkc);
     }
@@ -517,5 +535,34 @@ TEST(EmulatedESC, watchdog)
     uint8_t counter = 0;
     esc.read(reg::WDOG_COUNTER_PDO, &counter, 1);
     EXPECT_GT(counter, 0);
+}
+
+TEST(EmulatedESC, watchdog_inactive_without_outputs)
+{
+    // An input-only terminal has no output FMMU, so the process-data watchdog never fires
+    // (it monitors output delivery). Without this, every digital-input slave bounces to SAFE_OP.
+    EmulatedESC esc;
+    uint16_t wkc = 0;
+    DatagramHeader header{Command::NOP, 0, 0, 0, 0, 0, 0, 0};
+
+    configureOutputFmmuAndEnterSafeOP(esc, 1);  // input FMMU only
+
+    uint16_t divider = 2498;
+    esc.write(reg::WDG_DIVIDER, &divider, 2);
+    uint16_t wdg_time = 100;
+    esc.write(reg::WDG_TIME_PDO, &wdg_time, 2);
+
+    for (int i = 0; i < 30; ++i)
+    {
+        esc.processDatagram(&header, nullptr, &wkc);
+    }
+
+    uint16_t status = 0;
+    esc.read(reg::WDOG_STATUS, &status, 2);
+    EXPECT_EQ(status & 0x01, 1);  // still healthy: no outputs to monitor
+
+    uint8_t counter = 0;
+    esc.read(reg::WDOG_COUNTER_PDO, &counter, 1);
+    EXPECT_EQ(counter, 0);
 }
 

--- a/unit/src/mailbox/CoE/response-t.cc
+++ b/unit/src/mailbox/CoE/response-t.cc
@@ -109,10 +109,12 @@ class CoE_Response : public ::testing::Test
 public:
     void SetUp() override
     {
-        mbx.enableCoE(std::move(createTestDictionary()));
+        dict = createTestDictionary();
+        mbx.enableCoE(dict);
     }
 
     MockESC esc;
+    CoE::Dictionary dict{};  // declared before mbx so it outlives the reference
     Mailbox mbx{&esc, TEST_MAILBOX_SIZE, 1};
 };
 
@@ -356,7 +358,7 @@ TEST_F(CoE_Response, SDO_read_non_expedited)
         CoE::addEntry<uint64_t>(object, 0, 64, 0, CoE::Access::READ, static_cast<CoE::DataType>(0x001B), "Large Entry", large_data);
         dict.push_back(std::move(object));
     }
-    mbx.enableCoE(std::move(dict));
+    mbx.enableCoE(dict);
 
     std::vector<uint8_t> raw_message = createTestReadSDO(0x8000, 0);
     auto response_msg = createSDOMessage(&mbx, std::move(raw_message));
@@ -396,7 +398,7 @@ TEST_F(CoE_Response, SDO_write_non_expedited)
         CoE::addEntry<uint64_t>(object, 0, 64, 0, CoE::Access::WRITE, static_cast<CoE::DataType>(0x001B), "Large Entry", large_data);
         dict.push_back(std::move(object));
     }
-    mbx.enableCoE(std::move(dict));
+    mbx.enableCoE(dict);
 
     // Create a non-expedited download message
     std::vector<uint8_t> raw_message(TEST_MAILBOX_SIZE, 0);
@@ -454,7 +456,7 @@ TEST_F(CoE_Response, SDO_read_unauthorized)
         CoE::addEntry<uint32_t>(object, 0, 32, 0, CoE::Access::WRITE, static_cast<CoE::DataType>(7), "Write Only", 0);
         dict.push_back(std::move(object));
     }
-    mbx.enableCoE(std::move(dict));
+    mbx.enableCoE(dict);
 
     std::vector<uint8_t> raw_message = createTestReadSDO(0x9000, 0);
     auto response_msg = createSDOMessage(&mbx, std::move(raw_message));
@@ -558,7 +560,7 @@ TEST_F(CoE_Response, SDO_read_CA_unauthorized_entry)
         CoE::addEntry<uint32_t>(object, 2, 32, 40, CoE::Access::WRITE, static_cast<CoE::DataType>(7), "Write Only", 0);
         dict.push_back(std::move(object));
     }
-    mbx.enableCoE(std::move(dict));
+    mbx.enableCoE(dict);
 
     std::vector<uint8_t> raw_message = createTestReadSDO(0xA000, 0, true);
     auto response_msg = createSDOMessage(&mbx, std::move(raw_message));
@@ -596,7 +598,7 @@ TEST_F(CoE_Response, SDO_write_CA_unauthorized_entry)
         CoE::addEntry<uint32_t>(object, 2, 32, 40, CoE::Access::WRITE, static_cast<CoE::DataType>(7), "Write Only", 0);
         dict.push_back(std::move(object));
     }
-    mbx.enableCoE(std::move(dict));
+    mbx.enableCoE(dict);
 
     uint32_t data[3] = {5, 0x11111111, 0x22222222};
     uint32_t data_size = sizeof(data);
@@ -1062,7 +1064,7 @@ TEST(CoE_Roundtrip, sdo_segmented_upload_master_slave)
     }
 
     Mailbox slave{MBX, 1};
-    slave.enableCoE(std::move(dict));
+    slave.enableCoE(dict);
 
     mailbox::request::Mailbox master;
     master.recv_size = MBX;
@@ -1113,7 +1115,7 @@ TEST(CoE_Roundtrip, sdo_segmented_download_master_slave)
     }
 
     Mailbox slave{MBX, 1};
-    slave.enableCoE(std::move(dict));
+    slave.enableCoE(dict);
 
     mailbox::request::Mailbox master;
     master.recv_size = MBX;

--- a/unit/src/mailbox/response-t.cc
+++ b/unit/src/mailbox/response-t.cc
@@ -35,7 +35,8 @@ class Mailbox_Response : public ::testing::Test
 public:
     void SetUp() override
     {
-        mbx.enableCoE(createResponseTestDictionary());
+        dict = createResponseTestDictionary();
+        mbx.enableCoE(dict);
 
         EXPECT_CALL(esc, read(reg::SYNC_MANAGER + sizeof(SyncManager::Register) * 0, _, sizeof(SyncManager::Register)))
             .WillRepeatedly(DoAll(
@@ -82,6 +83,7 @@ public:
     MockESC esc;
     SyncManager::Register sm_in {RESP_MBX_IN_ADDR,  RESP_MBX_SIZE, SM_CONTROL_MODE_MAILBOX | SM_CONTROL_DIRECTION_READ,  0, SM_ACTIVATE_ENABLE, 0};
     SyncManager::Register sm_out{RESP_MBX_OUT_ADDR, RESP_MBX_SIZE, SM_CONTROL_MODE_MAILBOX | SM_CONTROL_DIRECTION_WRITE, 0, SM_ACTIVATE_ENABLE, 0};
+    CoE::Dictionary dict{};  // declared before mbx so it outlives the reference
     Mailbox mbx{&esc, RESP_MBX_SIZE, 2};
 };
 
@@ -389,7 +391,8 @@ class Mailbox_Response_Standalone : public ::testing::Test
 public:
     void SetUp() override
     {
-        mbx.enableCoE(createResponseTestDictionary());
+        dict = createResponseTestDictionary();
+        mbx.enableCoE(dict);
     }
 
     std::vector<uint8_t> buildRawSDORead(uint16_t index, uint8_t subindex)
@@ -403,6 +406,7 @@ public:
         return raw;
     }
 
+    CoE::Dictionary dict{};  // declared before mbx so it outlives the reference
     Mailbox mbx{RESP_MBX_SIZE, 2};
 };
 

--- a/unit/src/masterOD-gateway-t.cc
+++ b/unit/src/masterOD-gateway-t.cc
@@ -33,11 +33,13 @@ public:
     void SetUp() override
     {
         MasterOD od(testIdentity());
-        mbx.enableCoE(od.createDictionary());
+        dict_ = od.createDictionary();
+        mbx.enableCoE(dict_);
         bus.setMasterMailbox(&mbx);
     }
 
     std::shared_ptr<MockLink> link{std::make_shared<MockLink>()};
+    CoE::Dictionary dict_{};  // declared before mbx so it outlives the reference
     mailbox::response::Mailbox mbx{MBX_SIZE};
     Bus bus{link};
 };

--- a/unit/src/masterOD-t.cc
+++ b/unit/src/masterOD-t.cc
@@ -61,9 +61,11 @@ public:
     void SetUp() override
     {
         MasterOD od(defaultIdentity());
-        mbx.enableCoE(od.createDictionary());
+        dict_ = od.createDictionary();
+        mbx.enableCoE(dict_);
     }
 
+    CoE::Dictionary dict_{};  // declared before mbx so it outlives the reference
     mailbox::response::Mailbox mbx{MBX_SIZE};
 };
 
@@ -221,8 +223,9 @@ TEST_F(MasterODTest, optional_strings_omitted_when_empty)
     minimal.vendor_id = 0x42;
     MasterOD od_minimal(minimal);
 
+    CoE::Dictionary dict_minimal = od_minimal.createDictionary();
     mailbox::response::Mailbox mbx_minimal{MBX_SIZE};
-    mbx_minimal.enableCoE(od_minimal.createDictionary());
+    mbx_minimal.enableCoE(dict_minimal);
 
     // 0x1008 should not exist
     auto reply = mbx_minimal.processRequest(buildSDOUpload(0x1008, 0));
@@ -278,7 +281,7 @@ TEST(MasterODPopulate, creates_config_objects_from_sii)
     od.populate(dict, slaves);
 
     mailbox::response::Mailbox mbx{MBX_SIZE};
-    mbx.enableCoE(std::move(dict));
+    mbx.enableCoE(dict);
 
     auto const& configs = od.configurationData();
     ASSERT_EQ(2u, configs.size());
@@ -329,7 +332,7 @@ TEST(MasterODPopulate, hole_subindex_aborts_cleanly)
     od.populate(dict, slaves);
 
     mailbox::response::Mailbox mbx{MBX_SIZE};
-    mbx.enableCoE(std::move(dict));
+    mbx.enableCoE(dict);
 
     for (uint8_t hole : {uint8_t{9}, uint8_t{32}, uint8_t{41}})
     {
@@ -371,7 +374,7 @@ TEST(MasterODPopulate, entry_pointers_survive_dictionary_move)
     od.populate(dict, slaves);
 
     mailbox::response::Mailbox mbx{MBX_SIZE};
-    mbx.enableCoE(std::move(dict));
+    mbx.enableCoE(dict);
 
     auto const& configs = od.configurationData();
     ASSERT_EQ(2u, configs.size());
@@ -395,7 +398,7 @@ TEST(MasterODPopulate, number_of_entries_is_highest_supported_subindex)
     od.populate(dict, slaves);
 
     mailbox::response::Mailbox mbx{MBX_SIZE};
-    mbx.enableCoE(std::move(dict));
+    mbx.enableCoE(dict);
 
     auto reply = mbx.processRequest(buildSDOUpload(0x8000, 0));
     ASSERT_FALSE(reply.empty());
@@ -426,7 +429,7 @@ TEST(MasterODPopulate, optional_subindices_exist_with_defaults)
     od.populate(dict, slaves);
 
     mailbox::response::Mailbox mbx{MBX_SIZE};
-    mbx.enableCoE(std::move(dict));
+    mbx.enableCoE(dict);
 
     // :02 Type — from SII general order string
     auto reply_type = mbx.processRequest(buildSDOUpload(0x8000, 2));
@@ -483,7 +486,7 @@ TEST(MasterODPopulate, mandatory_subindices_from_spec)
     od.populate(dict, slaves);
 
     mailbox::response::Mailbox mbx{MBX_SIZE};
-    mbx.enableCoE(std::move(dict));
+    mbx.enableCoE(dict);
 
     // :03 Name
     auto reply_name = mbx.processRequest(buildSDOUpload(0x8000, 3));
@@ -535,7 +538,7 @@ TEST(MasterODPopulate, name_falls_back_when_sii_has_no_string)
     od.populate(dict, slaves);
 
     mailbox::response::Mailbox mbx{MBX_SIZE};
-    mbx.enableCoE(std::move(dict));
+    mbx.enableCoE(dict);
 
     auto reply0 = mbx.processRequest(buildSDOUpload(0x8000, 3));
     auto reply1 = mbx.processRequest(buildSDOUpload(0x8001, 3));

--- a/unit/src/slave/PDO-t.cc
+++ b/unit/src/slave/PDO-t.cc
@@ -55,6 +55,8 @@ public:
         pdo_.setInput(input_, PDO_SIZE);
         pdo_.setOutput(output_, PDO_SIZE);
         setupSmReads();
+        // configureMapping needs the SM resolved by configure(); production maps after it too.
+        pdo_.configure();
     }
 
     void setupSmReads()
@@ -68,10 +70,11 @@ public:
                     Return(sizeof(SyncManager::Register))));
         };
 
+        // Conventional layout: SM2 = outputs (0x1C12), SM3 = inputs (0x1C13).
         setupSm(0, sm_mbx_in_);
         setupSm(1, sm_mbx_out_);
-        setupSm(2, sm_pdo_in_);
-        setupSm(3, sm_pdo_out_);
+        setupSm(2, sm_pdo_out_);
+        setupSm(3, sm_pdo_in_);
         setupSm(4, sm_empty_);
 
         // PDI control byte used by activateSm/deactivateSm:
@@ -131,8 +134,8 @@ TEST_F(PDOTest, configure_input_only_leaves_output_unused)
 {
     // Input-only terminal (e.g. a digital input like EL1008): no buffered-write SM.
     // configure must still succeed; the output direction stays Unused.
-    SyncManager::Register empty{};  // index 3 (output) replaced by an empty SM
-    ON_CALL(esc_, read(static_cast<uint16_t>(reg::SYNC_MANAGER + sizeof(SyncManager::Register) * 3), _, sizeof(SyncManager::Register)))
+    SyncManager::Register empty{};  // SM2 (output) replaced by an empty SM
+    ON_CALL(esc_, read(static_cast<uint16_t>(reg::SYNC_MANAGER + sizeof(SyncManager::Register) * 2), _, sizeof(SyncManager::Register)))
         .WillByDefault(DoAll(
             Invoke([empty](uint16_t, void *ptr, uint16_t)
                    { std::memcpy(ptr, &empty, sizeof(SyncManager::Register)); }),
@@ -159,7 +162,7 @@ TEST_F(PDOTest, isConfigOk_invalid_input_length_mismatch)
     configurePdo();
     SyncManager::Register bad = sm_pdo_in_;
     bad.length = PDO_SIZE + 1;
-    ON_CALL(esc_, read(static_cast<uint16_t>(reg::SYNC_MANAGER + sizeof(SyncManager::Register) * 2), _, sizeof(SyncManager::Register)))
+    ON_CALL(esc_, read(static_cast<uint16_t>(reg::SYNC_MANAGER + sizeof(SyncManager::Register) * 3), _, sizeof(SyncManager::Register)))
         .WillByDefault(DoAll(
             Invoke([bad](uint16_t, void *ptr, uint16_t)
                    { std::memcpy(ptr, &bad, sizeof(SyncManager::Register)); }),
@@ -172,7 +175,7 @@ TEST_F(PDOTest, isConfigOk_invalid_output_length_mismatch)
     configurePdo();
     SyncManager::Register bad = sm_pdo_out_;
     bad.length = PDO_SIZE + 1;
-    ON_CALL(esc_, read(static_cast<uint16_t>(reg::SYNC_MANAGER + sizeof(SyncManager::Register) * 3), _, sizeof(SyncManager::Register)))
+    ON_CALL(esc_, read(static_cast<uint16_t>(reg::SYNC_MANAGER + sizeof(SyncManager::Register) * 2), _, sizeof(SyncManager::Register)))
         .WillByDefault(DoAll(
             Invoke([bad](uint16_t, void *ptr, uint16_t)
                    { std::memcpy(ptr, &bad, sizeof(SyncManager::Register)); }),
@@ -184,44 +187,46 @@ TEST_F(PDOTest, isConfigOk_invalid_output_length_mismatch)
 
 TEST_F(PDOTest, activateOutput_unused_type_no_esc_calls)
 {
-    // Before configure(), sm_output_.type == SyncManager::Unused
+    // Fresh PDO: the fixture configures in SetUp, so test the pre-configure state here.
+    PDO unconfigured{&esc_};
     EXPECT_CALL(esc_, write(_, _, _)).Times(0);
-    pdo_.activateOutput(true);
+    unconfigured.activateOutput(true);
 }
 
 TEST_F(PDOTest, activateInput_unused_type_no_esc_calls)
 {
+    PDO unconfigured{&esc_};
     EXPECT_CALL(esc_, write(_, _, _)).Times(0);
-    pdo_.activateInput(true);
+    unconfigured.activateInput(true);
 }
 
 TEST_F(PDOTest, activateOutput_true_calls_activateSm)
 {
     configurePdo();
-    EXPECT_CALL(esc_, write(smPdiAddr(3), _, sizeof(uint8_t))).Times(1);
+    EXPECT_CALL(esc_, write(smPdiAddr(2), _, sizeof(uint8_t))).Times(1);
     pdo_.activateOutput(true);
 }
 
 TEST_F(PDOTest, activateInput_true_calls_activateSm)
 {
     configurePdo();
-    EXPECT_CALL(esc_, write(smPdiAddr(2), _, sizeof(uint8_t))).Times(1);
+    EXPECT_CALL(esc_, write(smPdiAddr(3), _, sizeof(uint8_t))).Times(1);
     pdo_.activateInput(true);
 }
 
 TEST_F(PDOTest, activateOutput_false_calls_deactivateSm)
 {
     configurePdo();
-    setupDeactivatePdi(3);
-    EXPECT_CALL(esc_, write(smPdiAddr(3), _, sizeof(uint8_t))).Times(1);
+    setupDeactivatePdi(2);
+    EXPECT_CALL(esc_, write(smPdiAddr(2), _, sizeof(uint8_t))).Times(1);
     pdo_.activateOutput(false);
 }
 
 TEST_F(PDOTest, activateInput_false_calls_deactivateSm)
 {
     configurePdo();
-    setupDeactivatePdi(2);
-    EXPECT_CALL(esc_, write(smPdiAddr(2), _, sizeof(uint8_t))).Times(1);
+    setupDeactivatePdi(3);
+    EXPECT_CALL(esc_, write(smPdiAddr(3), _, sizeof(uint8_t))).Times(1);
     pdo_.activateInput(false);
 }
 
@@ -578,4 +583,53 @@ TEST_F(PDOTest, configureMapping_null_old_data_no_memcpy)
     ASSERT_NE(nullptr, entry);
     ASSERT_TRUE(entry->is_mapped);
     ASSERT_EQ(static_cast<void *>(input_), entry->data);
+}
+
+TEST_F(PDOTest, configureMapping_mailboxless_input_on_sm0_uses_0x1C10)
+{
+    // EL1004-class terminal: no mailbox, process input on SM0, so its assignment is at
+    // 0x1C10 (not the mailbox-slave 0x1C13). The mapped entry must still alias the buffer.
+    auto setupSm = [this](int idx, SyncManager::Register const& sm)
+    {
+        ON_CALL(esc_, read(static_cast<uint16_t>(reg::SYNC_MANAGER + sizeof(SyncManager::Register) * idx), _, sizeof(SyncManager::Register)))
+            .WillByDefault(DoAll(
+                Invoke([sm](uint16_t, void* ptr, uint16_t) { std::memcpy(ptr, &sm, sizeof(SyncManager::Register)); }),
+                Return(sizeof(SyncManager::Register))));
+    };
+    SyncManager::Register sm_in_sm0 = makeSM(PDO_IN_ADDR, PDO_SIZE, SM_CONTROL_MODE_BUFFERED | SM_CONTROL_DIRECTION_READ);
+    setupSm(0, sm_in_sm0);
+    setupSm(1, sm_empty_);
+    setupSm(2, sm_empty_);
+    setupSm(3, sm_empty_);
+    setupSm(4, sm_empty_);
+    ASSERT_EQ(0, pdo_.configure());
+
+    CoE::Dictionary dict;
+    {
+        CoE::Object obj{0x6000, CoE::ObjectCode::VAR, "Input", {}};
+        CoE::addEntry<uint16_t>(obj, 0, 16, 0, CoE::Access::READ | CoE::Access::WRITE,
+                                CoE::DataType::UNSIGNED16, "Val", uint16_t{0x1234});
+        dict.push_back(std::move(obj));
+    }
+    {
+        CoE::Object obj{0x1A00, CoE::ObjectCode::RECORD, "TxPDO map", {}};
+        CoE::addEntry<uint8_t> (obj, 0, 8,  0, CoE::Access::READ, CoE::DataType::UNSIGNED8,  "Count", uint8_t{1});
+        CoE::addEntry<uint32_t>(obj, 1, 32, 8, CoE::Access::READ, CoE::DataType::UNSIGNED32, "M1",
+                                makeMappingEntry(0x6000, 0, 16));
+        dict.push_back(std::move(obj));
+    }
+    {
+        CoE::Object obj{0x1C10, CoE::ObjectCode::RECORD, "TxPDO assign", {}};
+        CoE::addEntry<uint8_t> (obj, 0, 8,  0, CoE::Access::READ, CoE::DataType::UNSIGNED8,  "Count", uint8_t{1});
+        CoE::addEntry<uint16_t>(obj, 1, 16, 8, CoE::Access::READ, CoE::DataType::UNSIGNED16, "PDO 1", uint16_t{0x1A00});
+        dict.push_back(std::move(obj));
+    }
+
+    ASSERT_EQ(StatusCode::ECAT_NO_ERROR, pdo_.configureMapping(dict));
+
+    auto [obj2, entry2] = CoE::findObject(dict, 0x6000, 0);
+    ASSERT_NE(nullptr, entry2);
+    ASSERT_TRUE(entry2->is_mapped);
+    ASSERT_EQ(static_cast<void *>(input_), entry2->data);
+    ASSERT_EQ(0x1234, *static_cast<uint16_t *>(entry2->data));
 }

--- a/unit/src/slave/slave-t.cc
+++ b/unit/src/slave/slave-t.cc
@@ -55,6 +55,7 @@ public:
     SyncManager::Register pdo_in_ {PDO_IN_ADDR,  sizeof(buffer_in_),  SM_CONTROL_MODE_BUFFERED | SM_CONTROL_DIRECTION_READ,  0, SM_ACTIVATE_ENABLE, 0};
     SyncManager::Register pdo_out_{PDO_OUT_ADDR, sizeof(buffer_out_), SM_CONTROL_MODE_BUFFERED | SM_CONTROL_DIRECTION_WRITE, 0, SM_ACTIVATE_ENABLE, 0};
 
+    CoE::Dictionary dict_{};  // application-owned OD (declared before mbx_ so it outlives it)
     mailbox::response::Mailbox mbx_{&esc_, MBX_SIZE};
 
     uint16_t al_control_{State::INIT};
@@ -116,9 +117,11 @@ public:
 
     void configureMailbox()
     {
-        mbx_.enableCoE(createTestDictionary());
+        dict_ = createTestDictionary();
+        mbx_.enableCoE(dict_);         // application-owned OD, referenced by the mailbox
         ASSERT_EQ(0, mbx_.configure());
         slave_.setMailbox(&mbx_);
+        slave_.setDictionary(&dict_);  // and injected into the slave for bind / mapping
     }
 
     void configurePdo()
@@ -503,4 +506,65 @@ TEST_F(SlaveTest, bind_different_objects_return_different_pointers)
     ASSERT_NE(nullptr, ptr_a);
     ASSERT_NE(nullptr, ptr_b);
     ASSERT_NE(static_cast<void*>(ptr_a), static_cast<void*>(ptr_b));
+}
+
+
+// --- Mailboxless terminal: an app-owned OD (no mailbox) still maps PDOs ---
+
+TEST_F(SlaveTest, dictionary_without_mailbox_maps_pdo_on_sm0_and_binds)
+{
+    // EL1004-class: no mailbox, process input on SM0 (assignment object 0x1C10). The
+    // application owns the OD and injects it via setDictionary; the slave still reaches
+    // SAFE_OP, maps the entry, and bind() resolves - with no mailbox at all.
+    SyncManager::Register sm_in_sm0{PDO_IN_ADDR, sizeof(buffer_in_),
+        SM_CONTROL_MODE_BUFFERED | SM_CONTROL_DIRECTION_READ, 0, SM_ACTIVATE_ENABLE, 0};
+    SyncManager::Register sm_empty{};
+    auto setSm = [this](int idx, SyncManager::Register const& sm)
+    {
+        ON_CALL(esc_, read(reg::SYNC_MANAGER + sizeof(SyncManager::Register) * idx, _, sizeof(SyncManager::Register)))
+            .WillByDefault(DoAll(
+                Invoke([sm](uint16_t, void* ptr, uint16_t)
+                {
+                    std::memcpy(ptr, &sm, sizeof(SyncManager::Register));
+                }),
+                Return(0)));
+    };
+    setSm(0, sm_in_sm0);
+    setSm(1, sm_empty);
+    setSm(2, sm_empty);
+    setSm(3, sm_empty);
+
+    {
+        CoE::Object obj{0x6000, CoE::ObjectCode::VAR, "Input", {}};
+        CoE::addEntry<uint16_t>(obj, 0, 16, 0, CoE::Access::READ | CoE::Access::WRITE,
+                                CoE::DataType::UNSIGNED16, "Val", uint16_t{0x1234});
+        dict_.push_back(std::move(obj));
+    }
+    {
+        CoE::Object obj{0x1A00, CoE::ObjectCode::RECORD, "TxPDO map", {}};
+        CoE::addEntry<uint8_t> (obj, 0, 8,  0, CoE::Access::READ, CoE::DataType::UNSIGNED8,  "Count", uint8_t{1});
+        CoE::addEntry<uint32_t>(obj, 1, 32, 8, CoE::Access::READ, CoE::DataType::UNSIGNED32, "M1",
+                                (static_cast<uint32_t>(0x6000) << 16) | 16u);
+        dict_.push_back(std::move(obj));
+    }
+    {
+        CoE::Object obj{0x1C10, CoE::ObjectCode::RECORD, "TxPDO assign", {}};
+        CoE::addEntry<uint8_t> (obj, 0, 8,  0, CoE::Access::READ, CoE::DataType::UNSIGNED8,  "Count", uint8_t{1});
+        CoE::addEntry<uint16_t>(obj, 1, 16, 8, CoE::Access::READ, CoE::DataType::UNSIGNED16, "PDO 1", uint16_t{0x1A00});
+        dict_.push_back(std::move(obj));
+    }
+
+    slave_.setDictionary(&dict_);  // app-owned OD, no mailbox
+
+    slave_.start();
+    goToSafeOP();
+
+    auto [obj, entry] = CoE::findObject(dict_, 0x6000, 0);
+    ASSERT_NE(nullptr, entry);
+    ASSERT_TRUE(entry->is_mapped);
+    ASSERT_EQ(static_cast<void*>(buffer_in_), entry->data);
+
+    uint16_t* bound = nullptr;
+    slave_.bind(0x6000, bound);
+    ASSERT_EQ(static_cast<void*>(buffer_in_), static_cast<void*>(bound));
 }


### PR DESCRIPTION
Emulator: one bit-accurate FMMU engine for register and process-data space
Replace the PDO lists with a single Fmmu list and one copy engine: a byte fast path (memcpy, every normal PDO) plus a bit-accurate read-modify-write path for sub-byte mappings.