### PR TITLE
Emulator fidelity: EEPROM master writes and broadcast OR/ADP semantics

### DIFF
--- a/lib/slave/include/kickcat/ESC/EmulatedESC.h
+++ b/lib/slave/include/kickcat/ESC/EmulatedESC.h
@@ -198,6 +198,11 @@ namespace kickcat
         void processWriteCommand    (DatagramHeader* header, void* data, uint16_t* wkc, uint16_t offset);
         void processReadWriteCommand(DatagramHeader* header, void* data, uint16_t* wkc, uint16_t offset);
 
+        // Broadcast reads OR the memory into the frame instead of overwriting it (ETG.1000.4).
+        void processBroadcastReadCommand     (DatagramHeader* header, void* data, uint16_t* wkc, uint16_t offset);
+        void processBroadcastReadWriteCommand(DatagramHeader* header, void* data, uint16_t* wkc, uint16_t offset);
+        int32_t readOrIntoFrame(uint16_t offset, void* data, uint16_t size);
+
         // FPxx target: configured station address, or the station alias when set.
         bool matchesConfiguredAddress(uint16_t position) const;
 

--- a/lib/slave/src/ESC/EmulatedESC.cc
+++ b/lib/slave/src/ESC/EmulatedESC.cc
@@ -413,9 +413,29 @@ namespace kickcat
             }
 
             //************* Broadcast *************//
-            case Command::BRD:  { processReadCommand     (header, data, wkc, offset); break; }
-            case Command::BWR:  { processWriteCommand    (header, data, wkc, offset); break; }
-            case Command::BRW:  { processReadWriteCommand(header, data, wkc, offset); break; }
+            // ETG.1000.4 5.4.x.4: every slave processes the datagram and increments ADP;
+            // read data is bitwise-ORed into the frame, not copied over it.
+            case Command::BRD:
+            {
+                processBroadcastReadCommand(header, data, wkc, offset);
+                ++position;
+                header->address = createAddress(position, offset);
+                break;
+            }
+            case Command::BWR:
+            {
+                processWriteCommand(header, data, wkc, offset);
+                ++position;
+                header->address = createAddress(position, offset);
+                break;
+            }
+            case Command::BRW:
+            {
+                processBroadcastReadWriteCommand(header, data, wkc, offset);
+                ++position;
+                header->address = createAddress(position, offset);
+                break;
+            }
 
             //************** Logical **************//
             case Command::LRD:  { processLRD(header, data, wkc); break; }
@@ -505,8 +525,9 @@ namespace kickcat
             memory_.al_status = memory_.al_control;
         }
 
-        // Handle eeprom access
-        uint16_t order = memory_.eeprom_control & 0x0701;
+        // Handle eeprom access. Command is in bits [10:8] only: a conformant master
+        // sets WR_EN (bit 0) alongside WRITE, so matching on bit 0 too drops writes.
+        uint16_t order = memory_.eeprom_control & eeprom::Control::COMMAND;
         switch (order)
         {
             case eeprom::Control::READ:
@@ -526,11 +547,20 @@ namespace kickcat
             }
             case eeprom::Control::WRITE:
             {
+                if (not (memory_.eeprom_control & eeprom::Control::WR_EN))
+                {
+                    // Datasheet 0x0502[14]: write command without write enable
+                    memory_.eeprom_control &= ~eeprom::Control::COMMAND;
+                    memory_.eeprom_control |= eeprom::Control::ERROR_WR_EN;
+                    break;
+                }
+
                 if (memory_.eeprom_address >= eeprom_.size())
                 {
                     // Increase eeprom size to let the write be done properly
                     // This is a shortcut for emulation, real device should handle the eeprom size.
-                    eeprom_.resize(memory_.eeprom_address);
+                    // One word past the address (word-addressed); fill mimics an unwritten eeprom.
+                    eeprom_.resize(std::size_t(memory_.eeprom_address) + 1, 0xFFFF);
                 }
 
                 memory_.eeprom_control &= ~0x0700; // clear order
@@ -548,13 +578,14 @@ namespace kickcat
                     last_write_eeprom_ = since_epoch();
                     std::memcpy(eeprom_.data() + memory_.eeprom_address, &memory_.eeprom_data, 2);
                     memory_.eeprom_control &= ~0x0700; // clear order
+                    memory_.eeprom_control &= ~eeprom::Control::WR_EN; // self-clearing once the write is done
                 }
 
                 break;
             }
             case eeprom::Control::NOP:
             {
-                memory_.eeprom_control &= ~eeprom::Control::ERROR_CMD;
+                memory_.eeprom_control &= ~(eeprom::Control::ERROR_CMD | eeprom::Control::ERROR_WR_EN);
                 break;
             }
             case eeprom::Control::RELOAD:
