### PR TITLE
Redundancy correctness fixes

### DIFF
--- a/lib/include/kickcat/Frame.h
+++ b/lib/include/kickcat/Frame.h
@@ -41,7 +41,7 @@ namespace kickcat
 
         /// \brief helper to get access on next datagram
         /// \return a tuple with a pointer on the datagram header, a pointer on the datagram data, the working counter
-        std::tuple<DatagramHeader const*, uint8_t*, uint16_t> nextDatagram();
+        std::tuple<DatagramHeader*, uint8_t*, uint16_t> nextDatagram();
 
         /// \brief helper to peek on a datagram while advancing internal pointer to the next one.
         /// \details This API is designed for network simulation.

--- a/lib/include/kickcat/LoopbackSocket.h
+++ b/lib/include/kickcat/LoopbackSocket.h
@@ -39,8 +39,13 @@ namespace kickcat
         {
             Frame frame;
             std::memcpy(frame.data(), data, static_cast<size_t>(size));
-            network_.route(frame);
+            bool delivered = network_.route(frame);
             tick_();
+            if (not delivered)
+            {
+                pending_ = false; // frame destroyed by an ESC (circulating flag)
+                return size;
+            }
             std::memcpy(buffer_, frame.data(), static_cast<size_t>(size));
             size_ = size;
             pending_ = true;

--- a/lib/master/include/kickcat/AbstractLink.h
+++ b/lib/master/include/kickcat/AbstractLink.h
@@ -1,13 +1,36 @@
 #ifndef KICKCAT_ABSTRACT_LINK_H
 #define KICKCAT_ABSTRACT_LINK_H
 
+#include <cstdint>
 #include <cstring>
 #include <functional>
+#include <vector>
 
 #include "kickcat/Frame.h"
 
 namespace kickcat
 {
+    /// \brief Payload layout of a mapped logical frame, keyed by its logical address.
+    /// \details Required to splice the two redundancy copies of an LRW datagram: inputs and
+    ///          outputs share logical addresses, so the copies cannot be merged from the
+    ///          command alone.
+    struct LogicalFrameDescription
+    {
+        uint32_t address{0};        // logical address
+        int32_t  logical_size{0};   // full logical address range (PDO + mailbox status bits)
+        int32_t  pdo_size{0};       // process data only
+
+        // Per-slave LRW expectations in bus position order, to attribute each slave to a
+        // ring segment from the per-copy working counters when redundancy splices a frame
+        struct Entry
+        {
+            uint16_t contribution{0};  // expected wkc contribution of this slave on LRW
+            int32_t  input_offset{-1}; // frame offset of its input block, -1 when none
+            int32_t  input_size{0};
+        };
+        std::vector<Entry> entries;
+    };
+
     /// \brief Abstract interface for the EtherCAT link layer.
     /// \details The link layer is responsible for sending and receiving EtherCAT frames on the wire.
     ///          It provides two communication modes:
@@ -33,6 +56,10 @@ namespace kickcat
         virtual void addDatagram(enum Command command, uint32_t address, void const* data, uint16_t data_size,
                                  std::function<DatagramState(DatagramHeader const*, uint8_t const* data, uint16_t wkc)> const& process,
                                  std::function<void(DatagramState const& state)> const& error) = 0;
+
+        /// \brief Provide the layout of the mapped logical frames, replacing any previous one.
+        /// \details Links without redundancy support ignore it.
+        virtual void setLogicalMapping(std::vector<LogicalFrameDescription> const&) {}
 
         /// \brief Convenience overload: queue a datagram with a typed payload.
         template<typename T>

--- a/lib/master/include/kickcat/Bus.h
+++ b/lib/master/include/kickcat/Bus.h
@@ -227,9 +227,8 @@ namespace kickcat
 
         struct PIFrame
         {
-            uint32_t address;               // logical address
-            int32_t  logical_size;          // full logical address range (PDO + mailbox status bits)
-            int32_t  pdo_size;              // process data only (used by LWR)
+            LogicalFrameDescription description;
+
             std::vector<blockIO> inputs;    // slave to master
             std::vector<blockIO> outputs;
             std::vector<MailboxStatusEntry> mailbox_read_status;
@@ -237,6 +236,14 @@ namespace kickcat
 
             // Adjust wkc in case the slave do not have a PDO read but still answer because of the mbx check
             uint16_t mailbox_status_wkc_read_adjust{0};
+
+            // Sum of description entry contributions, so the cyclic LRW check and the
+            // segment attribution cannot drift apart
+            uint16_t expected_lrw_wkc{0};
+
+            // Outgoing payload, zeroed once at mapping time so the gaps between output
+            // blocks never carry residual bytes on the wire
+            std::vector<uint8_t> output_buffer;
         };
         std::vector<PIFrame> pi_frames_; // PI frame description
 

--- a/lib/master/include/kickcat/Link.h
+++ b/lib/master/include/kickcat/Link.h
@@ -10,6 +10,15 @@ namespace kickcat
 {
     class AbstractSocket;
 
+    /// \brief Rebuild a spliced LRW payload in place in data_nominal from the two ring copies.
+    /// \details Slaves are attributed to a segment by accumulating their expected contributions
+    ///          against the prefix copy's wkc.
+    /// \warning On a split ring each copy loops back at the break: data_nominal holds the
+    ///          tail-injected copy (bus-order suffix) and data_redundancy the head-injected
+    ///          copy (bus-order prefix).
+    void mergeSplitLRW(LogicalFrameDescription const& desc, uint8_t* data_nominal, uint8_t const* data_redundancy,
+                       uint16_t wkc_nominal, uint16_t wkc_redundancy);
+
     class Link final : public AbstractLink
     {
         friend class LinkTest;
@@ -32,6 +41,8 @@ namespace kickcat
                          std::function<DatagramState(DatagramHeader const*, uint8_t const* data, uint16_t wkc)> const& process,
                          std::function<void(DatagramState const& state)> const& error) override;
 
+        void setLogicalMapping(std::vector<LogicalFrameDescription> const& mapping) override { logical_mapping_ = mapping; }
+
         void finalizeDatagrams() override;
         void processDatagrams() override;
 
@@ -46,6 +57,13 @@ namespace kickcat
         uint8_t index_head_{0};
         uint8_t sent_frame_{0};
 
+        // Index outside the [index_queue_, index_head_) window: previous-cycle leftover.
+        bool isStale(uint8_t index) const
+        {
+            uint8_t const in_flight = static_cast<uint8_t>(index_head_ - index_queue_);
+            return static_cast<uint8_t>(index - index_queue_) >= in_flight;
+        }
+
         struct Callbacks
         {
             DatagramState status{DatagramState::LOST};
@@ -53,6 +71,8 @@ namespace kickcat
             std::function<void(DatagramState const& state)> error; // May throw exception.
         };
         std::array<Callbacks, 256> callbacks_{};
+
+        std::vector<LogicalFrameDescription> logical_mapping_{}; // Empty: command-based default merge.
 
         struct IRQ
         {
@@ -65,7 +85,7 @@ namespace kickcat
         void read() ;
         void sendFrame() ;
         bool isDatagramAvailable() ;
-        std::tuple<DatagramHeader const*, uint8_t*, uint16_t> nextDatagram() ;
+        std::tuple<DatagramHeader const*, uint8_t*, uint16_t> nextDatagram(bool& dropped_pair) ;
         void addDatagramToFrame(uint8_t index, enum Command command, uint32_t address, void const* data, uint16_t data_size) ;
         void resetFrameContext() ;
         void checkEcatEvents(uint16_t irq);

--- a/lib/master/src/Bus.cc
+++ b/lib/master/src/Bus.cc
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <cstring>
 #include <inttypes.h>
 #include <algorithm>
@@ -524,8 +525,10 @@ namespace kickcat
         // Second step: create 'block I/O' lists for read and write op
         // Note A: offset computing will overlap input and output in the frame (better density and compatibility, more works for master)
         // Note B: a frame cannot handle more than 1486 bytes
-        pi_frames_.resize(1);
-        pi_frames_[0].address = 0;
+        // Full reset: a previous mapping would otherwise leak its block IO lists into this one.
+        pi_frames_.clear();
+        pi_frames_.push_back(PIFrame{});
+        pi_frames_[0].description.address = 0;
         std::vector<std::vector<Slave*>> frame_mbx_slaves(1);
         uint32_t address = 0;
         for (auto& slave : slaves_)
@@ -534,23 +537,27 @@ namespace kickcat
             int32_t size = std::max(slave.input.bsize, slave.output.bsize);
             if ((address + size) > (pi_frames_.size() * MAX_ETHERCAT_PAYLOAD_SIZE)) // do we overflow current frame ?
             {
-                pi_frames_.back().logical_size = address - pi_frames_.back().address; // frame size = current address - frame address
+                auto& desc = pi_frames_.back().description;
+                desc.logical_size = address - desc.address; // frame size = current address - frame address
 
                 // current size will overflow the frame at the current offset: set in on the next frame
                 address = static_cast<uint32_t>(pi_frames_.size()) * MAX_ETHERCAT_PAYLOAD_SIZE;
-                pi_frames_.push_back({address, 0, 0, {}, {}, {}, {}, 0});
+                PIFrame new_frame{};
+                new_frame.description.address = address;
+                pi_frames_.push_back(std::move(new_frame));
                 frame_mbx_slaves.push_back({});
             }
 
             // create block IO entries
+            PIFrame& current_frame = pi_frames_.back();
             if (slave.input.bsize > 0)
             {
-                pi_frames_.back().inputs.push_back ({nullptr, address - pi_frames_.back().address, slave.input.bsize,  &slave});
+                current_frame.inputs.push_back ({nullptr, address - current_frame.description.address, slave.input.bsize,  &slave});
             }
 
             if (slave.output.bsize > 0)
             {
-                pi_frames_.back().outputs.push_back({nullptr, address - pi_frames_.back().address, slave.output.bsize, &slave});
+                current_frame.outputs.push_back({nullptr, address - current_frame.description.address, slave.output.bsize, &slave});
             }
 
             // save mapping offset (need to configure slave FMMU)
@@ -567,12 +574,13 @@ namespace kickcat
         }
 
         // update last frame size
-        pi_frames_.back().logical_size = address - pi_frames_.back().address;
+        auto& last_desc = pi_frames_.back().description;
+        last_desc.logical_size = address - last_desc.address;
 
         // Set pdo_size for all frames (equals logical_size before mailbox status extension)
         for (auto& frame : pi_frames_)
         {
-            frame.pdo_size = frame.logical_size;
+            frame.description.pdo_size = frame.description.logical_size;
         }
 
         // Extend frames with bit-wise mailbox status mappings
@@ -593,7 +601,7 @@ namespace kickcat
                 // PDO input FMMU (FMMU1) is read-direction, and so are mailbox status FMMUs,
                 // so we insert a 3-byte gap between the PDO region and the status region,
                 // and between the read-check and write-check regions when both are active.
-                uint32_t status_offset = static_cast<uint32_t>(frame.pdo_size);
+                uint32_t status_offset = static_cast<uint32_t>(frame.description.pdo_size);
                 constexpr uint32_t FMMU_BYTE_SEPARATION = 3;
 
                 if (mailbox_status_fmmu_ & MailboxStatusFMMU::READ_CHECK)
@@ -626,7 +634,7 @@ namespace kickcat
                     status_offset += write_bytes;
                 }
 
-                frame.logical_size = static_cast<int32_t>(status_offset);
+                frame.description.logical_size = static_cast<int32_t>(status_offset);
 
                 // WKC adjustment: only count slaves that gain a read-direction FMMU
                 // but have no TxPDO (input). Slaves with TxPDO already increment WKC
@@ -642,6 +650,64 @@ namespace kickcat
                 frame.mailbox_status_wkc_read_adjust = adjust;
             }
         }
+
+        for (auto& frame : pi_frames_)
+        {
+            frame.output_buffer.assign(static_cast<size_t>(frame.description.logical_size), 0);
+
+            // Per-slave LRW expectations, indexed by bus position (= position in slaves_)
+            std::vector<LogicalFrameDescription::Entry> by_position(slaves_.size());
+            for (auto const& bio : frame.inputs)
+            {
+                std::ptrdiff_t position = bio.slave - slaves_.data();
+                auto& entry = by_position[position];
+                entry.contribution += 1;
+                entry.input_offset = static_cast<int32_t>(bio.offset);
+                entry.input_size = bio.size;
+            }
+            for (auto const& bio : frame.outputs)
+            {
+                std::ptrdiff_t position = bio.slave - slaves_.data();
+                by_position[position].contribution += 2;
+            }
+
+            // Mailbox status FMMUs add one read increment for slaves without input PDO,
+            // once per slave whichever check directions are enabled
+            std::vector<bool> counted(slaves_.size(), false);
+            auto countMailboxStatus = [&](std::vector<MailboxStatusEntry> const& status_entries)
+            {
+                for (auto const& ms : status_entries)
+                {
+                    std::ptrdiff_t position = ms.slave - slaves_.data();
+                    if ((ms.slave->input.bsize == 0) and (not counted[position]))
+                    {
+                        counted[position] = true;
+                        by_position[position].contribution += 1;
+                    }
+                }
+            };
+            countMailboxStatus(frame.mailbox_read_status);
+            countMailboxStatus(frame.mailbox_write_status);
+
+            frame.description.entries.clear();
+            frame.expected_lrw_wkc = 0;
+            for (auto const& entry : by_position)
+            {
+                if (entry.contribution > 0)
+                {
+                    frame.description.entries.push_back(entry);
+                    frame.expected_lrw_wkc += entry.contribution;
+                }
+            }
+        }
+
+        std::vector<LogicalFrameDescription> descriptions;
+        descriptions.reserve(pi_frames_.size());
+        for (auto const& frame : pi_frames_)
+        {
+            descriptions.push_back(frame.description);
+        }
+        link_->setLogicalMapping(descriptions);
 
         // Validate the client buffer can hold the process image before writing into it.
         std::size_t required = 0;
@@ -718,7 +784,7 @@ namespace kickcat
                 return DatagramState::OK;
             };
 
-            link_->addDatagram(Command::LRD, pi_frame.address, nullptr, static_cast<uint16_t>(pi_frame.logical_size), process, error);
+            link_->addDatagram(Command::LRD, pi_frame.description.address, nullptr, static_cast<uint16_t>(pi_frame.description.logical_size), process, error);
         }
     }
 
@@ -732,9 +798,9 @@ namespace kickcat
 
     void Bus::sendLogicalWrite(std::function<void(DatagramState const&)> const& error)
     {
-        for (auto const& pi_frame : pi_frames_)
+        for (auto& pi_frame : pi_frames_)
         {
-            uint8_t buffer[MAX_ETHERCAT_PAYLOAD_SIZE];
+            uint8_t* buffer = pi_frame.output_buffer.data();
             for (auto const& output : pi_frame.outputs)
             {
                 std::memcpy(buffer + output.offset, output.iomap, output.size);
@@ -749,7 +815,7 @@ namespace kickcat
                 }
                 return DatagramState::OK;
             };
-            link_->addDatagram(Command::LWR, pi_frame.address, buffer, static_cast<uint16_t>(pi_frame.pdo_size), process, error);
+            link_->addDatagram(Command::LWR, pi_frame.description.address, buffer, static_cast<uint16_t>(pi_frame.description.pdo_size), process, error);
         }
 
         if (dc_slave_ != nullptr)
