### PR TITLE
DC robustness fixes

### DIFF
--- a/examples/master/marvin/marvin.cc
+++ b/examples/master/marvin/marvin.cc
@@ -251,6 +251,11 @@ int main(int argc, char *argv[])
             bus.sendLogicalWrite(false_alarm); // Update outputPDO
             bus.processAwaitingFrames();
             bus.finalizeDatagrams();
+
+            if ((i % 1000) == 0)
+            {
+                bus.isDCSynchronized(1000ns);
+            }
         }
         catch (kickcat::ErrorDatagram const& e)
         {
@@ -294,11 +299,6 @@ int main(int argc, char *argv[])
                     printf("  Motor %zu fault: error_code=0x%04x\n", m, motors[m].input->error_code);
                 }
             }
-        }
-
-        if ((i % 1000) == 0)
-        {
-            bus.isDCSynchronized(1000ns);
         }
 
         timer.wait_next_tick();

--- a/lib/include/kickcat/protocol.h
+++ b/lib/include/kickcat/protocol.h
@@ -375,11 +375,8 @@ namespace kickcat
         uint8_t forwarded[4];
         uint8_t malformed_frame;
         uint8_t pdi;
-        uint16_t spi_pdi;
-        uint16_t uc_pdi;
-        uint16_t avalon_pdi;
-        uint16_t axi_pdi;
-        uint8_t lost_link[4];
+        uint16_t pdi_error_code; // 0x30E:0x30F - interpretation depends on the PDI type
+        uint8_t lost_link[4];    // 0x310:0x313
     } __attribute__((__packed__));
 
     std::string toString(ErrorCounters const& counters);

--- a/lib/master/include/kickcat/Bus.h
+++ b/lib/master/include/kickcat/Bus.h
@@ -129,7 +129,8 @@ namespace kickcat
         /// \details Reads the system time difference register (0x092C) of each DC slave.
         ///          The value converges to zero when the slave is synchronized with the reference clock.
         /// \param  threshold  Maximum acceptable time difference in nanoseconds
-        /// \return true if all DC slaves are synchronized within the given threshold
+        /// \return true if all DC slaves are synchronized within the given threshold,
+        ///         false if any status could not be read (lost frame, invalid working counter)
         bool isDCSynchronized(nanoseconds threshold = 1000ns, bool log_all = false);
 
 

--- a/lib/master/src/dc.cc
+++ b/lib/master/src/dc.cc
@@ -485,7 +485,11 @@ namespace kickcat
         nanoseconds now = since_ecat_epoch();
         uint64_t raw_now = now.count();
         link_->addDatagram(Command::FPWR, createAddress(dc_slave_->address, reg::DC_SYSTEM_TIME), &raw_now, sizeof(uint64_t), process, error);
-        link_->addDatagram(Command::FRMW, createAddress(dc_slave_->address, reg::DC_SYSTEM_TIME), nullptr,  sizeof(uint64_t), process, error);
+
+        // Slaves not matching the FRMW address write the payload to their own clock. Pre-fill it
+        // with master time: slaves cut from the reference by a ring split track master time instead
+        // of being slammed to zero by the redundancy frame copy.
+        link_->addDatagram(Command::FRMW, createAddress(dc_slave_->address, reg::DC_SYSTEM_TIME), &raw_now, sizeof(uint64_t), process, error);
     }
 
 
@@ -503,9 +507,22 @@ namespace kickcat
         };
         std::vector<DCSlaveSync> dc_syncs;
 
-        auto error = [](DatagramState const& state)
+        // process callbacks keep references into dc_syncs: no reallocation allowed past this point
+        size_t dc_slaves_count = 0;
+        for (auto const& slave : slaves_)
         {
-            THROW_ERROR_DATAGRAM("Error while reading DC sync status", state);
+            if (slave.isDCSupport() and &slave != dc_slave_)
+            {
+                ++dc_slaves_count;
+            }
+        }
+        dc_syncs.reserve(dc_slaves_count);
+
+        bool datagram_error = false;
+        auto error = [&datagram_error](DatagramState const& state)
+        {
+            dc_error("DC sync status: datagram %s\n", toString(state));
+            datagram_error = true;
         };
 
         for (auto& slave : slaves_)
@@ -532,7 +549,7 @@ namespace kickcat
         }
         link_->processDatagrams();
 
-        bool synchronized = true;
+        bool synchronized = not datagram_error;
         for (auto const& sync : dc_syncs)
         {
             // DC_SYSTEM_TIME_DIFF uses sign-magnitude encoding (bit 31 = sign, bits 30:0 = magnitude)

--- a/lib/src/Frame.cc
+++ b/lib/src/Frame.cc
@@ -109,11 +109,23 @@ namespace kickcat
                 case Command::APRD:
                 case Command::FPRD:
                 case Command::LRD:
-                case Command::FRMW:
-                case Command::ARMW:
                 {
                     // no-op or read only command: clear the area
                     std::memset(pos, 0, data_size);
+                    break;
+                }
+                case Command::FRMW:
+                case Command::ARMW:
+                {
+                    // non-matching slaves write the payload to memory: keep caller data when provided
+                    if (data == nullptr)
+                    {
+                        std::memset(pos, 0, data_size);
+                    }
+                    else
+                    {
+                        std::memcpy(pos, data, data_size);
+                    }
                     break;
                 }
                 default:


### PR DESCRIPTION
- isDCSynchronized: reserve dc_syncs before queuing datagrams. The process callbacks capture references into the vector; push_back reallocation left them dangling (use-after-free writes on every call with 2+ DC slaves).
- isDCSynchronized: report a lost frame or invalid working counter as "not synchronized" instead of throwing from a status query.
- sendDriftCompensation: pre-fill the FRMW payload with master time. Slaves not matching the FRMW address write the payload to their clock, so on a split ring the redundancy copy was writing system time 0 into every tail-segment slave each cycle.
- ErrorCounters: 0x30E:0x30F is a single PDI error code register whose interpretation depends on the PDI type (ESC datasheet sec2 2.9.5); laying out the four interpretations sequentially shifted lost_link to 0x316 while ESCs define it at 0x310:0x313.
- marvin: run the periodic DC sync check inside the try block so a single lost frame no longer terminates the process.