@@ -587,6 +618,49 @@ namespace kickcat
         if (written > 0)
         {
             *wkc += 1;
+        }
+    }
+
+
+    int32_t EmulatedESC::readOrIntoFrame(uint16_t offset, void* data, uint16_t size)
+    {
+        uint8_t buffer[MAX_ETHERCAT_PAYLOAD_SIZE];
+        int32_t read = computeInternalMemoryAccess(offset, buffer, size, Access::ECAT_READ);
+        uint8_t* frame = static_cast<uint8_t*>(data);
+        for (int32_t i = 0; i < read; ++i)
+        {
+            frame[i] |= buffer[i];
+        }
+        return read;
+    }
+
+
+    void EmulatedESC::processBroadcastReadCommand(DatagramHeader* header, void* data, uint16_t* wkc, uint16_t offset)
+    {
+        if (readOrIntoFrame(offset, data, header->len) > 0)
+        {
+            *wkc += 1;
+        }
+    }
+
+
+    void EmulatedESC::processBroadcastReadWriteCommand(DatagramHeader* header, void* data, uint16_t* wkc, uint16_t offset)
+    {
+        // ETG.1000.4 5.4.3.4: the data as received is written, the memory content
+        // before the write is ORed into the frame.
+        uint8_t swap[MAX_ETHERCAT_PAYLOAD_SIZE];
+        std::memcpy(swap, data, header->len);
+
+        int32_t read    = readOrIntoFrame(offset, data, header->len);
+        int32_t written = computeInternalMemoryAccess(offset, swap, header->len, Access::ECAT_WRITE);
+
+        if (read > 0)
+        {
+            *wkc += 1;
+        }
+        if (written > 0)
+        {
+            *wkc += 2;
         }
     }
 

--- a/unit/src/EmulatedESC-t.cc
+++ b/unit/src/EmulatedESC-t.cc
@@ -190,34 +190,74 @@ TEST(EmulatedESC, ecat_bxx_registers)
     uint64_t payload = 0xCAFE0000DECA0000;
     DatagramHeader header{Command::BRD, 0, 0, sizeof(uint64_t), 0, 0, 0, 0};
 
-    // Test that the ECAT Bxx can read/write any address below 0x1000
+    // Test that the ECAT Bxx can read/write any address below 0x1000.
+    // ETG.1000.4: broadcast reads OR the memory into the frame and every
+    // broadcast command increments ADP.
     for (uint16_t address = 0; address < 0x1000; address += sizeof(uint64_t))
     {
-        header.address = createAddress(0, address);
-
         uint64_t read_test = 0;
         uint16_t wkc = 0;
 
         header.command = Command::BRD;
+        header.address = createAddress(0, address);
         esc.processDatagram(&header, &read_test, &wkc);
         ASSERT_EQ(wkc, 1);
+        ASSERT_EQ(header.address, createAddress(1, address)); // +1 on address position for each ESC processing
         ASSERT_NE(read_test, payload);
 
         header.command = Command::BWR;
+        header.address = createAddress(0, address);
         esc.processDatagram(&header, &payload, &wkc);
         ASSERT_EQ(wkc, 2);
+        ASSERT_EQ(header.address, createAddress(1, address));
 
         read_test = 0xDEAD0000BEEF0000;
         header.command = Command::BRW;
+        header.address = createAddress(0, address);
         esc.processDatagram(&header, &read_test, &wkc);
         ASSERT_EQ(wkc, 5);
-        ASSERT_EQ(read_test, payload);
+        ASSERT_EQ(header.address, createAddress(1, address));
+        ASSERT_EQ(read_test, 0xDEAD0000BEEF0000 | payload);   // frame = request data OR memory
 
+        read_test = 0;
         header.command = Command::BRD;
+        header.address = createAddress(0, address);
         esc.processDatagram(&header, &read_test, &wkc);
         ASSERT_EQ(wkc, 6);
-        ASSERT_EQ(read_test, 0xDEAD0000BEEF0000);
+        ASSERT_EQ(header.address, createAddress(1, address));
+        ASSERT_EQ(read_test, 0xDEAD0000BEEF0000);             // BRW wrote the data as received
     }