@@ -768,9 +834,9 @@ namespace kickcat
 
     void Bus::sendLogicalReadWrite(std::function<void(DatagramState const&)> const& error)
     {
-        for (auto const& pi_frame : pi_frames_)
+        for (auto& pi_frame : pi_frames_)
         {
-            uint8_t buffer[MAX_ETHERCAT_PAYLOAD_SIZE];
+            uint8_t* buffer = pi_frame.output_buffer.data();
             for (auto const& output : pi_frame.outputs)
             {
                 std::memcpy(buffer + output.offset, output.iomap, output.size);
@@ -778,11 +844,9 @@ namespace kickcat
 
             auto process = [&pi_frame](DatagramHeader const*, uint8_t const* data, uint16_t wkc)
             {
-                uint16_t expected_wkc = static_cast<uint16_t>(pi_frame.inputs.size() + pi_frame.outputs.size() * 2
-                    + pi_frame.mailbox_status_wkc_read_adjust);
-                if (wkc != expected_wkc)
+                if (wkc != pi_frame.expected_lrw_wkc)
                 {
-                    bus_error("Invalid working counter: expected %d, got %d\n", expected_wkc, wkc);
+                    bus_error("Invalid working counter: expected %d, got %d\n", pi_frame.expected_lrw_wkc, wkc);
                     return DatagramState::INVALID_WKC;
                 }
 
@@ -803,7 +867,7 @@ namespace kickcat
                 return DatagramState::OK;
             };
 
-            link_->addDatagram(Command::LRW, pi_frame.address, buffer, static_cast<uint16_t>(pi_frame.logical_size), process, error);
+            link_->addDatagram(Command::LRW, pi_frame.description.address, buffer, static_cast<uint16_t>(pi_frame.description.logical_size), process, error);
         }
 
         if (dc_slave_ != nullptr)
@@ -918,7 +982,7 @@ namespace kickcat
                 {
                     fmmu::Register fmmu;
                     std::memset(&fmmu, 0, sizeof(fmmu::Register));
-                    fmmu.logical_address    = frame.address + entry.byte_offset;
+                    fmmu.logical_address    = frame.description.address + entry.byte_offset;
                     fmmu.length             = 1;
                     fmmu.logical_start_bit  = entry.bit_position;
                     fmmu.logical_stop_bit   = entry.bit_position;

--- a/lib/master/src/Link.cc
+++ b/lib/master/src/Link.cc
@@ -1,5 +1,6 @@
 #include <inttypes.h>
 #include <algorithm>
+#include <cstring>
 
 #include "Link.h"
 
@@ -9,6 +10,48 @@
 
 namespace kickcat
 {
+    void mergeSplitLRW(LogicalFrameDescription const& desc, uint8_t* data_nominal, uint8_t const* data_redundancy,
+                       uint16_t wkc_nominal, uint16_t wkc_redundancy)
+    {
+        if (wkc_redundancy == 0)
+        {
+            return; // nominal copy went through every slave of the frame
+        }
+
+        if (wkc_nominal == 0)
+        {
+            std::memcpy(data_nominal, data_redundancy, static_cast<size_t>(desc.logical_size));
+            return;
+        }
+
+        // Both wkc non-zero <=> split ring. Each copy loops back at the break and returns on the
+        // interface it was injected on, so through Link::read()'s socket crossover data_nominal
+        // is the bus-order suffix and data_redundancy the prefix. Attribution is exact only when
+        // every slave answered; otherwise the wkc check discards the cycle anyway.
+        uint16_t acc = 0;
+        for (auto const& entry : desc.entries)
+        {
+            if (acc >= wkc_redundancy)
+            {
+                break;
+            }
+            acc += entry.contribution;
+            if (entry.input_offset >= 0)
+            {
+                std::memcpy(data_nominal + entry.input_offset, data_redundancy + entry.input_offset,
+                            static_cast<size_t>(entry.input_size));
+            }
+        }
+
+        // Mailbox status bits are inserted at bit granularity over a zero-filled area: OR
+        // rebuilds them whichever segment each slave ended on.
+        for (int32_t i = desc.pdo_size; i < desc.logical_size; ++i)
+        {
+            data_nominal[i] |= data_redundancy[i];
+        }
+    }
+
+
     Link::Link(std::shared_ptr<AbstractSocket> socket_nominal,
                                    std::shared_ptr<AbstractSocket> socket_redundancy,
                                    std::function<void(void)> const& redundancyActivatedCallback,
@@ -69,14 +112,39 @@ namespace kickcat
         sent_frame_ = 0;
         uint16_t irq = 0;
 
+        int32_t stale_budget = waiting_frame;
         for (int32_t i = 0; i < waiting_frame; ++i)
         {
             read();
+            bool stale_frame = false;
+            bool dropped_datagram = false;
             while (isDatagramAvailable())
             {
-                auto [header, data, wkc] = nextDatagram();
+                bool dropped_pair = false;
+                auto [header, data, wkc] = nextDatagram(dropped_pair);
+                dropped_datagram = dropped_datagram or dropped_pair;
+                if (isStale(header->index))
+                {
+                    // Frame from a previous cycle, already reported lost: drop it. Reading it again
+                    // here would corrupt the dispatch of the frames currently being iterated.
+                    stale_frame = true;
+                    continue;
+                }
                 irq |= header->irq; // aggregate IRQ feedbacks
-                callbacks_[header->index].status = callbacks_[header->index].process(header, data, wkc);
+                auto& callback = callbacks_[header->index];
+                if (callback.status == DatagramState::OK)
+                {
+                    continue; // already answered by the other redundancy copy: never downgrade it
+                }
+                callback.status = callback.process(header, data, wkc);
+            }
+
+            if ((stale_frame or dropped_datagram) and (stale_budget > 0))
+            {
+                // A stale or desynchronized frame consumed this read: the expected one may still
+                // be queued behind it.
+                --stale_budget;
+                --i;
             }
         }
 
@@ -95,14 +163,6 @@ namespace kickcat
                     client_exception = std::current_exception();
                 }
             }
-
-            // Attach a callback to handle not THAT lost frames.
-            // -> if a frame suspected to be lost was in fact in the pipe, it is needed to pop it
-            callbacks_[i].process = [&](DatagramHeader const*, uint8_t const*, uint16_t)
-                {
-                    read();
-                    return DatagramState::OK;
-                };
         }
 
         index_queue_ = index_head_;
@@ -240,7 +300,7 @@ namespace kickcat
         {
             for (int32_t i = 0; i < datagrams; ++i)
             {
-                int32_t index = index_head_ - i - 1;
+                uint8_t index = static_cast<uint8_t>(index_head_ - i - 1);
                 callbacks_[index].status = DatagramState::SEND_ERROR;
             }
         }
@@ -287,28 +347,95 @@ namespace kickcat
     }
 
 
-    std::tuple<DatagramHeader const*, uint8_t*, uint16_t> Link::nextDatagram()
+    std::tuple<DatagramHeader const*, uint8_t*, uint16_t> Link::nextDatagram(bool& dropped_pair)
     {
         bool nom = frame_nominal_.isDatagramAvailable();
         bool red = frame_redundancy_.isDatagramAvailable();
 
-        auto [header_nominal, data_nominal, wkc_nominal] = frame_nominal_.nextDatagram();
-        auto [header_redundancy, data_redundancy, wkc_redundancy] = frame_redundancy_.nextDatagram();
-
         // When using the bus without redundancy not nom and red is the used case.
         if (not nom and red)
         {
-            return std::make_tuple(header_redundancy, data_redundancy, wkc_redundancy);
+            return frame_redundancy_.nextDatagram();
         }
 
         if (nom and not red)
         {
+            return frame_nominal_.nextDatagram();
+        }
+
+        auto [header_nominal, data_nominal, wkc_nominal] = frame_nominal_.nextDatagram();
+        auto [header_redundancy, data_redundancy, wkc_redundancy] = frame_redundancy_.nextDatagram();
+
+        if (header_nominal->index != header_redundancy->index)
+        {
+            // Desynchronized sockets (frame lost or delayed on one interface): these are two
+            // unrelated datagrams, merging them would corrupt the dispatch. Keep the earliest
+            // in-window one, drop the other.
+            dropped_pair = true;
+            uint8_t const ahead_nominal = static_cast<uint8_t>(header_nominal->index - index_queue_);
+            uint8_t const ahead_redundancy = static_cast<uint8_t>(header_redundancy->index - index_queue_);
+            if (ahead_redundancy < ahead_nominal)
+            {
+                return std::make_tuple(header_redundancy, data_redundancy, wkc_redundancy);
+            }
             return std::make_tuple(header_nominal, data_nominal, wkc_nominal);
         }
 
-        // all frames have data
-        std::transform(data_nominal, &data_nominal[header_nominal->len], data_redundancy, data_nominal, std::bit_or<uint8_t>());
+        if (isStale(header_nominal->index))
+        {
+            // Stale pair: its merge context may be gone, report it unmerged for the caller to drop.
+            return std::make_tuple(header_nominal, data_nominal, wkc_nominal);
+        }
+
+        // Two copies of the same datagram: each one carries the events and wkc of its own ring segment.
+        header_nominal->irq |= header_redundancy->irq;
         uint16_t wkc = wkc_nominal + wkc_redundancy;
+        switch (header_nominal->command)
+        {
+            case Command::NOP:
+            case Command::BRD:
+            case Command::APRD:
+            case Command::FPRD:
+            case Command::LRD:
+            case Command::BRW:
+            {
+                // Read command: the payload was zeroed at send time, so OR-ing the two copies
+                // rebuilds the data whichever segment each slave answered on. BRW confirmations
+                // are request|slave-data per segment: OR-ing them yields the intact-ring result.
+                std::transform(data_nominal, &data_nominal[header_nominal->len], data_redundancy, data_nominal, std::bit_or<uint8_t>());
+                break;
+            }
+            case Command::LRW:
+            {
+                auto desc = std::find_if(logical_mapping_.begin(), logical_mapping_.end(),
+                    [&](LogicalFrameDescription const& d) { return d.address == header_nominal->address; });
+                if ((desc != logical_mapping_.end()) and (header_nominal->len == desc->logical_size))
+                {
+                    // The length check fences the splice: mergeSplitLRW writes logical_size
+                    // bytes, which only the mapped datagram itself can absorb.
+                    mergeSplitLRW(*desc, data_nominal, data_redundancy, wkc_nominal, wkc_redundancy);
+                    break;
+                }
+                [[fallthrough]]; // LRW outside the mapping: single-segment rule
+            }
+            case Command::APRW:
+            case Command::FPRW:
+            {
+                // Read data is only in the copy whose segment holds the addressed slaves: take
+                // the other copy when the nominal one went through none of them.
+                if ((wkc_nominal == 0) and (wkc_redundancy != 0))
+                {
+                    std::memcpy(data_nominal, data_redundancy, header_nominal->len);
+                }
+                break;
+            }
+            default:
+            {
+                // Write commands echo the sent payload, identical in both copies; ARMW/FRMW read
+                // data cannot be attributed to a copy from the wkc alone. Keep the nominal copy.
+                break;
+            }
+        }
         return std::make_tuple(header_nominal, data_nominal, wkc);
     }
 

--- a/lib/slave/include/kickcat/EmulatedNetwork.h
+++ b/lib/slave/include/kickcat/EmulatedNetwork.h
@@ -48,7 +48,9 @@ namespace kickcat
 
         // Route a received frame through the slaves in physical order. `redundancy`
         // selects the tail injection path (meaningful only when redundancy is set).
-        void route(Frame& frame, bool redundancy = false);
+        // Returns false when an ESC destroyed the frame (circulating flag already set
+        // at a closed port 0): the frame must not be delivered back to the master.
+        bool route(Frame& frame, bool redundancy = false);
 
         size_t size()          const { return slaves_.size(); }
         bool   hasRedundancy() const { return redundancy_node_ != NO_NODE; }
@@ -72,9 +74,27 @@ namespace kickcat
             std::array<Port, PORT_COUNT> ports{};
         };
 
+        // One EPU passage of the frame walk. A passage at a closed port 0 is where real
+        // ESCs handle the circulating flag: set it, or destroy an already-flagged frame.
+        struct Hop
+        {
+            size_t node;
+            bool   port0_closed;
+        };
+
         void buildLine();
         void rebuild();
-        void buildOrder(size_t node, uint8_t entry_port, std::vector<size_t>& order, std::vector<bool>& visited) const;
+        bool isValidInjection(size_t node, uint8_t port) const;
+
+        // Physical frame walk from a master injection point. The EtherCAT processing unit
+        // sits between port 0 and the forwarding chain, so a node processes the frame each
+        // time it proceeds from port 0: entry through port 0, return from the port-0 branch,
+        // or loopback at a closed port 0. Returns true when the frame left the segment
+        // through a master port (recorded in exit_node/exit_port), or when the walk budget
+        // is exhausted - exit_node then keeps its caller-provided value (NO_NODE after
+        // rebuild()).
+        bool walkFrame(size_t node, uint8_t entry_port, std::vector<Hop>& order,
+                       size_t& exit_node, uint8_t& exit_port, size_t& budget) const;
         nanoseconds buildReceiveTimes(size_t node, uint8_t entry_port, nanoseconds t_in, std::vector<bool>& visited);
         void computeDlStatus();
         void writeReceiveTimes(size_t node, nanoseconds base);
@@ -87,8 +107,8 @@ namespace kickcat
         size_t  redundancy_node_ = NO_NODE;
         uint8_t redundancy_port_ = 0;
 
-        std::vector<size_t> order_nominal_;      // node indices in physical processing order
-        std::vector<size_t> order_redundancy_;
+        std::vector<Hop> order_nominal_;         // EPU passages in physical processing order
+        std::vector<Hop> order_redundancy_;
 
         // Per-(node, port) DC receive-time offset and per-node EPU offset, relative
         // to frame entry; combined with a per-latch time base when a frame latches.

--- a/lib/slave/src/EmulatedNetwork.cc
+++ b/lib/slave/src/EmulatedNetwork.cc
@@ -121,26 +121,48 @@ namespace kickcat
         rebuild();
     }
 
-    void EmulatedNetwork::buildOrder(size_t node, uint8_t entry_port, std::vector<size_t>& order,
-                                     std::vector<bool>& visited) const
+    bool EmulatedNetwork::walkFrame(size_t node, uint8_t entry_port, std::vector<Hop>& order,
+                                    size_t& exit_node, uint8_t& exit_port, size_t& budget) const
     {
-        if (visited[node])
+        if (budget == 0)
         {
-            return;
+            return true; // malformed cyclic wiring: stop the walk instead of recursing forever
         }
-        visited[node] = true;
-        order.push_back(node);
+        --budget;
+
+        if (entry_port == 0)
+        {
+            order.push_back({node, false});
+        }
 
         uint8_t start = indexInOrder(entry_port);
         for (uint8_t k = 1; k < PORT_COUNT; ++k)
         {
             uint8_t p = PORT_ORDER[(start + k) % PORT_COUNT];
             Port const& port = nodes_[node].ports[p];
-            if (port.up and (port.peer_node != NO_NODE) and (not visited[port.peer_node]))
+            if (port.to_master)
             {
-                buildOrder(port.peer_node, port.peer_port, order, visited);
+                exit_node = node;
+                exit_port = p;
+                return true; // frame leaves the segment through the master port
+            }
+            if (port.up and (port.peer_node != NO_NODE))
+            {
+                if (walkFrame(port.peer_node, port.peer_port, order, exit_node, exit_port, budget))
+                {
+                    return true;
+                }
+                if (p == 0)
+                {
+                    order.push_back({node, false}); // frame came back into port 0: EPU passage
+                }
+            }
+            else if (p == 0)
+            {
+                order.push_back({node, true}); // closed port 0 loops back through the EPU
             }
         }
+        return false; // frame leaves back through its entry port
     }
 
     nanoseconds EmulatedNetwork::buildReceiveTimes(size_t node, uint8_t entry_port, nanoseconds t_in,
@@ -153,7 +175,10 @@ namespace kickcat
         visited[node] = true;
 
         recv_offset_[node][entry_port] = t_in;
-        epu_offset_[node]              = t_in;
+        if (entry_port == 0)
+        {
+            epu_offset_[node] = t_in; // EPU sits right behind port 0 reception
+        }
 
         nanoseconds const fwd = nodes_[node].esc->forwardingDelay();
         nanoseconds t = t_in + fwd;
@@ -163,13 +188,25 @@ namespace kickcat
         {
             uint8_t p = PORT_ORDER[(start + k) % PORT_COUNT];
             Port const& port = nodes_[node].ports[p];
+            if (port.to_master)
+            {
+                break; // frame leaves the segment: nothing downstream sees it
+            }
             if (port.up and (port.peer_node != NO_NODE) and (not visited[port.peer_node]))
             {
                 t += CABLE_DELAY;
                 nanoseconds t_child_out = buildReceiveTimes(port.peer_node, port.peer_port, t, visited);
                 t = t_child_out + CABLE_DELAY;
                 recv_offset_[node][p] = t;   // frame received back from the child branch
+                if (p == 0)
+                {
+                    epu_offset_[node] = t;   // EPU passage on the way back through port 0
+                }
                 t += fwd;
+            }
+            else if ((p == 0) and ((not port.up) or (port.peer_node == NO_NODE)))
+            {
+                epu_offset_[node] = t;       // closed port 0: loopback through the EPU
             }
         }
         return t;
@@ -198,8 +235,17 @@ namespace kickcat
         }
     }
 
+    bool EmulatedNetwork::isValidInjection(size_t node, uint8_t port) const
+    {
+        // NO_NODE is size_t(-1): the node bound also rejects "no injection".
+        return (node < nodes_.size()) and (port < PORT_COUNT);
+    }
+
     void EmulatedNetwork::rebuild()
     {
+        bool const has_nominal = isValidInjection(injection_node_, injection_port_);
+        bool const has_redundancy = isValidInjection(redundancy_node_, redundancy_port_);
+
         // Master injection points are derived here so connect() only manages wires.
         for (auto& node : nodes_)
         {
@@ -208,39 +254,53 @@ namespace kickcat
                 port.to_master = false;
             }
         }
-        if (injection_node_ != NO_NODE)
+        if (has_nominal)
         {
             nodes_[injection_node_].ports[injection_port_].to_master = true;
         }
-        if (redundancy_node_ != NO_NODE)
+        if (has_redundancy)
         {
             nodes_[redundancy_node_].ports[redundancy_port_].to_master = true;
         }
 
         size_t const n = nodes_.size();
+        // Worst case frame walk: both directions of every port of every node, plus the
+        // injection hop - anything longer means a wiring cycle.
+        size_t const walk_budget = 2 * PORT_COUNT * (n + 1);
 
         order_nominal_.clear();
-        std::vector<bool> visited_order(n, false);
-        buildOrder(injection_node_, injection_port_, order_nominal_, visited_order);
-
         order_redundancy_.clear();
         ring_intact_ = false;
-        if (redundancy_node_ != NO_NODE)
+
+        size_t exit_node = NO_NODE;
+        uint8_t exit_port = 0;
+        if (has_nominal)
         {
-            // Ring is closed when the head injection already reaches the tail port.
-            ring_intact_ = visited_order[redundancy_node_];
-            // The two paths PARTITION the slaves (shared visited set): the redundant
-            // path covers only what the nominal path could not reach. So each slave is
-            // processed by exactly one frame and the master's WKC sum stays correct -
-            // all slaves on the nominal frame when intact, head/tail split on a break.
-            buildOrder(redundancy_node_, redundancy_port_, order_redundancy_, visited_order);
+            size_t budget = walk_budget;
+            walkFrame(injection_node_, injection_port_, order_nominal_, exit_node, exit_port, budget);
+        }
+
+        if (has_redundancy)
+        {
+            // Ring closed <=> the head frame leaves the segment through the tail master port.
+            ring_intact_ = (exit_node == redundancy_node_) and (exit_port == redundancy_port_);
+
+            // With the ring closed the tail frame streams through every slave without an EPU
+            // passage and exits at the head: the walk yields an empty order. On a break each
+            // half is processed by exactly one frame, from the break outward - the partition
+            // keeps the master's summed WKC correct.
+            size_t budget = walk_budget;
+            walkFrame(redundancy_node_, redundancy_port_, order_redundancy_, exit_node, exit_port, budget);
         }
 
         recv_offset_.assign(n, std::array<nanoseconds, PORT_COUNT>{});
         epu_offset_.assign(n, 0ns);
         std::vector<bool> visited_time(n, false);
-        buildReceiveTimes(injection_node_, injection_port_, 0ns, visited_time);
-        if (redundancy_node_ != NO_NODE)
+        if (has_nominal)
+        {
+            buildReceiveTimes(injection_node_, injection_port_, 0ns, visited_time);
+        }
+        if (has_redundancy)
         {
             buildReceiveTimes(redundancy_node_, redundancy_port_, 0ns, visited_time);
         }
@@ -262,20 +322,21 @@ namespace kickcat
         nodes_[node].esc->write(reg::DC_ECAT_RECEIVED_TIME, &epu, sizeof(epu));
     }
 
-    void EmulatedNetwork::route(Frame& frame, bool redundancy)
+    bool EmulatedNetwork::route(Frame& frame, bool redundancy)
     {
         if (dirty_)
         {
             rebuild();
         }
 
-        std::vector<size_t> const* order = &order_nominal_;
+        std::vector<Hop> const* order = &order_nominal_;
         if (redundancy)
         {
             order = &order_redundancy_;
         }
 
         frame.resetContext();
+        bool destroyed = false;
         while (true)
         {
             auto [header, data, wkc] = frame.peekDatagram();
@@ -287,19 +348,36 @@ namespace kickcat
             uint16_t offset = static_cast<uint16_t>(header->address >> 16);
             bool latch = isPhysicalWrite(header->command) and (offset == reg::DC_RECEIVED_TIME);
 
-            for (size_t idx : *order)
+            for (auto const& hop : *order)
             {
-                nodes_[idx].esc->processDatagram(header, data, wkc);
+                if (hop.port0_closed)
+                {
+                    if (header->circulating)
+                    {
+                        // Already circulated once: this ESC destroys the frame. Cut-through
+                        // forwarding means upstream hops still process every datagram.
+                        destroyed = true;
+                        break;
+                    }
+                    header->circulating = 1;
+                }
+                nodes_[hop.node].esc->processDatagram(header, data, wkc);
+            }
+
+            if (destroyed)
+            {
+                continue;
             }
 
             if (latch)
             {
                 nanoseconds base = since_ecat_epoch();
-                for (size_t idx : *order)
+                for (auto const& hop : *order)
                 {
-                    writeReceiveTimes(idx, base);
+                    writeReceiveTimes(hop.node, base);
                 }
             }
         }
+        return not destroyed;
     }
 }

--- a/lib/src/Frame.cc
+++ b/lib/src/Frame.cc
@@ -184,9 +184,9 @@ namespace kickcat
     }
 
 