+}
+
+TEST(EmulatedESC, ecat_brd_or_merges_across_slaves)
+{
+    // Two slaves answering the same BRD: the master must see the OR of both
+    // memories (a faulted slave's AL_STATUS bits cannot be masked by a healthy
+    // slave answering later), and each slave increments ADP.
+    EmulatedESC esc_faulted;
+    EmulatedESC esc_healthy;
+
+    uint16_t al_status = State::SAFE_OP | AL_STATUS_ERR_IND;
+    esc_faulted.write(reg::AL_STATUS, &al_status, sizeof(al_status));
+    al_status = State::OPERATIONAL;
+    esc_healthy.write(reg::AL_STATUS, &al_status, sizeof(al_status));
+
+    // Keep the device-emulation AL_STATUS mirror from overwriting the values above.
+    uint16_t al_control = State::SAFE_OP | AL_STATUS_ERR_IND;
+    esc_faulted.write(reg::AL_CONTROL, &al_control, sizeof(al_control));
+    al_control = State::OPERATIONAL;
+    esc_healthy.write(reg::AL_CONTROL, &al_control, sizeof(al_control));
+
+    DatagramHeader header{Command::BRD, 0, createAddress(0, reg::AL_STATUS), sizeof(uint16_t), 0, 0, 0, 0};
+    uint16_t read_test = 0;
+    uint16_t wkc = 0;
+    esc_faulted.processDatagram(&header, &read_test, &wkc);
+    esc_healthy.processDatagram(&header, &read_test, &wkc);
+
+    ASSERT_EQ(wkc, 2);
+    ASSERT_EQ(header.address, createAddress(2, reg::AL_STATUS));
+    ASSERT_EQ(read_test, State::SAFE_OP | State::OPERATIONAL | AL_STATUS_ERR_IND);
+    ASSERT_NE(read_test & AL_STATUS_ERR_IND, 0);
 }
 
 TEST(EmulatedESC, ecat_PDOs)
@@ -452,6 +492,124 @@ TEST(EmulatedESC, ecat_eeprom_reload_reapplies_config)
 
     esc.read(reg::STATION_ALIAS, &alias, sizeof(alias));
     ASSERT_EQ(alias, 0xBEEF);