-    std::tuple<DatagramHeader const*, uint8_t*, uint16_t> Frame::nextDatagram()
+    std::tuple<DatagramHeader*, uint8_t*, uint16_t> Frame::nextDatagram()
     {
-        DatagramHeader const* header = reinterpret_cast<DatagramHeader*>(next_datagram_);
+        DatagramHeader* header = reinterpret_cast<DatagramHeader*>(next_datagram_);
         uint8_t* data = next_datagram_ + sizeof(DatagramHeader);
         uint8_t* wkc_addr = data + header->len;
         uint16_t wkc;

--- a/simulation/network_simulator.cc
+++ b/simulation/network_simulator.cc
@@ -354,7 +354,10 @@ int main(int argc, char* argv[])
         {
             return false;
         }
-        network.route(frame, redundant_path);
+        if (not network.route(frame, redundant_path))
+        {
+            return true; // frame destroyed by an ESC (circulating flag): nothing to send back
+        }
 
         AbstractSocket* out = in;            // broken segment: loop back to the same port
         if (network.ringIntact())

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(kickcat_unit src/adler32_sum-t.cc
                             src/link-t.cc
                             src/prints-t.cc
                             src/protocol-t.cc
+                            src/redundancy-t.cc
                             src/Ring-t.cc
                             src/SBufQueue-t.cc
                             src/slave-t.cc

--- a/unit/mocks/EmulatedNetworkHelpers.h
+++ b/unit/mocks/EmulatedNetworkHelpers.h
@@ -1,0 +1,65 @@
+#ifndef KICKCAT_MOCK_EMULATED_NETWORK_HELPERS_H
+#define KICKCAT_MOCK_EMULATED_NETWORK_HELPERS_H
+
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "kickcat/ESC/EmulatedESC.h"
+
+namespace kickcat
+{
+    inline std::vector<std::unique_ptr<EmulatedESC>> makeSlaves(size_t n)
+    {
+        std::vector<std::unique_ptr<EmulatedESC>> slaves;
+        for (size_t i = 0; i < n; ++i)
+        {
+            slaves.push_back(std::make_unique<EmulatedESC>());
+        }
+        return slaves;
+    }
+
+    inline std::vector<EmulatedESC*> pointers(std::vector<std::unique_ptr<EmulatedESC>> const& slaves)
+    {
+        std::vector<EmulatedESC*> ptrs;
+        for (auto const& s : slaves)
+        {
+            ptrs.push_back(s.get());
+        }
+        return ptrs;
+    }
+
+    // Overlapped mapping like Bus::createMapping: input and output FMMUs share the
+    // same logical range, the layout that makes a spliced LRW impossible to OR.
+    inline void configureOverlappedPdo(EmulatedESC& esc, uint32_t logical_address, uint32_t input_value)
+    {
+        uint8_t current = State::PRE_OP;
+        esc.write(reg::AL_STATUS, &current, 1);
+        uint8_t next = State::SAFE_OP;
+        esc.write(reg::AL_CONTROL, &next, 1);
+
+        fmmu::Register fmmu;
+        std::memset(&fmmu, 0, sizeof(fmmu::Register));
+        fmmu.type               = 2; // master -> slave
+        fmmu.logical_address    = logical_address;
+        fmmu.length             = 4;
+        fmmu.logical_stop_bit   = 0x7;
+        fmmu.physical_address   = 0x1200;
+        fmmu.activate           = 1;
+        esc.write(reg::FMMU + 0x00, &fmmu, sizeof(fmmu::Register));
+
+        fmmu.type             = 1; // slave -> master, same logical range
+        fmmu.physical_address = 0x1100;
+        esc.write(reg::FMMU + 0x10, &fmmu, sizeof(fmmu::Register));
+
+        // Run internal logic so the state machine reaches SAFE_OP and applies the FMMUs
+        DatagramHeader header{Command::BRD, 0, 0, sizeof(uint64_t), 0, 0, 0, 0};
+        uint64_t dummy = 0;
+        uint16_t wkc = 0;
+        esc.processDatagram(&header, &dummy, &wkc);
+
+        esc.write(0x1100, &input_value, sizeof(input_value));
+    }
+}
+
+#endif

--- a/unit/mocks/Link.h
+++ b/unit/mocks/Link.h
@@ -128,6 +128,9 @@ namespace kickcat
 
         void finalizeDatagrams() override {}
 
+        void setLogicalMapping(std::vector<LogicalFrameDescription> const& mapping) override { logical_mapping_ = mapping; }
+        std::vector<LogicalFrameDescription> const& logicalMapping() const { return logical_mapping_; }
+
         void setTimeout(nanoseconds const&) override {}
 
         void checkRedundancyNeeded() override {}
@@ -146,6 +149,7 @@ namespace kickcat
 
         std::vector<PendingDatagram> pending_datagrams_;
         std::queue<QueuedResponse> queued_responses_;
+        std::vector<LogicalFrameDescription> logical_mapping_;
         struct WtrResponse // wtr: writeThenRead
         {
             Command expected_command{};

--- a/unit/src/EmulatedNetwork-t.cc
+++ b/unit/src/EmulatedNetwork-t.cc
@@ -2,34 +2,16 @@
 
 #include <memory>
 
+#include "mocks/EmulatedNetworkHelpers.h"
+
 #include "kickcat/EmulatedNetwork.h"
-#include "kickcat/ESC/EmulatedESC.h"
 #include "kickcat/Frame.h"
+#include "kickcat/Link.h"
 
 using namespace kickcat;
 
 namespace
 {
-    std::vector<std::unique_ptr<EmulatedESC>> makeSlaves(size_t n)
-    {
-        std::vector<std::unique_ptr<EmulatedESC>> slaves;
-        for (size_t i = 0; i < n; ++i)
-        {
-            slaves.push_back(std::make_unique<EmulatedESC>());
-        }
-        return slaves;
-    }
-
-    std::vector<EmulatedESC*> pointers(std::vector<std::unique_ptr<EmulatedESC>> const& slaves)
-    {
-        std::vector<EmulatedESC*> ptrs;
-        for (auto const& s : slaves)
-        {
-            ptrs.push_back(s.get());
-        }
-        return ptrs;
-    }
-
     // Route a single auto-increment write addressed to the k-th visited slave (the
     // exact mechanism the master uses in setAddresses). After routing, the slave at
     // processing position k holds `value`.
@@ -77,6 +59,7 @@ namespace
     bool pl(uint16_t dl, uint8_t port)   { return (dl >> (4 + port)) & 1u; }
     bool com(uint16_t dl, uint8_t port)  { return (dl >> (9 + 2 * port)) & 1u; }
     bool loop(uint16_t dl, uint8_t port) { return (dl >> (8 + 2 * port)) & 1u; }
+
 }
 
 TEST(EmulatedNetwork, line_processing_order_is_array_order)
@@ -197,6 +180,207 @@ TEST(EmulatedNetwork, intact_ring_routes_every_slave_on_the_nominal_path_only)
     }
 }
 
+TEST(EmulatedNetwork, split_ring_lrw_master_merge_rebuilds_inputs)
+{
+    auto slaves = makeSlaves(3);
+    EmulatedNetwork net(pointers(slaves));
+    net.setRedundancyInjection(2, 1);
+
+    for (size_t i = 0; i < slaves.size(); ++i)
+    {
+        configureOverlappedPdo(*slaves[i], static_cast<uint32_t>(i * 8), static_cast<uint32_t>(0xA0B0C000 + i));
+    }
+
+    // Wire break between slave 0 and slave 1: the nominal copy reaches slave 0 only,
+    // the redundancy copy reaches slaves 2 then 1.
+    net.setLinkState(0, 1, false);
+
+    uint8_t outputs[24];
+    for (size_t i = 0; i < sizeof(outputs); ++i)
+    {
+        outputs[i] = static_cast<uint8_t>(0x80 + i);
+    }
+
+    Frame frame_head;
+    frame_head.addDatagram(0, Command::LRW, 0, outputs, sizeof(outputs));
+    frame_head.finalize();
+    net.route(frame_head, false);
+
+    Frame frame_tail;
+    frame_tail.addDatagram(0, Command::LRW, 0, outputs, sizeof(outputs));
+    frame_tail.finalize();
+    net.route(frame_tail, true);
+
+    frame_head.resetContext();
+    auto [header_head, data_head, wkc_head] = frame_head.peekDatagram();
+    frame_tail.resetContext();
+    auto [header_tail, data_tail, wkc_tail] = frame_tail.peekDatagram();
+
+    ASSERT_EQ(3, *wkc_head); // slave 0: read + write
+    ASSERT_EQ(6, *wkc_tail); // slaves 1 and 2
+
+    // Outputs reached the slaves whichever segment they ended on
+    for (size_t i = 0; i < slaves.size(); ++i)
+    {
+        uint32_t out = 0;
+        slaves[i]->read(0x1200, &out, sizeof(out));
+        uint32_t expected = 0;
+        std::memcpy(&expected, outputs + i * 8, sizeof(expected));
+        EXPECT_EQ(expected, out);
+    }
+
+    // Master-side rebuild of the spliced response. On a split each copy loops back to the
+    // interface it was injected on, and Link::read() crosses the sockets: the tail copy is
+    // the merge's data_nominal argument, the head copy its data_redundancy argument.
+    LogicalFrameDescription desc{};
+    desc.logical_size = sizeof(outputs);
+    desc.pdo_size = sizeof(outputs);
+    desc.entries = {{3, 0, 4}, {3, 8, 4}, {3, 16, 4}};
+
+    mergeSplitLRW(desc, data_tail, data_head, *wkc_tail, *wkc_head);
+
+    for (size_t i = 0; i < slaves.size(); ++i)
+    {
+        uint32_t input = 0;
+        std::memcpy(&input, data_tail + i * 8, sizeof(input));
+        EXPECT_EQ(static_cast<uint32_t>(0xA0B0C000 + i), input);
+
+        // The unmapped gap keeps the echoed output payload
+        EXPECT_EQ(0, std::memcmp(data_tail + i * 8 + 4, outputs + i * 8 + 4, 4));
+    }
+}
+
+
+TEST(EmulatedNetwork, intact_ring_sets_no_circulating_flag)
+{
+    auto slaves = makeSlaves(3);
+    EmulatedNetwork net(pointers(slaves));
+    net.setRedundancyInjection(2, 1);
+
+    uint16_t dummy = 0;
+    for (bool redundancy : {false, true})
+    {
+        Frame frame;
+        frame.addDatagram(0, Command::BRD, createAddress(0, reg::TYPE), &dummy, sizeof(dummy));
+        frame.finalize();
+        EXPECT_TRUE(net.route(frame, redundancy));
+
+        frame.resetContext();
+        auto [header, data, wkc] = frame.peekDatagram();
+        EXPECT_EQ(0, header->circulating);
+    }
+}
+
+
+TEST(EmulatedNetwork, split_tail_copy_carries_circulating_flag)
+{
+    auto slaves = makeSlaves(3);
+    EmulatedNetwork net(pointers(slaves));
+    net.setRedundancyInjection(2, 1);
+    net.setLinkState(0, 1, false);
+
+    uint16_t dummy = 0;
+
+    // Head copy loops back at slave 0's closed port 1: no closed-port-0 EPU passage.
+    Frame frame_head;
+    frame_head.addDatagram(0, Command::BRD, createAddress(0, reg::TYPE), &dummy, sizeof(dummy));
+    frame_head.finalize();
+    EXPECT_TRUE(net.route(frame_head, false));
+    frame_head.resetContext();
+    auto [header_head, data_head, wkc_head] = frame_head.peekDatagram();
+    EXPECT_EQ(0, header_head->circulating);
+
+    // Tail copy loops back at slave 1's closed port 0: that EPU passage sets the flag.
+    Frame frame_tail;
+    frame_tail.addDatagram(0, Command::BRD, createAddress(0, reg::TYPE), &dummy, sizeof(dummy));
+    frame_tail.finalize();
+    EXPECT_TRUE(net.route(frame_tail, true));
+    frame_tail.resetContext();
+    auto [header_tail, data_tail, wkc_tail] = frame_tail.peekDatagram();
+    EXPECT_EQ(1, header_tail->circulating);
+    EXPECT_EQ(2, *wkc_tail); // the flag does not prevent processing on this passage
+}
+
+
+TEST(EmulatedNetwork, already_circulating_frame_is_destroyed_at_closed_port0)
+{
+    auto slaves = makeSlaves(3);
+    EmulatedNetwork net(pointers(slaves));
+    net.setRedundancyInjection(2, 1);
+    net.setLinkState(0, 1, false);
+
+    uint16_t value = 0xBEEF;
+    Frame frame;
+    frame.addDatagram(0, Command::BWR, createAddress(0, reg::STATION_ADDR), &value, sizeof(value));
+    frame.finalize();
+    frame.resetContext();
+    auto [header, data, wkc] = frame.peekDatagram();
+    header->circulating = 1;
+
+    EXPECT_FALSE(net.route(frame, true));
+
+    // The destroying ESC sits at the break: no slave of the segment applied the write.
+    for (auto const& s : slaves)
+    {
+        uint16_t addr = 0;
+        s->read(reg::STATION_ADDR, &addr, sizeof(addr));
+        EXPECT_NE(0xBEEF, addr);
+    }
+}
+
+
+TEST(EmulatedNetwork, split_ring_epu_times_follow_redundancy_processing_order)
+{
+    auto slaves = makeSlaves(3);
+    for (auto& s : slaves)
+    {
+        s->setForwardingDelay(100ns);
+    }
+    EmulatedNetwork net(pointers(slaves));
+    net.setRedundancyInjection(2, 1);
+    net.setLinkState(0, 1, false);
+
+    // Latch on the tail path: enters slave 2 at port 1, streams to the break, loops back
+    // at slave 1's closed port 0 and is processed from the break outward.
+    uint8_t dummy = 0;
+    Frame frame;
+    frame.addDatagram(0, Command::BWR, createAddress(0, reg::DC_RECEIVED_TIME), &dummy, sizeof(dummy));
+    frame.finalize();
+    EXPECT_TRUE(net.route(frame, true));
+
+    uint32_t ports[3][4];
+    uint64_t epu[3];
+    for (size_t i = 1; i < 3; ++i)
+    {
+        slaves[i]->read(reg::DC_RECEIVED_TIME, ports[i], sizeof(ports[i]));
+        slaves[i]->read(reg::DC_ECAT_RECEIVED_TIME, &epu[i], sizeof(epu[i]));
+    }
+
+    // Port times follow the stream toward the break, EPU times the processing on the
+    // way back: both slaves pass their EPU at the same offset (zero cable delay).
+    EXPECT_EQ(100u, ports[1][1] - ports[2][1]); // slave 1 entered one hop after slave 2
+    EXPECT_EQ(200u, ports[2][0] - ports[2][1]); // round trip to the break and back
+    EXPECT_EQ(epu[1], epu[2]);
+    EXPECT_EQ(200u, static_cast<uint32_t>(epu[1]) - ports[2][1]);
+}
+
+
+TEST(EmulatedNetwork, empty_network_routes_without_slaves)
+{
+    EmulatedNetwork net({});
+
+    uint8_t dummy = 0;
+    Frame frame;
+    frame.addDatagram(0, Command::BRD, 0, &dummy, sizeof(dummy));
+    frame.finalize();
+    net.route(frame);
+
+    frame.resetContext();
+    auto [header, data, wkc] = frame.peekDatagram();
+    EXPECT_EQ(0, *wkc);
+}
+
+
 TEST(EmulatedNetwork, set_link_state_ignores_out_of_range_nodes)
 {
     auto slaves = makeSlaves(3);
@@ -207,6 +391,94 @@ TEST(EmulatedNetwork, set_link_state_ignores_out_of_range_nodes)
     net.setLinkState(99, 100, false);
     auto order = discoverOrder(net, slaves, false, 3);
     EXPECT_EQ(order, (std::vector<size_t>{0, 1, 2}));
+}
+
+TEST(EmulatedNetwork, injection_port_out_of_range_is_inert)
+{
+    auto slaves = makeSlaves(3);
+    EmulatedNetwork net(pointers(slaves));
+    net.setInjection(0, 7);
+
+    uint8_t dummy = 0;
+    Frame frame;
+    frame.addDatagram(0, Command::BRD, createAddress(0, reg::TYPE), &dummy, sizeof(dummy));
+    frame.finalize();
+    net.route(frame);
+    frame.resetContext();
+    auto [header, data, wkc] = frame.peekDatagram();
+    EXPECT_EQ(0, *wkc);
+
+    // hasRedundancy() only validates the node; rebuild() also rejects the port. Pin
+    // that split: the flag reads true but the redundancy path stays empty.
+    net.setRedundancyInjection(2, 9);
+    EXPECT_TRUE(net.hasRedundancy());
+
+    Frame frame_red;
+    frame_red.addDatagram(0, Command::BRD, createAddress(0, reg::TYPE), &dummy, sizeof(dummy));
+    frame_red.finalize();
+    net.route(frame_red, true);
+    frame_red.resetContext();
+    auto [header_red, data_red, wkc_red] = frame_red.peekDatagram();
+    EXPECT_EQ(0, *wkc_red);
+}
+
+TEST(EmulatedNetwork, cyclic_wiring_terminates)
+{
+    auto slaves = makeSlaves(2);
+    EmulatedNetwork net(pointers(slaves));
+
+    // Two-node loop with the injection overlapping a wired port: without the walk
+    // budget the frame walk would recurse forever between the two port-0 entries.
+    net.connect(0, 1, 1, 0);
+    net.connect(1, 1, 0, 0);
+    net.setInjection(0, 0);
+
+    uint8_t dummy = 0;
+    Frame frame;
+    frame.addDatagram(0, Command::BRD, createAddress(0, reg::TYPE), &dummy, sizeof(dummy));
+    frame.finalize();
+    net.route(frame);   // returning at all is the assertion
+
+    frame.resetContext();
+    auto [header, data, wkc] = frame.peekDatagram();
+    // The property under test is termination with a bounded number of EPU passes, not
+    // the exact budget value.
+    EXPECT_GT(*wkc, 0);
+    EXPECT_LE(*wkc, 100);
+}
+
+TEST(EmulatedNetwork, circulating_destroy_processes_remaining_datagrams_upstream)
+{
+    auto slaves = makeSlaves(3);
+    EmulatedNetwork net(pointers(slaves));
+
+    // Mis-wired star: both stubs are entered through port 1, so their closed port 0
+    // loops the frame back. The first stub sets the circulating flag, the second
+    // destroys the frame.
+    net.connect(0, 1, 1, 1);
+    net.connect(0, 2, 2, 1);
+    net.setInjection(0, 0);
+
+    uint16_t value_a = 0x1111;
+    uint16_t value_b = 0x2222;
+    Frame frame;
+    frame.addDatagram(0, Command::BWR, createAddress(0, reg::STATION_ADDR), &value_a, sizeof(value_a));
+    frame.addDatagram(1, Command::BWR, createAddress(0, reg::STATION_ADDR), &value_b, sizeof(value_b));
+    frame.finalize();
+
+    EXPECT_FALSE(net.route(frame));
+
+    // Cut-through forwarding: every hop upstream of the destroyer processed BOTH
+    // datagrams before the frame died (the second write wins); the destroyer saw none.
+    for (size_t i = 0; i < 2; ++i)
+    {
+        uint16_t addr = 0;
+        slaves[i]->read(reg::STATION_ADDR, &addr, sizeof(addr));
+        EXPECT_EQ(value_b, addr);
+    }
+    uint16_t untouched = 0;
+    slaves[2]->read(reg::STATION_ADDR, &untouched, sizeof(untouched));
+    EXPECT_EQ(0, untouched);
 }
 
 TEST(EmulatedNetwork, broken_wire_splits_into_two_redundancy_paths)
@@ -222,9 +494,11 @@ TEST(EmulatedNetwork, broken_wire_splits_into_two_redundancy_paths)
     auto nominal = discoverOrder(net, slaves, false, 2);
     EXPECT_EQ(nominal, (std::vector<size_t>{0, 1}));
 
-    // Redundant frame from the tail reaches slaves 3 and 2.
+    // The redundant frame streams unprocessed to the break, loops back through the
+    // EPU at the closed port 0, and is processed from the break outward: 2 then 3
+    // (real ESCs process on the port0 path only, not at port of entry).
     auto redundant = discoverOrder(net, slaves, true, 2);
-    EXPECT_EQ(redundant, (std::vector<size_t>{3, 2}));
+    EXPECT_EQ(redundant, (std::vector<size_t>{2, 3}));
 
     // The two ports straddling the break now show loopback / no communication.
     uint16_t dl1 = dlStatus(*slaves[1]);

--- a/unit/src/bus-t.cc
+++ b/unit/src/bus-t.cc
@@ -16,6 +16,13 @@ struct SDOAnswer
 } __attribute__((__packed__));
 
 
+struct BusAccessor : public Bus
+{
+    using Bus::Bus;
+    using Bus::pi_frames_;
+};
+
+
 class BusTest : public testing::Test
 {
 public:
@@ -28,29 +35,35 @@ public:
 
     void addFetchEepromWord(uint32_t word)
     {
-        // broadcastWrite: set address
-        mock_link->handleWriteThenRead(Command::BWR, 1);
+        // broadcastWrite: set address (wkc checked against slave count)
+        mock_link->handleWriteThenRead(Command::BWR, nb_slaves_);
 
-        // areEepromReady: check status (not busy)
-        mock_link->handleProcess(Command::FPRD, uint16_t{0x0080}, 1);
+        // areEepromReady: one status FPRD (not busy) per slave
+        for (int i = 0; i < nb_slaves_; ++i)
+        {
+            mock_link->handleProcess(Command::FPRD, uint16_t{0x0080}, 1);
+        }
 
-        // readEeprom: fetch data word
-        mock_link->handleProcess(Command::FPRD, word, 1);
+        // readEeprom: one data FPRD per pending slave (same content for all)
+        for (int i = 0; i < nb_slaves_; ++i)
+        {
+            mock_link->handleProcess(Command::FPRD, word, 1);
+        }
     }
 
     void detectAndReset()
     {
         // detectSlaves: broadcastRead
-        mock_link->handleWriteThenRead(Command::BRD, 1);
+        mock_link->handleWriteThenRead(Command::BRD, nb_slaves_);
 
         // reset slaves
         for (int i = 0; i < 11; ++i)
         {
-            mock_link->handleWriteThenRead(Command::BWR, 1);
+            mock_link->handleWriteThenRead(Command::BWR, nb_slaves_);
         }
         for (int i = 0; i < 3; ++i)
         {
-            mock_link->handleWriteThenRead(Command::BRD, 1);
+            mock_link->handleWriteThenRead(Command::BRD, nb_slaves_);
         }
     }
 
@@ -59,27 +72,36 @@ public:
         detectAndReset();
 
         // PDIO Watchdog: 3 broadcastWrites (divider, time PDI, time PDO)
-        mock_link->handleWriteThenRead(Command::BWR, 1);
-        mock_link->handleWriteThenRead(Command::BWR, 1);
-        mock_link->handleWriteThenRead(Command::BWR, 1);
+        mock_link->handleWriteThenRead(Command::BWR, nb_slaves_);
+        mock_link->handleWriteThenRead(Command::BWR, nb_slaves_);
+        mock_link->handleWriteThenRead(Command::BWR, nb_slaves_);
 
         // eeprom to master
-        mock_link->handleWriteThenRead(Command::BWR, 1);
+        mock_link->handleWriteThenRead(Command::BWR, nb_slaves_);
 
-        // setAddresses
+        // setAddresses: all APWR datagrams are packed in a single frame
         mock_link->handleWriteThenRead(Command::APWR, 1);
 
-        // fetchESC
-        mock_link->handleProcess(Command::FPRD, ESC::Description{0x4, 0, 0, 8, 8, 16, 0xf, 0x1cc}, 1);
+        // fetchESC: one FPRD per slave
+        for (int i = 0; i < nb_slaves_; ++i)
+        {
+            mock_link->handleProcess(Command::FPRD, ESC::Description{0x4, 0, 0, 8, 8, 16, 0xf, 0x1cc}, 1);
+        }
 
-        // fetch DL status
-        mock_link->handleProcess(Command::FPRD, uint16_t(0x0030), 1); // PL_port0 and PL_port1 active
+        // fetch DL status: one FPRD per slave
+        for (int i = 0; i < nb_slaves_; ++i)
+        {
+            mock_link->handleProcess(Command::FPRD, uint16_t(0x0030), 1); // PL_port0 and PL_port1 active
+        }
 
         // requestState: INIT
-        mock_link->handleWriteThenRead(Command::BWR, 1);
+        mock_link->handleWriteThenRead(Command::BWR, nb_slaves_);
 
-        // waitForState: check state INIT
-        mock_link->handleProcess(Command::FPRD, uint8_t(State::INIT), 1);
+        // waitForState: one AL status check per slave
+        for (int i = 0; i < nb_slaves_; ++i)
+        {
+            mock_link->handleProcess(Command::FPRD, uint8_t(State::INIT), 1);
+        }
 
         // fetchEeprom
         addFetchEepromWord(0);
@@ -130,36 +152,50 @@ public:
 
         addFetchEepromWord(0xFFFFFFFF);     // end of eeprom
 
-        // configureMailboxes
-        mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+        // configureMailboxes: one FPWR per slave
+        for (int i = 0; i < nb_slaves_; ++i)
+        {
+            mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+        }
 
         // requestState: PREOP
-        mock_link->handleWriteThenRead(Command::BWR, 1);
+        mock_link->handleWriteThenRead(Command::BWR, nb_slaves_);
 
-        // waitForState: check state PREOP
-        mock_link->handleProcess(Command::FPRD, uint8_t(State::PRE_OP), 1);
+        // waitForState: one AL status check per slave
+        for (int i = 0; i < nb_slaves_; ++i)
+        {
+            mock_link->handleProcess(Command::FPRD, uint8_t(State::PRE_OP), 1);
+        }
 
-        // checkMailboxes: write check + read check
-        mock_link->handleProcess(Command::FPRD, uint8_t{0x08}, 1);
-        mock_link->handleProcess(Command::FPRD, uint8_t{0}, 1);
+        // checkMailboxes: write checks (all slaves) then read checks (all slaves)
+        for (int i = 0; i < nb_slaves_; ++i)
+        {
+            mock_link->handleProcess(Command::FPRD, uint8_t{0x08}, 1);
+        }
+        for (int i = 0; i < nb_slaves_; ++i)
+        {
+            mock_link->handleProcess(Command::FPRD, uint8_t{0}, 1);
+        }
 
         bus.init(watchdog);
 
-        ASSERT_EQ(1, bus.detectedSlaves());
+        ASSERT_EQ(nb_slaves_, bus.detectedSlaves());
 
-        auto const& slave = bus.slaves().at(0);
-        ASSERT_EQ(0xCAFEDECA, slave.sii.info.vendor_id);
-        ASSERT_EQ(0xA5A5A5A5, slave.sii.info.product_code);
-        ASSERT_EQ(0x5A5A5A5A, slave.sii.info.revision_number);
-        ASSERT_EQ(0x12345678, slave.sii.info.serial_number);
-        ASSERT_EQ(0x1000,     slave.mailbox.recv_offset);
-        ASSERT_EQ(0x2000,     slave.mailbox.send_offset);
-        ASSERT_EQ(0x0100,     slave.mailbox.recv_size);
-        ASSERT_EQ(0x0200,     slave.mailbox.send_size);
+        for (auto const& slave : bus.slaves())
+        {
+            ASSERT_EQ(0xCAFEDECA, slave.sii.info.vendor_id);
+            ASSERT_EQ(0xA5A5A5A5, slave.sii.info.product_code);
+            ASSERT_EQ(0x5A5A5A5A, slave.sii.info.revision_number);
+            ASSERT_EQ(0x12345678, slave.sii.info.serial_number);
+            ASSERT_EQ(0x1000,     slave.mailbox.recv_offset);
+            ASSERT_EQ(0x2000,     slave.mailbox.send_offset);
+            ASSERT_EQ(0x0100,     slave.mailbox.recv_size);
+            ASSERT_EQ(0x0200,     slave.mailbox.send_size);
 
-        ASSERT_EQ(1, slave.sii.TxPDO.size());
-        ASSERT_EQ(1, slave.sii.RxPDO.size());
-        ASSERT_EQ(2, slave.sii.RxPDO[0].entries.size());
+            ASSERT_EQ(1, slave.sii.TxPDO.size());
+            ASSERT_EQ(1, slave.sii.RxPDO.size());
+            ASSERT_EQ(2, slave.sii.RxPDO[0].entries.size());
+        }
     }
 
     template<typename T>
@@ -199,7 +235,8 @@ public:
 
 protected:
     std::shared_ptr<MockLink> mock_link{ std::make_shared<MockLink>() };
-    Bus bus{ mock_link };
+    BusAccessor bus{ mock_link };
+    int nb_slaves_{1}; // set in a derived fixture constructor, before SetUp runs
 };
 
 TEST_F(BusTest, nop)
@@ -313,6 +350,28 @@ TEST_F(BusTest, logical_cmd)
 
     mock_link->handleProcess(Command::LRW, uint8_t{0}, 0);
     ASSERT_THROW(bus.processDataReadWrite([](DatagramState const&){ throw std::overflow_error(""); }), std::overflow_error);
+}
+
+
+TEST_F(BusTest, description_entries_built_at_mapping)
+{
+    auto& slave = bus.slaves().at(0);
+    slave.sii.info.mailbox_protocol = eeprom::MailboxProtocol::None;
+
+    for (int i = 0; i < 4; ++i)
+    {
+        mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+    }
+
+    uint8_t iomap[256];
+    bus.createMapping(iomap, sizeof(iomap));
+
+    ASSERT_EQ(1u, bus.pi_frames_.size());
+    auto const& entries = bus.pi_frames_[0].description.entries;
+    ASSERT_EQ(1u, entries.size());
+    ASSERT_EQ(3, entries[0].contribution); // input + output
+    ASSERT_EQ(0, entries[0].input_offset);
+    ASSERT_EQ(slave.input.bsize, entries[0].input_size);
 }
 
 
@@ -1106,4 +1165,212 @@ TEST_F(BusTest, mailbox_sequencer_no_skip_without_fmmu)
 
     // Phase 3: sendWriteMessages -> nothing
     sequencer.step(noop);
+}
+
+
+// ---------- Two-slave bus fixture ----------
+
+// Same eeprom content as BusTest, replayed for two identical slaves:
+// TxPDO 32 bytes, RxPDO 48 bytes, CoE mailbox, two SyncManagers.
+class BusTest2Slaves : public BusTest
+{
+public:
+    BusTest2Slaves()
+    {
+        nb_slaves_ = 2;
+    }
+};
+
+
+TEST_F(BusTest2Slaves, description_entries_multi_slave_offsets)
+{
+    auto& slave0 = bus.slaves().at(0);
+    auto& slave1 = bus.slaves().at(1);
+    slave0.sii.info.mailbox_protocol = eeprom::MailboxProtocol::None;
+    slave1.sii.info.mailbox_protocol = eeprom::MailboxProtocol::None;
+
+    // configureFMMUs: SM+FMMU for input and output, per slave
+    for (int i = 0; i < 8; ++i)
+    {
+        mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+    }
+
+    uint8_t iomap[256];
+    bus.createMapping(iomap, sizeof(iomap));
+
+    ASSERT_EQ(32, slave0.input.bsize);
+    ASSERT_EQ(48, slave0.output.bsize);
+
+    ASSERT_EQ(1u, bus.pi_frames_.size());
+    auto const& entries = bus.pi_frames_[0].description.entries;
+    ASSERT_EQ(2u, entries.size());
+
+    ASSERT_EQ(3, entries[0].contribution);
+    ASSERT_EQ(0, entries[0].input_offset);
+    ASSERT_EQ(slave0.input.bsize, entries[0].input_size);
+
+    // overlapped layout: slave 1 blocks start after max(in, out) of slave 0
+    int32_t expected_offset = slave0.input.bsize;
+    if (slave0.output.bsize > expected_offset)
+    {
+        expected_offset = slave0.output.bsize;
+    }
+    ASSERT_EQ(3, entries[1].contribution);
+    ASSERT_EQ(expected_offset, entries[1].input_offset);
+    ASSERT_EQ(slave1.input.bsize, entries[1].input_size);
+}
+
+
+TEST_F(BusTest2Slaves, description_entries_mailbox_only_slave_contribution)
+{
+    auto& slave0 = bus.slaves().at(0);
+    auto& slave1 = bus.slaves().at(1);
+
+    // slave 0: mailbox but no PDO at all
+    slave0.is_static_mapping = true;
+    slave0.input.bsize = 0;
+    slave0.output.bsize = 0;
+
+    // slave 1: plain PDO slave, out of the mailbox status scope
+    slave1.sii.info.mailbox_protocol = eeprom::MailboxProtocol::None;
+
+    bus.configureMailboxStatusCheck(MailboxStatusFMMU::READ_CHECK | MailboxStatusFMMU::WRITE_CHECK);
+
+    // configureFMMUs: 4 FPWR for slave 1, then 2 FPWR for slave 0 mailbox status FMMUs
+    for (int i = 0; i < 6; ++i)
+    {
+        mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+    }
+
+    uint8_t iomap[256];
+    bus.createMapping(iomap, sizeof(iomap));
+
+    ASSERT_EQ(1u, bus.pi_frames_.size());
+    auto const& frame = bus.pi_frames_[0];
+    auto const& entries = frame.description.entries;
+    ASSERT_EQ(2u, entries.size());
+
+    // counted exactly once although both read and write status FMMUs reference it
+    ASSERT_EQ(1, entries[0].contribution);
+    ASSERT_EQ(-1, entries[0].input_offset);
+    ASSERT_EQ(0, entries[0].input_size);
+
+    ASSERT_EQ(3, entries[1].contribution);
+    ASSERT_EQ(0, entries[1].input_offset);
+    ASSERT_EQ(slave1.input.bsize, entries[1].input_size);
+
+    ASSERT_EQ(1, frame.mailbox_status_wkc_read_adjust);
+}
+
+
+TEST_F(BusTest, output_buffer_zeroed_between_blocks)
+{
+    auto& slave = bus.slaves().at(0);
+    slave.sii.info.mailbox_protocol = eeprom::MailboxProtocol::None;
+    slave.is_static_mapping = true;
+    slave.input.bsize = 8;
+    slave.input.sync_manager = 1;
+    slave.output.bsize = 4;
+    slave.output.sync_manager = 0;
+
+    // configureFMMUs: 4 FPWR
+    for (int i = 0; i < 4; ++i)
+    {
+        mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+    }
+
+    uint8_t iomap[256];
+    std::memset(iomap, 0xFF, sizeof(iomap)); // dirty client buffer: zeroes must come from the mapping
+    bus.createMapping(iomap, sizeof(iomap));
+
+    // logical size = max(in 8, out 4); bytes 4-7 are an input-only gap
+    auto const& frame = bus.pi_frames_[0];
+    ASSERT_EQ(8, frame.description.logical_size);
+    ASSERT_EQ(8u, frame.output_buffer.size());
+    for (uint8_t byte : frame.output_buffer)
+    {
+        ASSERT_EQ(0, byte);
+    }
+
+    // LRW payload: output block from the iomap, input-only gap still zeroed
+    std::memset(slave.output.data, 0xAB, 4);
+    bus.sendLogicalReadWrite([](DatagramState const&){});
+
+    ASSERT_EQ(1u, mock_link->pendingDatagrams().size());
+    auto const& sent = mock_link->pendingDatagrams()[0];
+    ASSERT_EQ(Command::LRW, sent.command);
+    ASSERT_EQ(8u, sent.data.size());
+    for (int i = 0; i < 4; ++i)
+    {
+        ASSERT_EQ(0xAB, sent.data[i]);
+    }
+    for (int i = 4; i < 8; ++i)
+    {
+        ASSERT_EQ(0, sent.data[i]);
+    }
+
+    // drain the awaiting datagram (wkc = 1 input + 2 * 1 output)
+    uint64_t reply = 0;
+    mock_link->handleProcess(Command::LRW, reply, 3);
+    bus.processAwaitingFrames();
+}
+
+
+TEST_F(BusTest, create_mapping_twice_does_not_duplicate_state)
+{
+    auto& slave = bus.slaves().at(0);
+    slave.sii.info.mailbox_protocol = eeprom::MailboxProtocol::None;
+
+    uint8_t iomap[256];
+    for (int run = 0; run < 2; ++run)
+    {
+        // configureFMMUs: 4 FPWR per run
+        for (int i = 0; i < 4; ++i)
+        {
+            mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+        }
+        bus.createMapping(iomap, sizeof(iomap));
+
+        ASSERT_EQ(1u, bus.pi_frames_.size());
+        auto const& frame = bus.pi_frames_[0];
+        ASSERT_EQ(1u, frame.inputs.size());
+        ASSERT_EQ(1u, frame.outputs.size());
+        ASSERT_EQ(1u, frame.description.entries.size());
+        ASSERT_EQ(3, frame.description.entries[0].contribution);
+        ASSERT_EQ(0, frame.description.entries[0].input_offset);
+        ASSERT_EQ(slave.input.bsize, frame.description.entries[0].input_size);
+
+        // The link copy tracks the current mapping: replaced, not appended
+        auto const& mapping = mock_link->logicalMapping();
+        ASSERT_EQ(1u, mapping.size());
+        ASSERT_EQ(frame.description.address, mapping[0].address);
+        ASSERT_EQ(frame.description.logical_size, mapping[0].logical_size);
+        ASSERT_EQ(frame.description.entries.size(), mapping[0].entries.size());
+    }
+}
+
+
+TEST_F(BusTest, logical_mapping_shared_with_link_at_mapping)
+{
+    auto& slave = bus.slaves().at(0);
+    slave.sii.info.mailbox_protocol = eeprom::MailboxProtocol::None;
+
+    for (int i = 0; i < 4; ++i)
+    {
+        mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+    }
+
+    uint8_t iomap[256];
+    bus.createMapping(iomap, sizeof(iomap));
+
+    auto const& mapping = mock_link->logicalMapping();
+    ASSERT_EQ(1u, mapping.size());
+    auto const& desc = mapping[0];
+    ASSERT_EQ(bus.pi_frames_[0].description.address, desc.address);
+    ASSERT_EQ(48, desc.logical_size); // max(in 32, out 48)
+    ASSERT_EQ(48, desc.pdo_size);
+    ASSERT_EQ(1u, desc.entries.size());
+    ASSERT_EQ(3, desc.entries[0].contribution); // 1 input + 2 outputs
+    ASSERT_EQ(0, desc.entries[0].input_offset);
+    ASSERT_EQ(32, desc.entries[0].input_size);
 }