+}
+
+namespace
+{
+    // Drive the exact Bus::writeEeprom sequence: FPWR data word, then FPWR the
+    // WRITE|WR_EN request until the control register no longer reports ERROR_CMD.
+    bool masterWriteEepromWord(EmulatedESC& esc, uint16_t station, uint16_t address, uint16_t word)
+    {
+        DatagramHeader header{Command::FPWR, 0, createAddress(station, reg::EEPROM_DATA), sizeof(word), 0, 0, 0, 0};
+        uint16_t wkc = 0;
+        esc.processDatagram(&header, &word, &wkc);
+        if (wkc != 1)
+        {
+            return false;
+        }
+
+        for (int retry = 0; retry < 20; ++retry)
+        {
+            eeprom::Request req{static_cast<uint16_t>(eeprom::Control::WRITE | eeprom::Control::WR_EN), address, 0};
+            header.command = Command::FPWR;
+            header.address = createAddress(station, reg::EEPROM_CONTROL);
+            header.len     = sizeof(req);
+            wkc = 0;
+            esc.processDatagram(&header, &req, &wkc);
+            if (wkc != 1)
+            {
+                return false;
+            }
+
+            uint16_t control = 0;
+            header.command = Command::FPRD;
+            header.address = createAddress(station, reg::EEPROM_CONTROL);
+            header.len     = sizeof(control);
+            wkc = 0;
+            esc.processDatagram(&header, &control, &wkc);
+            if (wkc != 1)
+            {
+                return false;
+            }
+            if (not (control & eeprom::Control::ERROR_CMD))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // READ command then fetch the data register (lower 32 bits = 2 words).
+    uint32_t masterReadEepromWords(EmulatedESC& esc, uint16_t station, uint16_t address)
+    {
+        eeprom::Request req{eeprom::Control::READ, address, 0};
+        DatagramHeader header{Command::FPWR, 0, createAddress(station, reg::EEPROM_CONTROL), sizeof(req), 0, 0, 0, 0};
+        uint16_t wkc = 0;
+        esc.processDatagram(&header, &req, &wkc);
+        EXPECT_EQ(wkc, 1);
+
+        uint32_t data = 0;
+        header.command = Command::FPRD;
+        header.address = createAddress(station, reg::EEPROM_DATA);
+        header.len     = sizeof(data);
+        wkc = 0;
+        esc.processDatagram(&header, &data, &wkc);
+        EXPECT_EQ(wkc, 1);
+        return data;
+    }
+}
+
+TEST(EmulatedESC, ecat_eeprom_master_write_sequence)
+{
+    EmulatedESC esc;
+    std::vector<uint16_t> image(8);
+    for (size_t i = 0; i < image.size(); ++i)
+    {
+        image[i] = static_cast<uint16_t>(0x1100 + i);
+    }
+    esc.loadEeprom(image);
+
+    uint16_t const station = 0x1234;
+    uint16_t wkc = 0;
+    DatagramHeader header{Command::APWR, 0, createAddress(0, reg::STATION_ADDR), sizeof(station), 0, 0, 0, 0};
+    uint16_t address_payload = station;
+    esc.processDatagram(&header, &address_payload, &wkc);
+    ASSERT_EQ(wkc, 1);
+
+    // Conformant master write (WRITE with WR_EN) must land in the EEPROM.
+    ASSERT_TRUE(masterWriteEepromWord(esc, station, 5, 0xCAFE));
+    ASSERT_TRUE(masterWriteEepromWord(esc, station, 6, 0xDECA));
+    ASSERT_EQ(masterReadEepromWords(esc, station, 5), 0xDECACAFEu);
+
+    // Writing past the loaded image must grow it (word-addressed) without
+    // corrupting the heap; the word at the new end of the EEPROM is reachable.
+    ASSERT_TRUE(masterWriteEepromWord(esc, station, 20, 0xBEEF));
+    ASSERT_TRUE(masterWriteEepromWord(esc, station, 21, 0xDEAD));
+    ASSERT_EQ(masterReadEepromWords(esc, station, 20), 0xDEADBEEFu);
+
+    // The gap created by the resize reads as an unwritten EEPROM, not as zeros.
+    ASSERT_EQ(masterReadEepromWords(esc, station, 10), 0xFFFFFFFFu);
+
+    // A WRITE command without WR_EN is refused: error bit 14 raised, data untouched.
+    uint16_t word = 0x5555;
+    header.command = Command::FPWR;
+    header.address = createAddress(station, reg::EEPROM_DATA);
+    header.len     = sizeof(word);
+    wkc = 0;
+    esc.processDatagram(&header, &word, &wkc);
+
+    eeprom::Request req{eeprom::Control::WRITE, 2, 0};
+    header.address = createAddress(station, reg::EEPROM_CONTROL);
+    header.len     = sizeof(req);
+    esc.processDatagram(&header, &req, &wkc);
+
+    uint16_t control = 0;
+    header.command = Command::FPRD;
+    header.address = createAddress(station, reg::EEPROM_CONTROL);
+    header.len     = sizeof(control);
+    esc.processDatagram(&header, &control, &wkc);
+    ASSERT_NE(control & eeprom::Control::ERROR_WR_EN, 0);
+    ASSERT_EQ(masterReadEepromWords(esc, station, 2), 0x11031102u); // image words 2 and 3 untouched
 }
 
 TEST(LoopbackSocket, runs_frame_through_slave_and_ticks)

--- a/unit/src/EmulatedNetwork-t.cc
+++ b/unit/src/EmulatedNetwork-t.cc
@@ -251,6 +251,40 @@ TEST(EmulatedNetwork, split_ring_lrw_master_merge_rebuilds_inputs)
 }
 
 
+TEST(EmulatedNetwork, brd_or_merges_data_and_increments_adp)
+{
+    auto slaves = makeSlaves(3);
+    EmulatedNetwork net(pointers(slaves));
+
+    // One distinct AL_STATUS bit per slave: the OR-merge must expose all of them.
+    uint16_t status = State::INIT;
+    slaves[0]->write(reg::AL_STATUS, &status, sizeof(status));
+    status = State::PRE_OP;
+    slaves[1]->write(reg::AL_STATUS, &status, sizeof(status));
+    status = State::SAFE_OP | AL_STATUS_ERR_IND;
+    slaves[2]->write(reg::AL_STATUS, &status, sizeof(status));
+
+    uint16_t payload = 0;
+    Frame frame;
+    frame.addDatagram(0, Command::BRD, createAddress(0, reg::AL_STATUS), &payload, sizeof(payload));
+    frame.finalize();
+    EXPECT_TRUE(net.route(frame, false));
+
+    frame.resetContext();
+    auto [header, data, wkc] = frame.peekDatagram();
+    EXPECT_EQ(3, *wkc);
+
+    // ETG.1000.4 Table 16: ADP incremented by one at each slave, DATA is the
+    // bitwise OR of the request data and every addressed slave's memory.
+    auto [position, offset] = extractAddress(header->address);
+    EXPECT_EQ(3, position);
+    EXPECT_EQ(reg::AL_STATUS, offset);
+
+    uint16_t merged = 0;
+    std::memcpy(&merged, data, sizeof(merged));
+    EXPECT_EQ(State::INIT | State::PRE_OP | State::SAFE_OP | AL_STATUS_ERR_IND, merged);
+}
+
 TEST(EmulatedNetwork, intact_ring_sets_no_circulating_flag)
 {
     auto slaves = makeSlaves(3);


### PR DESCRIPTION
EEPROM (ESC datasheet sec2, 2.11.3 reg 0x0502):
- Match the command on bits [10:8] only; the old 0x0701 mask compared WRITE|WR_EN against bare WRITE, silently dropping every conformant master write while Bus::writeEeprom reported success.
- Refuse a WRITE without WR_EN with error bit 14 (ERROR_WR_EN); NOP clears it along with ERROR_CMD. WR_EN self-clears once the write is done.
- Grow the eeprom vector to address + 1 words (was resize(address), one word short: the write at the word index 'address' overflowed the heap) and fill new words with 0xFFFF to mimic an unwritten eeprom.

Broadcast commands (ETG.1000.4 5.4.1.4 / 5.4.2.4 / 5.4.3.4):
- BRD/BRW OR the addressed memory into the frame instead of overwriting it, so a faulted slave's AL_STATUS bits survive a healthy slave answering later. BRW writes the data as received, per spec.
- BRD/BWR/BRW increment ADP at each slave, like the auto-increment commands.

ecat_bxx_registers asserted the old overwrite behavior and was updated to the spec semantics; the Link redundancy merge already assumed the OR behavior for zero-sent BRD payloads.