--- a/unit/src/link-t.cc
+++ b/unit/src/link-t.cc
@@ -39,6 +39,24 @@ public:
         ASSERT_EQ(link.callbacks_[0].status, DatagramState::SEND_ERROR);
     }
 
+    // Friendship does not extend to the generated test subclasses: expose the
+    // private state needed by the tests here.
+    void setIndexes(uint8_t index)
+    {
+        link.index_head_ = index;
+        link.index_queue_ = index;
+    }
+
+    DatagramState datagramStatus(uint8_t index)
+    {
+        return link.callbacks_[index].status;
+    }
+
+    uint8_t sentFrames()
+    {
+        return link.sent_frame_;
+    }
+
     template<typename T>
     void checkSendFrameRedundancy(std::vector<DatagramCheck<T>> expecteds)
     {
@@ -628,6 +646,64 @@ TEST_F(LinkTest, process_datagrams_line_cut_between_slaves)
 }
 
 
+TEST_F(LinkTest, process_datagrams_lrw_in_mapping_splices_both_copies)
+{
+    InSequence s;
+
+    // Split ring: slave 0's input (bytes 0-3) is in the prefix copy, slave 1's (bytes 4-7)
+    // in the suffix copy. Only the description-driven merge can rebuild the full payload.
+    int64_t sent      = 0x00000000FFFFFFFF;
+    int64_t tail_copy = 0x0102030405060708; // suffix: slave 1 input valid (bytes 4-7, LE)
+    int64_t head_copy = 0x1112131415161718; // prefix: slave 0 input valid (bytes 0-3, LE)
+    int64_t merged    = 0x0102030415161718;
+
+    LogicalFrameDescription desc{};
+    desc.address = 0;
+    desc.logical_size = sizeof(sent);
+    desc.pdo_size = sizeof(sent);
+    desc.entries = {{3, 0, 4}, {3, 4, 4}};
+    link.setLogicalMapping({desc});
+
+    std::vector<DatagramCheck<int64_t>> expecteds_1(1, {Command::LRW, sent});
+    addDatagram(Command::LRW, sent, merged, 6, false);
+    checkSendFrameRedundancy(expecteds_1);
+
+    io_redundancy->handleReply<int64_t>({tail_copy}, 3); // lands in the nominal frame
+    io_nominal->handleReply<int64_t>({head_copy}, 3);    // lands in the redundancy frame
+
+    link.processDatagrams();
+
+    ASSERT_EQ(1, process_callback_counter);
+    ASSERT_EQ(0, error_callback_counter);
+    ASSERT_EQ(DatagramState::OK, last_error);
+}
+
+
+TEST_F(LinkTest, process_datagrams_lrw_keeps_processed_copy)
+{
+    InSequence s;
+
+    // Inputs and outputs share logical addresses: the unprocessed ring copy echoes the
+    // output payload where the processed one carries inputs. OR-ing them would corrupt
+    // the inputs - the merge must keep the processed (nominal) copy.
+    int64_t output_payload = 0x00000000FFFFFFFF;
+    int64_t processed      = 0x0102030405060708;
+    Command cmd = Command::LRW;
+    std::vector<DatagramCheck<int64_t>> expecteds_1(1, {cmd, output_payload});
+    addDatagram(cmd, output_payload, processed, 3, false);
+    checkSendFrameRedundancy(expecteds_1);
+
+    io_redundancy->handleReply<int64_t>({processed}, 3);   // copy processed by the slaves
+    io_nominal->handleReply<int64_t>({output_payload}, 0); // unprocessed echo
+
+    link.processDatagrams();
+
+    ASSERT_EQ(1, process_callback_counter);
+    ASSERT_EQ(0, error_callback_counter);
+    ASSERT_EQ(DatagramState::OK, last_error);
+}
+
+
 TEST_F(LinkTest, process_datagrams_multiple_frames)
 {
     InSequence s;
@@ -1111,5 +1187,530 @@ TEST_F(LinkTest, event_callback)
         checkIRQ(false, 0);                         // No IRQ, no trigger (falling edge)
     }
     checkIRQ(false, EcatEvent::DC_LATCH);           // call default callback -> test that nothing crash
+}
+
+
+TEST_F(LinkTest, process_datagrams_stale_frame_on_nominal_socket_keeps_current_cycle)
+{
+    InSequence s;
+
+    int64_t skip{0};
+    int64_t stale_data   = 0x00000000DEADBEEF;
+    int64_t current_data = 0x0001020304050607;
+    Command cmd = Command::LRD;
+    std::vector<DatagramCheck<int64_t>> expecteds_1(1, {cmd, skip, false}); // no payload for logical read.
+
+    // Cycle 1: sent on the nominal interface only, no response - reported lost. The mock
+    // keeps the cycle-1 frame queued on io_nominal to replay it as a stale response later.
+    addDatagram(cmd, skip, current_data, 2, false);
+    io_nominal->checkSendFrame(expecteds_1);
+    EXPECT_CALL(*io_redundancy, write(_,_)).WillOnce(Return(0));
+    io_redundancy->readError();
+    io_nominal->readError();
+
+    link.processDatagrams();
+
+    ASSERT_EQ(0, process_callback_counter);
+    ASSERT_EQ(1, error_callback_counter);
+    ASSERT_EQ(DatagramState::LOST, last_error);
+
+    // Cycle 2: the redundancy socket delivers the current response while the nominal
+    // socket delivers the stale cycle-1 one.
+    addDatagram(cmd, skip, current_data, 2, false);
+    checkSendFrameRedundancy(expecteds_1);
+    io_redundancy->handleReply<int64_t>({current_data}, 2); // current frame
+    io_nominal->handleReply<int64_t>({stale_data}, 1);      // stale cycle-1 frame (index 0)
+    io_redundancy->readError();                             // retry read granted by the dropped datagram
+    io_nominal->readError();
+
+    link.processDatagrams();
+
+    // Current datagram dispatched with the current data, stale one silently dropped.
+    ASSERT_EQ(1, process_callback_counter);
+    ASSERT_EQ(1, error_callback_counter);
+}
+
+
+TEST_F(LinkTest, process_datagrams_stale_pair_is_dropped)
+{
+    InSequence s;
+
+    int64_t sent         = 0x00000000FFFFFFFF;
+    int64_t stale_data   = 0x00000000DEADBEEF;
+    int64_t current_data = 0x0102030405060708;
+
+    std::vector<DatagramCheck<int64_t>> expecteds_1(1, {Command::LRW, sent});
+
+    LogicalFrameDescription desc{};
+    desc.address = 0;
+    desc.logical_size = sizeof(sent);
+    desc.pdo_size = sizeof(sent);
+    desc.entries = {{3, 0, 8}};
+    link.setLogicalMapping({desc});
+
+    auto queueLRW = [&]()
+    {
+        link.addDatagram(Command::LRW, 0, &sent, sizeof(sent),
+            [&](DatagramHeader const*, uint8_t const* data, uint16_t wkc)
+            {
+                process_callback_counter++;
+                EXPECT_EQ(3, wkc); // sum of both current copies
+                EXPECT_EQ(0, std::memcmp(data, &current_data, sizeof(current_data)));
+                return DatagramState::OK;
+            },
+            [&](DatagramState const& status)
+            {
+                error_callback_counter++;
+                last_error = status;
+            });
+    };
+
+    // Cycle 1: no response on either interface - reported lost, both mocks keep the
+    // cycle-1 frame queued.
+    queueLRW();
+    checkSendFrameRedundancy(expecteds_1);
+    io_redundancy->readError();
+    io_nominal->readError();
+
+    link.processDatagrams();
+
+    ASSERT_EQ(0, process_callback_counter);
+    ASSERT_EQ(1, error_callback_counter);
+    ASSERT_EQ(DatagramState::LOST, last_error);
+    last_error = DatagramState::OK;
+
+    // Cycle 2: both interfaces deliver the stale cycle-1 pair first, the current pair behind.
+    queueLRW();
+    checkSendFrameRedundancy(expecteds_1);
+    io_redundancy->handleReply<int64_t>({stale_data}, 1);
+    io_nominal->handleReply<int64_t>({stale_data}, 1);
+    io_redundancy->handleReply<int64_t>({current_data}, 2);
+    io_nominal->handleReply<int64_t>({current_data}, 1);
+
+    link.processDatagrams();
+
+    // The stale pair was dropped by the in-flight window: only the current pair was dispatched.
+    ASSERT_EQ(1, process_callback_counter);
+    ASSERT_EQ(1, error_callback_counter);
+    ASSERT_EQ(DatagramState::OK, last_error);
+}
+
+
+TEST_F(LinkTest, process_datagrams_mismatched_pair_dispatches_both_datagrams)
+{
+    InSequence s;
+
+    int64_t skip{0};
+    int64_t logical_read = 1111;
+    Command cmd = Command::LRD;
+    std::vector<DatagramCheck<int64_t>> expecteds_15(15, {cmd, skip, false}); // no payload for logical read.
+    std::vector<DatagramCheck<int64_t>> expecteds_4(4, {cmd, skip, false});
+    std::vector<int64_t> answers_15(15, logical_read);
+    std::vector<int64_t> answers_4(4, logical_read);
+    std::vector<int64_t> skips_4(4, skip);
+
+    // Frame 1 is lost on the nominal interface at send time: only the redundancy
+    // socket will ever deliver it.
+    EXPECT_CALL(*io_nominal, write(_,_)).WillOnce(Return(0));
+    io_redundancy->checkSendFrame(expecteds_15);
+    io_nominal->checkSendFrame(expecteds_4);
+    io_redundancy->checkSendFrame(expecteds_4);
+
+    for (int32_t j = 0; j < 19; j++)
+    {
+        addDatagram(cmd, skip, logical_read, 2, false);
+    }
+
+    // First read round pairs frame 1 (from io_redundancy) with frame 2 (from io_nominal):
+    // mismatched indexes, frame 1 datagrams dispatched, frame 2 copies dropped.
+    io_redundancy->handleReply<int64_t>(answers_15, 2);
+    io_nominal->handleReply<int64_t>(skips_4, 0);
+    // Retry read granted by the dropped datagrams: frame 2 recovered from io_redundancy.
+    io_redundancy->handleReply<int64_t>(answers_4, 2);
+    io_nominal->readError();
+    io_redundancy->readError();
+    io_nominal->readError();
+
+    link.processDatagrams();
+
+    ASSERT_EQ(19, process_callback_counter);
+    ASSERT_EQ(0, error_callback_counter);
+    ASSERT_EQ(DatagramState::OK, last_error);
+}
+
+
+TEST_F(LinkTest, process_datagrams_merged_pair_aggregates_irq_of_both_copies)
+{
+    InSequence s;
+
+    int64_t skip{0};
+    int64_t logical_read = 0x0001020304050607;
+    Command cmd = Command::LRD;
+    std::vector<DatagramCheck<int64_t>> expecteds_1(1, {cmd, skip, false}); // no payload for logical read.
+
+    bool dl_status_event = false;
+    bool sm0_status_event = false;
+    link.attachEcatEventCallback(EcatEvent::DL_STATUS,  [&](){ dl_status_event = true; });
+    link.attachEcatEventCallback(EcatEvent::SM0_STATUS, [&](){ sm0_status_event = true; });
+
+    addDatagram(cmd, skip, logical_read, 2, false);
+    checkSendFrameRedundancy(expecteds_1); // check frame is sent on both interfaces.
+
+    // Each ring segment reports its own events: the merged pair must carry both.
+    io_redundancy->handleReply<int64_t>({logical_read}, 2, EcatEvent::DL_STATUS);
+    io_nominal->handleReply<int64_t>({skip}, 0, EcatEvent::SM0_STATUS);
+
+    link.processDatagrams();
+
+    ASSERT_EQ(1, process_callback_counter);
+    ASSERT_EQ(0, error_callback_counter);
+    ASSERT_EQ(DatagramState::OK, last_error);
+    ASSERT_TRUE(dl_status_event);
+    ASSERT_TRUE(sm0_status_event);
+}
+
+
+TEST_F(LinkTest, process_datagrams_never_downgrades_ok_status)
+{
+    uint8_t data = 3;
+    Command cmd = Command::BWR;
+    std::vector<DatagramCheck<uint8_t>> expecteds_small(1, {cmd, data});
+    std::vector<uint8_t> answers_small(1, data);
+
+    std::array<uint8_t, MAX_ETHERCAT_PAYLOAD_SIZE> big_payload;
+    std::array<uint8_t, MAX_ETHERCAT_PAYLOAD_SIZE> big_garbage;
+    std::fill(std::begin(big_payload), std::end(big_payload), 2);
+    std::fill(std::begin(big_garbage), std::end(big_garbage), 0xAA);
+
+    std::vector<DatagramCheck<std::array<uint8_t, MAX_ETHERCAT_PAYLOAD_SIZE>>> expecteds_big(1, {cmd, big_payload});
+    std::vector<std::array<uint8_t, MAX_ETHERCAT_PAYLOAD_SIZE>> answers_big(1, big_payload);
+    std::vector<std::array<uint8_t, MAX_ETHERCAT_PAYLOAD_SIZE>> answers_garbage(1, big_garbage);
+
+    InSequence s;
+
+    checkSendFrameRedundancy(expecteds_big);   // frame 1: index 0 alone (fills the frame)
+    checkSendFrameRedundancy(expecteds_small); // frame 2: index 1 alone
+
+    addDatagram(cmd, big_payload, big_payload, 2);
+    addDatagram(cmd, data, data, 2);
+
+    // Round 1: index 0 dispatched OK from the redundancy socket alone; the nominal
+    // socket keeps its copy queued.
+    io_redundancy->handleReply<std::array<uint8_t, MAX_ETHERCAT_PAYLOAD_SIZE>>(answers_big, 2);
+    io_nominal->readError();
+    // Round 2: the nominal socket delivers the index-0 duplicate (garbage payload):
+    // already OK, it must be skipped, and the dropped index-1 copy grants a retry.
+    io_redundancy->handleReply<uint8_t>(answers_small, 2);
+    io_nominal->handleReply<std::array<uint8_t, MAX_ETHERCAT_PAYLOAD_SIZE>>(answers_garbage, 0);
+    // Round 3: index 1 recovered from the nominal socket.
+    io_redundancy->readError();
+    io_nominal->handleReply<uint8_t>(answers_small, 2);
+
+    link.processDatagrams();
+
+    ASSERT_EQ(2, process_callback_counter); // duplicate dispatch skipped
+    ASSERT_EQ(0, error_callback_counter);
+    ASSERT_EQ(DatagramState::OK, last_error);
+    ASSERT_EQ(DatagramState::OK, datagramStatus(0));
+    ASSERT_EQ(DatagramState::OK, datagramStatus(1));
+}
+
+
+TEST_F(LinkTest, send_error_marks_wrapped_indexes)
+{
+    // Start near the index wrap so the frame spans indexes 254, 255, 0, 1.
+    setIndexes(254);
+    for (int32_t i = 0; i < 4; ++i)
+    {
+        link.addDatagram(Command::BRD, createAddress(0, 0x0000), nullptr, nullptr, nullptr);
+    }
+
+    EXPECT_CALL(*io_nominal, write(_,_)).WillOnce(Return(-1));
+    EXPECT_CALL(*io_redundancy, write(_,_)).WillOnce(Return(-1));
+
+    link.finalizeDatagrams();
+
+    ASSERT_EQ(0, sentFrames());
+    ASSERT_EQ(DatagramState::SEND_ERROR, datagramStatus(254));
+    ASSERT_EQ(DatagramState::SEND_ERROR, datagramStatus(255));
+    ASSERT_EQ(DatagramState::SEND_ERROR, datagramStatus(0));
+    ASSERT_EQ(DatagramState::SEND_ERROR, datagramStatus(1));
+}
+
+
+TEST_F(LinkTest, process_datagrams_split_read_or_merge_per_command)
+{
+    InSequence s;
+
+    int64_t skip{0};
+    int64_t half_head = 0x0001020300000000;
+    int64_t half_tail = 0x0000000004050607;
+    int64_t full      = 0x0001020304050607;
+
+    // LRD is covered elsewhere: pin the other OR-merged read commands. BRW reads
+    // OR-accumulate over the echoed payload (zero here), so it merges the same way.
+    std::vector<Command> commands{Command::BRD, Command::APRD, Command::FPRD, Command::BRW};
+    for (auto cmd : commands)
+    {
+        std::vector<DatagramCheck<int64_t>> expecteds_1(1, {cmd, skip, false}); // payload zeroed for read commands.
+        addDatagram(cmd, skip, full, 2, false);
+        checkSendFrameRedundancy(expecteds_1); // check frame is sent on both interfaces.
+
+        // Line cut between slaves: each socket returns half the payload.
+        io_redundancy->handleReply<int64_t>({half_tail}, 1);
+        io_nominal->handleReply<int64_t>({half_head}, 1);
+
+        link.processDatagrams();
+    }
+
+    ASSERT_EQ(4, process_callback_counter);
+    ASSERT_EQ(0, error_callback_counter);
+    ASSERT_EQ(DatagramState::OK, last_error);
+}
+
+
+TEST_F(LinkTest, process_datagrams_single_responder_rw_takes_answered_copy)
+{
+    InSequence s;
+
+    // RW command addressed to a slave on the head segment of a split ring: the read data
+    // is only in the head copy, the tail copy streams the echoed request through unprocessed.
+    int64_t sent      = 0x00000000FFFFFFFF;
+    int64_t read_data = 0x0102030405060708;
+    std::vector<Command> commands{Command::FPRW, Command::APRW};
+    for (auto cmd : commands)
+    {
+        std::vector<DatagramCheck<int64_t>> expecteds_1(1, {cmd, sent});
+        addDatagram(cmd, sent, read_data, 3, false);
+        checkSendFrameRedundancy(expecteds_1);
+
+        io_redundancy->handleReply<int64_t>({sent}, 0);    // tail copy: echo, lands in the nominal frame
+        io_nominal->handleReply<int64_t>({read_data}, 3);  // head copy: slave answered
+
+        link.processDatagrams();
+    }
+
+    ASSERT_EQ(2, process_callback_counter);
+    ASSERT_EQ(0, error_callback_counter);
+    ASSERT_EQ(DatagramState::OK, last_error);
+}
+
+
+TEST_F(LinkTest, lrw_mapping_dispatched_by_logical_address)
+{
+    InSequence s;
+
+    // Two mapped logical frames with different layouts: each LRW pair must be spliced
+    // with the description matching its own logical address.
+    int64_t sent = 0x00000000FFFFFFFF;
+
+    LogicalFrameDescription desc0{};
+    desc0.address = 0;
+    desc0.logical_size = sizeof(sent);
+    desc0.pdo_size = sizeof(sent);
+    desc0.entries = {{3, 0, 4}, {3, 4, 4}}; // two slaves: prefix covers bytes 0-3 only
+    LogicalFrameDescription desc1{};
+    desc1.address = 0x800;
+    desc1.logical_size = sizeof(sent);
+    desc1.pdo_size = sizeof(sent);
+    desc1.entries = {{3, 0, 8}};            // one slave: prefix covers the full payload
+    link.setLogicalMapping({desc0, desc1});
+
+    int64_t tail0   = 0x0102030405060708;
+    int64_t head0   = 0x1112131415161718;
+    int64_t merged0 = 0x0102030415161718; // bytes 0-3 from the prefix copy
+    int64_t tail1   = 0x2122232425262728;
+    int64_t head1   = 0x3132333435363738;
+    int64_t merged1 = head1;              // full payload from the prefix copy
+
+    int32_t checked = 0;
+    auto queueLRW = [&](uint32_t address, int64_t expected)
+    {
+        link.addDatagram(Command::LRW, address, &sent, sizeof(sent),
+            [&checked, expected](DatagramHeader const*, uint8_t const* data, uint16_t wkc)
+            {
+                ++checked;
+                EXPECT_EQ(6, wkc);
+                EXPECT_EQ(0, std::memcmp(data, &expected, sizeof(expected)));
+                return DatagramState::OK;
+            },
+            [&](DatagramState const& status)
+            {
+                error_callback_counter++;
+                last_error = status;
+            });
+    };
+
+    std::vector<DatagramCheck<int64_t>> expecteds_2(2, {Command::LRW, sent});
+    queueLRW(0, merged0);
+    queueLRW(0x800, merged1);
+    checkSendFrameRedundancy(expecteds_2);
+
+    io_redundancy->handleReply<int64_t>({tail0, tail1}, 3); // suffix copies, nominal frame
+    io_nominal->handleReply<int64_t>({head0, head1}, 3);    // prefix copies, redundancy frame
+
+    link.processDatagrams();
+
+    ASSERT_EQ(2, checked);
+    ASSERT_EQ(0, error_callback_counter);
+    ASSERT_EQ(DatagramState::OK, last_error);
+}
+
+
+TEST_F(LinkTest, process_datagrams_lrw_outside_mapping_takes_covering_copy)
+{
+    InSequence s;
+
+    // No logical mapping provided and the processed copy landed on the redundancy side:
+    // the fallback must take the copy that covered the slaves, not the echoed one.
+    int64_t output_payload = 0x00000000FFFFFFFF;
+    int64_t processed      = 0x0102030405060708;
+    Command cmd = Command::LRW;
+    std::vector<DatagramCheck<int64_t>> expecteds_1(1, {cmd, output_payload});
+    addDatagram(cmd, output_payload, processed, 3, false);
+    checkSendFrameRedundancy(expecteds_1);
+
+    io_redundancy->handleReply<int64_t>({output_payload}, 0); // unprocessed echo
+    io_nominal->handleReply<int64_t>({processed}, 3);         // copy processed by the slaves
+
+    link.processDatagrams();
+
+    ASSERT_EQ(1, process_callback_counter);
+    ASSERT_EQ(0, error_callback_counter);
+    ASSERT_EQ(DatagramState::OK, last_error);
+}
+
+
+TEST_F(LinkTest, lrw_not_matching_mapping_layout_uses_single_segment_rule)
+{
+    InSequence s;
+
+    // An LRW at a mapped address but with a different length is not the mapped datagram:
+    // splicing it with the mapping layout would write logical_size bytes over a smaller
+    // payload. It must take the single-segment rule instead.
+    int64_t sent      = 0x00000000FFFFFFFF;
+    int64_t tail_copy = 0x0102030405060708;
+    int64_t head_copy = 0x1112131415161718;
+
+    LogicalFrameDescription desc{};
+    desc.address = 0;
+    desc.logical_size = 16; // twice the datagram length below
+    desc.pdo_size = 16;
+    desc.entries = {{3, 0, 4}, {3, 4, 4}};
+    link.setLogicalMapping({desc});
+
+    std::vector<DatagramCheck<int64_t>> expecteds_1(1, {Command::LRW, sent});
+    addDatagram(Command::LRW, sent, tail_copy, 6, false); // nominal copy kept untouched
+    checkSendFrameRedundancy(expecteds_1);
+
+    io_redundancy->handleReply<int64_t>({tail_copy}, 3);
+    io_nominal->handleReply<int64_t>({head_copy}, 3);
+
+    link.processDatagrams();
+
+    ASSERT_EQ(1, process_callback_counter);
+    ASSERT_EQ(0, error_callback_counter);
+    ASSERT_EQ(DatagramState::OK, last_error);
+}
+
+
+// Hand-built 3-slave frame: inputs of 4 bytes at offsets 0/8/16, each slave contributing 3 (in+out).
+// Buffer roles follow Link::read()'s socket crossover: on a split ring `nominal` holds the
+// tail-injected copy (bus-order suffix), `redundancy` the head-injected copy (bus-order prefix).
+class LRWMergeTest : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        desc.logical_size = 26;
+        desc.pdo_size = 24; // last 2 bytes emulate a mailbox status area
+        for (int i = 0; i < 3; ++i)
+        {
+            desc.entries.push_back({3, i * 8, 4});
+        }
+
+        for (size_t i = 0; i < sizeof(nominal); ++i)
+        {
+            nominal[i] = static_cast<uint8_t>(0x10 + i);
+            redundancy[i] = static_cast<uint8_t>(0xA0 + i);
+        }
+    }
+
+protected:
+    LogicalFrameDescription desc{};
+    uint8_t nominal[26];
+    uint8_t redundancy[26];
+};
+
+
+TEST_F(LRWMergeTest, intact_ring_keeps_nominal_copy)
+{
+    // Intact ring: the head-injected copy processed every slave and exits at the tail, so it
+    // lands in the nominal buffer; the tail-injected copy streams through unprocessed (wkc 0).
+    uint8_t const expected[26] = {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C,
+                                  0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29};
+    mergeSplitLRW(desc, nominal, redundancy, 9, 0);
+    ASSERT_EQ(0, std::memcmp(nominal, expected, sizeof(expected)));
+}
+
+
+TEST_F(LRWMergeTest, break_on_last_cable_takes_head_copy)
+{
+    // Break between the last slave and the tail master port: the tail-injected copy loops back
+    // before reaching any slave (wkc 0), the head-injected copy processed everyone.
+    mergeSplitLRW(desc, nominal, redundancy, 0, 9);
+    ASSERT_EQ(0, std::memcmp(nominal, redundancy, sizeof(redundancy)));
+}
+
+
+TEST_F(LRWMergeTest, split_after_slave0_takes_head_input_from_prefix_copy)
+{
+    // Break between slave 0 and slave 1: the head copy processed slave 0 (wkc 3, prefix ->
+    // redundancy buffer), the tail copy processed slaves 1 and 2 (wkc 6 -> nominal buffer).
+    mergeSplitLRW(desc, nominal, redundancy, 6, 3);
+
+    uint8_t const expected[26] = {0xA0, 0xA1, 0xA2, 0xA3,  // slave 0 input: prefix (redundancy)
+                                  0x14, 0x15, 0x16, 0x17,  // gap (outputs): nominal
+                                  0x18, 0x19, 0x1A, 0x1B,  // slave 1 input: suffix (nominal)
+                                  0x1C, 0x1D, 0x1E, 0x1F,
+                                  0x20, 0x21, 0x22, 0x23,  // slave 2 input: suffix (nominal)
+                                  0x24, 0x25, 0x26, 0x27,
+                                  0x28 | 0xB8, 0x29 | 0xB9}; // status area: OR of both copies
+    ASSERT_EQ(0, std::memcmp(nominal, expected, sizeof(expected)));
+}
+
+
+TEST_F(LRWMergeTest, split_before_last_slave)
+{
+    // Break between slave 1 and slave 2: the head copy processed slaves 0 and 1 (wkc 6,
+    // prefix -> redundancy buffer), the tail copy processed slave 2 only (wkc 3).
+    mergeSplitLRW(desc, nominal, redundancy, 3, 6);
+
+    uint8_t const expected[26] = {0xA0, 0xA1, 0xA2, 0xA3,  // slave 0 input: prefix (redundancy)
+                                  0x14, 0x15, 0x16, 0x17,
+                                  0xA8, 0xA9, 0xAA, 0xAB,  // slave 1 input: prefix (redundancy)
+                                  0x1C, 0x1D, 0x1E, 0x1F,
+                                  0x20, 0x21, 0x22, 0x23,  // slave 2 input: suffix (nominal)
+                                  0x24, 0x25, 0x26, 0x27,
+                                  0x28 | 0xB8, 0x29 | 0xB9};
+    ASSERT_EQ(0, std::memcmp(nominal, expected, sizeof(expected)));
+}
+
+
+TEST_F(LRWMergeTest, wkc_inside_a_contribution_attributes_started_slave_to_prefix)
+{
+    // wkc 4 lands inside slave 1's contribution of 3 (partial answer: the summed-wkc check
+    // discards the cycle anyway): the attribution must keep copying until the count is
+    // covered, so slave 1 is taken from the prefix copy like slave 0.
+    mergeSplitLRW(desc, nominal, redundancy, 5, 4);
+
+    uint8_t const expected[26] = {0xA0, 0xA1, 0xA2, 0xA3,  // slave 0 input: prefix (redundancy)
+                                  0x14, 0x15, 0x16, 0x17,
+                                  0xA8, 0xA9, 0xAA, 0xAB,  // slave 1 input: prefix (redundancy)
+                                  0x1C, 0x1D, 0x1E, 0x1F,
+                                  0x20, 0x21, 0x22, 0x23,  // slave 2 input: suffix (nominal)
+                                  0x24, 0x25, 0x26, 0x27,
+                                  0x28 | 0xB8, 0x29 | 0xB9};
+    ASSERT_EQ(0, std::memcmp(nominal, expected, sizeof(expected)));
 }
 }

--- a/unit/src/redundancy-t.cc
+++ b/unit/src/redundancy-t.cc
@@ -1,0 +1,410 @@
+// End-to-end redundancy tests: a real Link over two sockets that physically route
+// frames through an EmulatedNetwork ring. Covers the full path through Link::read()'s
+// socket crossover down to mergeSplitLRW's segment attribution.
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstring>
+#include <memory>
+#include <queue>
+#include <vector>
+
+#include "mocks/EmulatedNetworkHelpers.h"
+
+#include "kickcat/AbstractSocket.h"
+#include "kickcat/EmulatedNetwork.h"
+#include "kickcat/Frame.h"
+#include "kickcat/Link.h"
+
+using namespace kickcat;
+
+namespace
+{
+    enum class NIC
+    {
+        NOMINAL,
+        REDUNDANCY,
+    };
+
+    // Physical model of one master cable: a written frame is routed through the segment
+    // and pops out on the other NIC when the ring is intact, or loops back at the break
+    // and returns on the NIC it was injected on.
+    class PhysicalSocket final : public AbstractSocket
+    {
+    public:
+        PhysicalSocket(EmulatedNetwork& net, NIC nic)
+            : net_(net)
+            , nic_(nic)
+        {
+        }
+
+        void setPeer(PhysicalSocket* peer) { peer_ = peer; }
+
+        void open(std::string const&) override {}
+        void setTimeout(nanoseconds) override {}
+        void close() noexcept override {}
+
+        int32_t read(void* frame, int32_t frame_size) override
+        {
+            if (rx_.empty())
+            {
+                return -1;
+            }
+            std::vector<uint8_t> const& raw = rx_.front();
+            int32_t size = static_cast<int32_t>(raw.size());
+            if (size > frame_size)
+            {
+                size = frame_size;
+            }
+            std::memcpy(frame, raw.data(), static_cast<size_t>(size));
+            rx_.pop();
+            return size;
+        }
+
+        int32_t write(void const* frame, int32_t frame_size) override
+        {
+            if (cut_to_master)
+            {
+                return frame_size; // severed master cable: the frame never reaches the segment
+            }
+
+            Frame routed(frame, frame_size);
+            if (not net_.route(routed, nic_ == NIC::REDUNDANCY))
+            {
+                return frame_size; // frame destroyed by an ESC (circulating flag)
+            }
+
+            PhysicalSocket* destination = this; // broken ring: loopback to the injection NIC
+            if (net_.ringIntact())
+            {
+                destination = peer_;
+            }
+            if (destination->cut_to_master)
+            {
+                return frame_size; // response lost on the severed cable
+            }
+            if (destination->drop_next_delivery)
+            {
+                destination->drop_next_delivery = false;
+                return frame_size;
+            }
+            destination->rx_.emplace(routed.data(), routed.data() + frame_size);
+            return frame_size;
+        }
+
+        bool cut_to_master{false};
+        bool drop_next_delivery{false};
+
+    private:
+        EmulatedNetwork& net_;
+        NIC nic_;
+        PhysicalSocket* peer_{nullptr};
+        std::queue<std::vector<uint8_t>> rx_;
+    };
+
+    constexpr int32_t  PI_SIZE    = 24;
+    constexpr uint32_t INPUT_BASE = 0xA0B0C000;
+
+    class RedundancyIntegration : public testing::Test
+    {
+    protected:
+        void SetUp() override
+        {
+            slaves_ = makeSlaves(3);
+            net_ = std::make_unique<EmulatedNetwork>(pointers(slaves_));
+            net_->setRedundancyInjection(2, 1); // close the ring on the tail slave
+
+            for (size_t i = 0; i < slaves_.size(); ++i)
+            {
+                configureOverlappedPdo(*slaves_[i], static_cast<uint32_t>(i * 8),
+                                       static_cast<uint32_t>(INPUT_BASE + i));
+            }
+
+            socket_nominal_    = std::make_shared<PhysicalSocket>(*net_, NIC::NOMINAL);
+            socket_redundancy_ = std::make_shared<PhysicalSocket>(*net_, NIC::REDUNDANCY);
+            socket_nominal_->setPeer(socket_redundancy_.get());
+            socket_redundancy_->setPeer(socket_nominal_.get());
+            link_ = std::make_unique<Link>(socket_nominal_, socket_redundancy_, [](){});
+
+            LogicalFrameDescription desc{};
+            desc.address = 0;
+            desc.logical_size = PI_SIZE;
+            desc.pdo_size = PI_SIZE;
+            desc.entries = {{3, 0, 4}, {3, 8, 4}, {3, 16, 4}};
+            link_->setLogicalMapping({desc});
+        }
+
+        struct CycleResult
+        {
+            std::array<uint8_t, PI_SIZE> data{};
+            uint16_t wkc{0};
+            bool processed{false};
+            int32_t errors{0};
+            DatagramState error_state{DatagramState::OK};
+        };
+
+        CycleResult runLRWCycle(uint8_t pattern_base)
+        {
+            CycleResult result;
+            uint8_t outputs[PI_SIZE];
+            for (int32_t i = 0; i < PI_SIZE; ++i)
+            {
+                outputs[i] = static_cast<uint8_t>(pattern_base + i);
+            }
+
+            auto process = [&result](DatagramHeader const*, uint8_t const* data, uint16_t wkc)
+            {
+                result.processed = true;
+                result.wkc = wkc;
+                std::memcpy(result.data.data(), data, result.data.size());
+                return DatagramState::OK;
+            };
+            auto error = [&result](DatagramState const& state)
+            {
+                ++result.errors;
+                result.error_state = state;
+            };
+
+            link_->addDatagram(Command::LRW, 0, outputs, PI_SIZE, process, error);
+            link_->processDatagrams();
+            return result;
+        }
+
+        // Every byte of the dispatched payload: rebuilt input blocks at i*8, echoed
+        // output bytes in the unmapped gaps.
+        void checkMergedPayload(CycleResult const& result, uint8_t pattern_base, uint32_t input_base)
+        {
+            for (size_t i = 0; i < slaves_.size(); ++i)
+            {
+                uint32_t input = 0;
+                std::memcpy(&input, result.data.data() + i * 8, sizeof(input));
+                EXPECT_EQ(static_cast<uint32_t>(input_base + i), input);
+
+                for (size_t b = 4; b < 8; ++b)
+                {
+                    EXPECT_EQ(static_cast<uint8_t>(pattern_base + i * 8 + b), result.data[i * 8 + b]);
+                }
+            }
+        }
+
+        void checkOutputsApplied(uint8_t pattern_base)
+        {
+            for (size_t i = 0; i < slaves_.size(); ++i)
+            {
+                uint8_t out[4];
+                slaves_[i]->read(0x1200, out, sizeof(out));
+                for (size_t b = 0; b < 4; ++b)
+                {
+                    EXPECT_EQ(static_cast<uint8_t>(pattern_base + i * 8 + b), out[b]);
+                }
+            }
+        }
+
+        void writeInputs(uint32_t base)
+        {
+            for (size_t i = 0; i < slaves_.size(); ++i)
+            {
+                uint32_t input = static_cast<uint32_t>(base + i);
+                slaves_[i]->write(0x1100, &input, sizeof(input));
+            }
+        }
+
+        std::vector<std::unique_ptr<EmulatedESC>> slaves_;
+        std::unique_ptr<EmulatedNetwork> net_;
+        std::shared_ptr<PhysicalSocket> socket_nominal_;
+        std::shared_ptr<PhysicalSocket> socket_redundancy_;
+        std::unique_ptr<Link> link_;
+    };
+}
+
+
+TEST_F(RedundancyIntegration, intact_ring_lrw_full_wkc_and_inputs)
+{
+    auto result = runLRWCycle(0x80);
+
+    EXPECT_TRUE(net_->ringIntact());
+    EXPECT_TRUE(result.processed);
+    EXPECT_EQ(0, result.errors);
+    EXPECT_EQ(9, result.wkc);
+    checkMergedPayload(result, 0x80, INPUT_BASE);
+    checkOutputsApplied(0x80);
+}
+
+TEST_F(RedundancyIntegration, split_between_slave0_and_slave1_rebuilds_all_inputs)
+{
+    // Head copy reaches slave 0 only (wkc 3), tail copy slaves 1 and 2 (wkc 6); each
+    // loops back to its own NIC, so Link::read() crosses them on dispatch.
+    net_->setLinkState(0, 1, false);
+
+    auto result = runLRWCycle(0x80);
+
+    EXPECT_FALSE(net_->ringIntact());
+    EXPECT_TRUE(result.processed);
+    EXPECT_EQ(0, result.errors);
+    EXPECT_EQ(9, result.wkc);
+    checkMergedPayload(result, 0x80, INPUT_BASE);
+    checkOutputsApplied(0x80);
+}
+
+TEST_F(RedundancyIntegration, split_between_slave1_and_slave2_rebuilds_all_inputs)
+{
+    // Prefix is now slaves 0 and 1 (head copy wkc 6), tail copy slave 2 only (wkc 3).
+    net_->setLinkState(1, 2, false);
+
+    auto result = runLRWCycle(0x80);
+
+    EXPECT_FALSE(net_->ringIntact());
+    EXPECT_TRUE(result.processed);
+    EXPECT_EQ(0, result.errors);
+    EXPECT_EQ(9, result.wkc);
+    checkMergedPayload(result, 0x80, INPUT_BASE);
+    checkOutputsApplied(0x80);
+}
+
+TEST_F(RedundancyIntegration, nominal_master_cable_cut_dispatches_tail_copy)
+{
+    // Dead head cable: the head frame is lost and the segment has no nominal injection
+    // anymore, so slave 0's port 0 loops back and the tail walk covers all three slaves.
+    socket_nominal_->cut_to_master = true;
+    net_->setInjection(EmulatedNetwork::NO_NODE, 0);
+
+    auto result = runLRWCycle(0x80);
+
+    EXPECT_TRUE(result.processed);
+    EXPECT_EQ(0, result.errors);
+    EXPECT_EQ(9, result.wkc);
+    checkMergedPayload(result, 0x80, INPUT_BASE);
+    checkOutputsApplied(0x80);
+}
+
+TEST_F(RedundancyIntegration, redundancy_master_cable_cut_dispatches_head_copy)
+{
+    // Dead tail cable: the tail frame is lost and the ring is open at the tail, so the
+    // head copy loops back at the last slave and covers all three on its own.
+    socket_redundancy_->cut_to_master = true;
+    net_->setRedundancyInjection(EmulatedNetwork::NO_NODE, 0);
+
+    auto result = runLRWCycle(0x80);
+
+    EXPECT_TRUE(result.processed);
+    EXPECT_EQ(0, result.errors);
+    EXPECT_EQ(9, result.wkc);
+    checkMergedPayload(result, 0x80, INPUT_BASE);
+    checkOutputsApplied(0x80);
+}
+
+TEST_F(RedundancyIntegration, copy_lost_in_flight_intact_ring_still_dispatches)
+{
+    // One copy of the pair dropped in flight while the ring is intact: the surviving copy
+    // was fully processed and must carry the cycle alone, with no fallout on later cycles.
+    socket_nominal_->drop_next_delivery = true; // loses the tail-injected copy
+
+    auto result = runLRWCycle(0x80);
+    EXPECT_TRUE(result.processed);
+    EXPECT_EQ(0, result.errors);
+    EXPECT_EQ(9, result.wkc);
+    checkMergedPayload(result, 0x80, INPUT_BASE);
+
+    writeInputs(0xD0E0F000);
+    auto clean = runLRWCycle(0x40);
+    EXPECT_TRUE(clean.processed);
+    EXPECT_EQ(0, clean.errors);
+    EXPECT_EQ(9, clean.wkc);
+    checkMergedPayload(clean, 0x40, 0xD0E0F000);
+
+    // Losing the head-injected copy is not coverable on an intact ring: the surviving
+    // tail copy streamed through unprocessed, so the cycle degrades visibly (wkc 0).
+    socket_redundancy_->drop_next_delivery = true;
+    writeInputs(0xB0B0B000);
+    auto degraded = runLRWCycle(0x20);
+    EXPECT_TRUE(degraded.processed);
+    EXPECT_EQ(0, degraded.wkc);
+
+    writeInputs(0xC1C1C100);
+    auto recovered = runLRWCycle(0x60);
+    EXPECT_TRUE(recovered.processed);
+    EXPECT_EQ(0, recovered.errors);
+    EXPECT_EQ(9, recovered.wkc);
+    checkMergedPayload(recovered, 0x60, 0xC1C1C100);
+}
+
+TEST_F(RedundancyIntegration, both_master_cables_cut_then_restored)
+{
+    socket_nominal_->cut_to_master = true;
+    socket_redundancy_->cut_to_master = true;
+
+    auto dead = runLRWCycle(0x80);
+    EXPECT_FALSE(dead.processed);
+    EXPECT_EQ(1, dead.errors);
+    EXPECT_EQ(DatagramState::LOST, dead.error_state);
+
+    socket_nominal_->cut_to_master = false;
+    socket_redundancy_->cut_to_master = false;
+    writeInputs(0xD0E0F000);
+
+    auto recovered = runLRWCycle(0x40);
+    EXPECT_TRUE(recovered.processed);
+    EXPECT_EQ(0, recovered.errors);
+    EXPECT_EQ(9, recovered.wkc);
+    checkMergedPayload(recovered, 0x40, 0xD0E0F000);
+    checkOutputsApplied(0x40);
+}
+
+TEST_F(RedundancyIntegration, heal_after_split_recovers_intact_behavior)
+{
+    net_->setLinkState(0, 1, false);
+    auto degraded = runLRWCycle(0x80);
+    EXPECT_TRUE(degraded.processed);
+    EXPECT_EQ(9, degraded.wkc);
+    checkMergedPayload(degraded, 0x80, INPUT_BASE);
+
+    net_->setLinkState(0, 1, true);
+    writeInputs(0xD0E0F000); // distinguishable from cycle 1 inputs
+
+    auto healed = runLRWCycle(0x40);
+
+    EXPECT_TRUE(net_->ringIntact());
+    EXPECT_TRUE(healed.processed);
+    EXPECT_EQ(0, healed.errors);
+    EXPECT_EQ(9, healed.wkc);
+    checkMergedPayload(healed, 0x40, 0xD0E0F000);
+    checkOutputsApplied(0x40);
+}
+
+TEST_F(RedundancyIntegration, brd_split_or_merge_through_link)
+{
+    net_->setLinkState(0, 1, false);
+
+    // Same value on both tail-segment slaves so the expected OR holds whether the
+    // emulated BRD overwrites or ORs within one copy: the cross-copy OR is what's pinned.
+    uint16_t const addr_head = 0x0022;
+    uint16_t const addr_tail = 0x4400;
+    slaves_[0]->write(reg::STATION_ADDR, &addr_head, sizeof(addr_head));
+    slaves_[1]->write(reg::STATION_ADDR, &addr_tail, sizeof(addr_tail));
+    slaves_[2]->write(reg::STATION_ADDR, &addr_tail, sizeof(addr_tail));
+
+    uint16_t value = 0;
+    uint16_t wkc = 0;
+    bool processed = false;
+    int32_t errors = 0;
+    auto process = [&](DatagramHeader const*, uint8_t const* data, uint16_t wkc_received)
+    {
+        processed = true;
+        wkc = wkc_received;
+        std::memcpy(&value, data, sizeof(value));
+        return DatagramState::OK;
+    };
+    auto error = [&errors](DatagramState const&)
+    {
+        ++errors;
+    };
+
+    link_->addDatagram(Command::BRD, createAddress(0, reg::STATION_ADDR), nullptr,
+                       sizeof(uint16_t), process, error);
+    link_->processDatagrams();
+
+    EXPECT_TRUE(processed);
+    EXPECT_EQ(0, errors);
+    EXPECT_EQ(3, wkc);       // 1 (head segment) + 2 (tail segment)
+    EXPECT_EQ(0x4422, value);
+}


### PR DESCRIPTION
  - Each datagram pair is now merged according to its command (OR for reads incl. BRW, non-zero-wkc copy for single-responder RW, keep-nominal otherwise), and LRW is spliced from the FMMU mapping.
  - Stale and desynchronized frames are fenced by the in-flight index window instead of being blindly OR-merged
  - the EmulatedNetwork now processes frames on the port-0/EPU path with circulating-flag and cut-through semantics   matching real ESCs.