### PR TITLE
Misc fixes

### DIFF
--- a/lib/include/kickcat/protocol.h
+++ b/lib/include/kickcat/protocol.h
@@ -507,7 +507,8 @@ namespace kickcat
             EoE  = 0x02,
             CoE  = 0x04,
             FoE  = 0x08,
-            SoE  = 0x10
+            SoE  = 0x10,
+            VoE  = 0x20
         };
 
         enum Control : uint16_t

--- a/lib/master/include/kickcat/Gateway.h
+++ b/lib/master/include/kickcat/Gateway.h
@@ -27,8 +27,12 @@ namespace kickcat
 
         /// \brief   Process pending requests
         /// \details A pending request is a request that was successfully transfered to the EtherCAT bus, waiting for its completion.
-        ///          All requests completed on the bus are sent back to their respective requestors
+        ///          All requests completed on the bus are sent back to their respective requestors.
+        ///          Failed requests (timeout, error) are dropped without a reply.
         void processPendingRequests();
+
+        /// \return Number of requests waiting for completion
+        std::size_t pendingRequests() const { return pendingRequests_.size(); }
 
     private:
         std::shared_ptr<AbstractDiagSocket> socket_;

--- a/lib/master/include/kickcat/Slave.h
+++ b/lib/master/include/kickcat/Slave.h
@@ -58,40 +58,40 @@ namespace kickcat
 
         //-----------------------------------------------------------//
 
-        uint16_t address;
+        uint16_t address{0};
         uint8_t al_status{State::INVALID};
-        uint16_t al_status_code;
+        uint16_t al_status_code{0};
 
-        mailbox::request::Mailbox mailbox;
-        mailbox::request::Mailbox mailbox_bootstrap;
-        int32_t waiting_datagram;  // how many datagram to process for this slave
+        mailbox::request::Mailbox mailbox{};
+        mailbox::request::Mailbox mailbox_bootstrap{};
+        int32_t waiting_datagram{0};  // how many datagram to process for this slave
 
-        DLStatus dl_status;
+        DLStatus dl_status{};
 
         eeprom::SII sii{};
 
         struct PIMapping
         {
-            uint8_t* data;         // buffer client to read or write back
-            int32_t size;          // size fo the mapping (in bits)
-            int32_t bsize;         // size of the mapping (in bytes)
-            int32_t sync_manager;  // associated Sync manager
-            uint32_t address;      // logical address
+            uint8_t* data{nullptr};   // buffer client to read or write back
+            int32_t size{0};          // size fo the mapping (in bits)
+            int32_t bsize{0};         // size of the mapping (in bytes)
+            int32_t sync_manager{0};  // associated Sync manager
+            uint32_t address{0};      // logical address
         };
         // set it to true to let user define the mapping, false to autodetect it
         // If set to true, user shall set input and output mapping bsize and sync_manager members.
-        bool is_static_mapping;
-        PIMapping input;  // slave to master
-        PIMapping output;
+        bool is_static_mapping{false};
+        PIMapping input{};  // slave to master
+        PIMapping output{};
 
-        ErrorCounters error_counters;
+        ErrorCounters error_counters{};
         int previous_errors_sum{0};
 
-        ESC::Description esc;
+        ESC::Description esc{};
 
         // DC received time record - required to compute propagation delay
-        nanoseconds dc_received_time[4];
-        nanoseconds dc_ecat_received_time;
+        nanoseconds dc_received_time[4]{};
+        nanoseconds dc_ecat_received_time{0ns};
         nanoseconds delay = 0ns;
         nanoseconds dc_time_offset = 0ns;
     };

--- a/lib/master/src/Bus.cc
+++ b/lib/master/src/Bus.cc
@@ -78,7 +78,7 @@ namespace kickcat
 
     void Bus::disableIRQ(enum EcatEvent event)
     {
-        link_->attachEcatEventCallback(event, {});
+        link_->attachEcatEventCallback(event, [](){});
 
         irq_mask_ &= ~event;
         uint16_t wkc = broadcastWrite(reg::ECAT_EVENT_MASK, &irq_mask_, 2);

--- a/lib/master/src/CoE.cc
+++ b/lib/master/src/CoE.cc
@@ -50,11 +50,15 @@ namespace kickcat
         uint32_t size = sizeof(object_size);
         auto sdo = slave.mailbox.createSDO(index, 0, false, CoE::SDO::request::UPLOAD, &object_size, &size, timeout);
         waitForMessage(sdo);
+        if (sdo->status() != MessageStatus::SUCCESS)
+        {
+            THROW_ERROR_CODE("Error while reading SDO - emulated complete access", error::category::CoE, sdo->status());
+        }
 
         uint8_t* pos = reinterpret_cast<uint8_t*>(data);
         size = *data_size;
         uint32_t already_read = 0;
-        for (uint8_t i = 1; i <= object_size; ++i)
+        for (uint16_t i = 1; i <= object_size; ++i)
         {
             size = *data_size - already_read;
             if (size == 0)
@@ -62,7 +66,7 @@ namespace kickcat
                 THROW_ERROR("Error while reading SDO - client buffer too small");
             }
 
-            sdo = slave.mailbox.createSDO(index, i, false, CoE::SDO::request::UPLOAD, pos, &size, timeout);
+            sdo = slave.mailbox.createSDO(index, static_cast<uint8_t>(i), false, CoE::SDO::request::UPLOAD, pos, &size, timeout);
             waitForMessage(sdo);
 
             if (sdo->status() != MessageStatus::SUCCESS)

--- a/lib/master/src/Gateway.cc
+++ b/lib/master/src/Gateway.cc
@@ -67,15 +67,24 @@ namespace kickcat
         pendingRequests_.erase(std::remove_if(pendingRequests_.begin(), pendingRequests_.end(),
             [&](std::shared_ptr<GatewayMessage> msg)-> bool
             {
-                if (msg->status() != MessageStatus::SUCCESS)
+                uint32_t const status = msg->status();
+                if (status == MessageStatus::RUNNING)
                 {
                     return false;
                 }
 
+                if (status != MessageStatus::SUCCESS)
+                {
+                    // Failed requests would otherwise accumulate forever: drop them without a reply.
+                    gateway_error("Request %d failed with status 0x%" PRIx32 "\n", msg->gatewayIndex(), status);
+                    return true;
+                }
+
+                size_t const reply_size = std::min(msg->size(), sizeof(frame) - sizeof(EthercatHeader));
                 header->type = EthercatType::MAILBOX;
-                header->len  = msg->size() & 0x7ff;
-                std::memcpy(frame + sizeof(EthercatHeader), msg->data(), msg->size());
-                socket_->sendTo(frame, static_cast<int32_t>(msg->size() + sizeof(EthercatHeader)), msg->gatewayIndex());
+                header->len  = reply_size & 0x7ff;
+                std::memcpy(frame + sizeof(EthercatHeader), msg->data(), reply_size);
+                socket_->sendTo(frame, static_cast<int32_t>(reply_size + sizeof(EthercatHeader)), msg->gatewayIndex());
 
                 return true;
             }),

--- a/lib/master/src/Link.cc
+++ b/lib/master/src/Link.cc
@@ -442,6 +442,12 @@ namespace kickcat
 
     void Link::attachEcatEventCallback(enum EcatEvent ecat_event, std::function<void()> callback)
     {
+        if (not callback)
+        {
+            // checkEcatEvents() invokes callbacks unchecked from the cyclic path
+            THROW_ERROR("attachEcatEventCallback: empty callback");
+        }
+
         int32_t index = 0;
         uint16_t mask = ecat_event;
         while (mask != 0)

--- a/lib/py_bindings/src/bus_py.cc
+++ b/lib/py_bindings/src/bus_py.cc
@@ -16,6 +16,18 @@ using namespace nb::literals;
 
 namespace kickcat
 {
+    namespace
+    {
+        // createMapping() keeps pointers into the io buffer, so it must live as long
+        // as the Bus instance (a function-local static would be shared by every Bus
+        // of the process and resized under the others' feet).
+        struct PyBus final : Bus
+        {
+            using Bus::Bus;
+            std::vector<uint8_t> io_buffer;
+        };
+    }
+
     void create_bus_python_bindings(nb::module_ &m)
     {
         nb::enum_<Bus::Access>(m, "Access")
@@ -36,19 +48,19 @@ namespace kickcat
                 });
             });
 
-        nb::class_<Bus>(m, "Bus")
+        nb::class_<PyBus>(m, "Bus")
             .def(nb::init<std::shared_ptr<Link>>())
             .def("init", &Bus::init)
             .def("detect_slaves", &Bus::detectSlaves)
             .def("slaves", &Bus::slaves, nb::rv_policy::reference_internal)
             .def("get_state", &Bus::getCurrentState)
             .def("request_state", &Bus::requestState)
-            .def("wait_for_state", [](Bus &self, State state, std::chrono::nanoseconds timeout)
+            .def("wait_for_state", [](PyBus &self, State state, std::chrono::nanoseconds timeout)
                 {
                     auto noop = [](){};
                     self.waitForState(state, timeout, noop);
                 })
-            .def("wait_for_state", [](Bus &self, State state, std::chrono::nanoseconds timeout, nb::callable callback)
+            .def("wait_for_state", [](PyBus &self, State state, std::chrono::nanoseconds timeout, nb::callable callback)
                 {
                     auto cpp_callback = [callback]()
                     {
@@ -56,7 +68,7 @@ namespace kickcat
                     };
                     self.waitForState(state, timeout, cpp_callback);
                 })
-            .def("process_data", [](Bus &self)
+            .def("process_data", [](PyBus &self)
                 {
                     auto read_error  = [](DatagramState const& state)
                     {
@@ -73,13 +85,13 @@ namespace kickcat
                     self.processDataRead(read_error);
                     self.processDataWrite(write_error);
                 })
-            .def("process_data_no_check", [](Bus &self)
+            .def("process_data_no_check", [](PyBus &self)
                 {
                     auto noop =[](DatagramState const&){};
                     self.processDataRead(noop);
                     self.processDataWrite(noop);
                 })
-            .def("process_mailboxes", [](Bus &self)
+            .def("process_mailboxes", [](PyBus &self)
                 {
                     auto check_error = [](DatagramState const& state)
                     {
@@ -97,7 +109,7 @@ namespace kickcat
                     };
                     self.processMessages(process_error);
                 })
-            .def("send_logical_read", [](Bus &self, nb::callable error_callback)
+            .def("send_logical_read", [](PyBus &self, nb::callable error_callback)
                 {
                     std::function<void(DatagramState const&)> cpp_callback =
                         [error_callback](DatagramState const& state)
@@ -107,7 +119,7 @@ namespace kickcat
                         };
                     self.sendLogicalRead(cpp_callback);
                 })
-            .def("send_logical_write", [](Bus &self, nb::callable error_callback)
+            .def("send_logical_write", [](PyBus &self, nb::callable error_callback)
                 {
                     std::function<void(DatagramState const&)> cpp_callback =
                         [error_callback](DatagramState const& state)
@@ -117,7 +129,7 @@ namespace kickcat
                         };
                     self.sendLogicalWrite(cpp_callback);
                 })
-            .def("send_refresh_error_counters", [](Bus &self, nb::callable error_callback)
+            .def("send_refresh_error_counters", [](PyBus &self, nb::callable error_callback)
                 {
                     std::function<void(DatagramState const&)> cpp_callback =
                         [error_callback](DatagramState const& state)
@@ -127,7 +139,7 @@ namespace kickcat
                         };
                     self.sendRefreshErrorCounters(cpp_callback);
                 })
-            .def("send_mailboxes_read_checks", [](Bus &self, nb::callable error_callback)
+            .def("send_mailboxes_read_checks", [](PyBus &self, nb::callable error_callback)
                 {
                     std::function<void(DatagramState const&)> cpp_callback =
                         [error_callback](DatagramState const& state)
@@ -137,7 +149,7 @@ namespace kickcat
                         };
                     self.sendMailboxesReadChecks(cpp_callback);
                 })
-            .def("send_mailboxes_write_checks", [](Bus &self, nb::callable error_callback)
+            .def("send_mailboxes_write_checks", [](PyBus &self, nb::callable error_callback)
                 {
                     std::function<void(DatagramState const&)> cpp_callback =
                         [error_callback](DatagramState const& state)
@@ -147,7 +159,7 @@ namespace kickcat
                         };
                     self.sendMailboxesWriteChecks(cpp_callback);
                 })
-            .def("send_read_messages", [](Bus &self, nb::callable error_callback)
+            .def("send_read_messages", [](PyBus &self, nb::callable error_callback)
                 {
                     std::function<void(DatagramState const&)> cpp_callback =
                         [error_callback](DatagramState const& state)
@@ -157,7 +169,7 @@ namespace kickcat
                         };
                     self.sendReadMessages(cpp_callback);
                 })
-            .def("send_write_messages", [](Bus &self, nb::callable error_callback)
+            .def("send_write_messages", [](PyBus &self, nb::callable error_callback)
                 {
                     std::function<void(DatagramState const&)> cpp_callback =
                         [error_callback](DatagramState const& state)
@@ -169,12 +181,12 @@ namespace kickcat
                 })
             .def("finalize_datagrams", &Bus::finalizeDatagrams)
             .def("process_awaiting_frames", &Bus::processAwaitingFrames)
-            .def("create_mapping", [](Bus &self, int size)
+            .def("create_mapping", [](PyBus &self, int size)
                 {
-                    static std::vector<uint8_t> io_buffer(size);
-                    self.createMapping(io_buffer.data(), io_buffer.size());
+                    self.io_buffer.assign(static_cast<std::size_t>(size), 0);
+                    self.createMapping(self.io_buffer.data(), self.io_buffer.size());
                 }, "size"_a = 4096)
-            .def("read_sdo", [](Bus &self, Slave& slave, uint16_t index, uint8_t subindex,
+            .def("read_sdo", [](PyBus &self, Slave& slave, uint16_t index, uint8_t subindex,
                                Bus::Access ca, uint32_t max_data_size = 4,
                                std::chrono::nanoseconds timeout = std::chrono::seconds(1))
                 {
@@ -187,7 +199,7 @@ namespace kickcat
                     buffer.resize(actual_size);
                     return nb::bytes(reinterpret_cast<const char*>(buffer.data()), actual_size);
                 })
-            .def("read_object_description", [](Bus &self, Slave& slave, uint16_t index) -> std::tuple<std::string, std::string>
+            .def("read_object_description", [](PyBus &self, Slave& slave, uint16_t index) -> std::tuple<std::string, std::string>
                 {
                     char buffer[4096];
                     uint32_t buffer_size = 4096; // in bytes
@@ -204,7 +216,7 @@ namespace kickcat
 
                     return {name, toString(*description)};
                 })
-            .def("read_entry_description",  [](Bus &self, Slave& slave, uint16_t index, uint8_t subindex) -> std::tuple<std::string, std::string>
+            .def("read_entry_description",  [](PyBus &self, Slave& slave, uint16_t index, uint8_t subindex) -> std::tuple<std::string, std::string>
                 {
                     char buffer[4096];
                     uint32_t buffer_size = 4096; // in bytes

--- a/lib/slave/src/ESC/EmulatedESC.cc
+++ b/lib/slave/src/ESC/EmulatedESC.cc
@@ -467,6 +467,10 @@ namespace kickcat
         {
             return true;
         }
+        if ((memory_.dl_control & 0x01000000) == 0)
+        {
+            return false; // alias addressing only when DL control 0x100[24] is set (master-written)
+        }
         return (memory_.station_alias != 0) and (position == memory_.station_alias);
     }
 
@@ -646,7 +650,19 @@ namespace kickcat
         // Mirror AL_STATUS - Device Emulation
         if(memory_.esc_configuration & 0x01)
         {
-            memory_.al_status = memory_.al_control;
+            if (memory_.al_status & AL_STATUS_ERR_IND)
+            {
+                // Self-set error (watchdog drop): hold AL_STATUS until the master acks it,
+                // otherwise the mirror would clear the fallback on the next tick.
+                if (memory_.al_control & AL_CONTROL_ERR_ACK)
+                {
+                    memory_.al_status = memory_.al_control & static_cast<uint16_t>(~AL_CONTROL_ERR_ACK);
+                }
+            }
+            else
+            {
+                memory_.al_status = memory_.al_control;
+            }
         }
 
         // Handle eeprom access. Command is in bits [10:8] only: a conformant master
@@ -938,10 +954,14 @@ namespace kickcat
                 {
                     memory_.watchdog_counter_process_data++; // Counter of how many times the watchdog has expired
                 }
-                // If the watchdog expires in OP, we must tell the master and potentially drop the status ourselves
-                memory_.al_control = (memory_.al_status & 0xFFF0) | State::SAFE_OP;
-                memory_.al_status |= AL_STATUS_ERR_IND; // Set Error Bit
-                memory_.al_status_code = SYNC_MANAGER_WATCHDOG; // SM Watchdog code
+                // Real ESCs never write AL_CONTROL (0x120, master-owned). Without a PDI
+                // application (device emulation) the ESC drops AL_STATUS itself; otherwise
+                // the application observes WDOG_STATUS and performs the fallback.
+                if (memory_.esc_configuration & 0x01)
+                {
+                    memory_.al_status = (memory_.al_status & 0xFFF0) | State::SAFE_OP | AL_STATUS_ERR_IND;
+                    memory_.al_status_code = SYNC_MANAGER_WATCHDOG; // SM Watchdog code
+                }
             }
         }
     }

--- a/lib/src/ESI/Parser.cc
+++ b/lib/src/ESI/Parser.cc
@@ -140,20 +140,23 @@ namespace
         {
             fail("empty numeric value");
         }
+
+        int base = 10;
+        if (text.rfind("#x", 0) == 0)
+        {
+            if (text.size() == 2) { fail("'#x' with no hex digits"); }
+            text[0] = '0';
+            base = 16;
+        }
+        else if (text.rfind("0x", 0) == 0 or text.rfind("0X", 0) == 0)
+        {
+            if (text.size() == 2) { fail("'0x' with no hex digits"); }
+            base = 16;
+        }
+
         try
         {
-            if (text.rfind("#x", 0) == 0)
-            {
-                if (text.size() == 2) { fail("'#x' with no hex digits"); }
-                text[0] = '0';
-                return std::stoll(text, nullptr, 16);
-            }
-            if (text.rfind("0x", 0) == 0 or text.rfind("0X", 0) == 0)
-            {
-                if (text.size() == 2) { fail("'0x' with no hex digits"); }
-                return std::stoll(text, nullptr, 16);
-            }
-            return std::stoll(text, nullptr, 10);
+            return std::stoll(text, nullptr, base);
         }
         catch (std::invalid_argument const&)
         {
@@ -161,7 +164,20 @@ namespace
         }
         catch (std::out_of_range const&)
         {
-            fail("numeric value exceeds int64 range");
+            // Unsigned values in [2^63, 2^64): keep the 64-bit pattern, consumers
+            // (DefaultValue copy, narrowChecked) work on raw bits.
+            if (text[0] != '-')
+            {
+                try
+                {
+                    return static_cast<int64_t>(std::stoull(text, nullptr, base));
+                }
+                catch (std::exception const&)
+                {
+                    // fall through to the range error
+                }
+            }
+            fail("numeric value exceeds 64-bit range");
         }
         return 0;  // unreachable; fail() always throws
     }
@@ -1756,7 +1772,9 @@ uint16_t Parser::loadAccess(XMLNode* node)
     auto node_flags = node->FirstChildElement("Flags");
     if (node_flags == nullptr)
     {
-        return flags;
+        // A missing <Flags> means default access, like an empty <Flags/> (access=0
+        // would make the object unreadable in the emulated-slave OD).
+        return CoE::Access::READ;
     }
 
     auto node_access = node_flags->FirstChildElement("Access");

--- a/lib/src/ESI/SIIBuilder.cc
+++ b/lib/src/ESI/SIIBuilder.cc
@@ -111,6 +111,7 @@ eeprom::SII buildSII(Device const& device)
         if (mb.coe) { protocol |= eeprom::MailboxProtocol::CoE; }
         if (mb.foe) { protocol |= eeprom::MailboxProtocol::FoE; }
         if (mb.soe) { protocol |= eeprom::MailboxProtocol::SoE; }
+        if (mb.voe) { protocol |= eeprom::MailboxProtocol::VoE; }
         sii.info.mailbox_protocol = protocol;
     }
 

--- a/lib/src/SIIParser.cc
+++ b/lib/src/SIIParser.cc
@@ -167,7 +167,10 @@ namespace kickcat::eeprom
                 }
                 case Category::General:
                 {
-                    std::memcpy(&general, category_data, sizeof(GeneralEntry));
+                    // Partially-programmed EEPROMs declare truncated categories: never read
+                    // past the declared size, missing fields stay zero.
+                    general = GeneralEntry{};
+                    std::memcpy(&general, category_data, std::min<std::size_t>(category_size, sizeof(GeneralEntry)));
                     break;
                 }
                 case Category::FMMU:
@@ -251,8 +254,16 @@ namespace kickcat::eeprom
             strings_data.push_back(count);
             for (std::size_t i = 1; i < strings.size(); ++i)
             {
-                strings_data.push_back(static_cast<uint8_t>(strings[i].size()));
-                strings_data.insert(strings_data.end(), strings[i].begin(), strings[i].end());
+                std::size_t len = strings[i].size();
+                if (len > 0xFF)
+                {
+                    // The length prefix is one byte: a longer string would wrap it and
+                    // corrupt the category framing.
+                    esi_warning("SII: string %zu is %zu bytes long, truncated to 255\n", i, len);
+                    len = 0xFF;
+                }
+                strings_data.push_back(static_cast<uint8_t>(len));
+                strings_data.insert(strings_data.end(), strings[i].begin(), strings[i].begin() + len);
             }
             // Pad to word boundary
             if (strings_data.size() % 2 != 0)

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(kickcat_unit src/adler32_sum-t.cc
                             src/redundancy-t.cc
                             src/Ring-t.cc
                             src/SBufQueue-t.cc
+                            src/SIIParser-t.cc
                             src/slave-t.cc
                             src/socket-t.cc
                             src/EEPROM_factory-t.cc

--- a/unit/src/ESI/Parser-t.cc
+++ b/unit/src/ESI/Parser-t.cc
@@ -441,6 +441,86 @@ TEST(ESIParser, loadDevice_filter_no_match_throws)
                  std::invalid_argument);
 }
 
+TEST(ESIParser, object_without_flags_defaults_to_read_access)
+{
+    // A missing <Flags> element means default access like an empty <Flags/>,
+    // not access=0 (which would make the object unreadable).
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes><DataType><Name>UDINT</Name><BitSize>32</BitSize></DataType></DataTypes>
+                        <Objects>
+                            <Object>
+                                <Index>#x1000</Index>
+                                <Name>NoFlags</Name>
+                                <Type>UDINT</Type>
+                                <BitSize>32</BitSize>
+                            </Object>
+                            <Object>
+                                <Index>#x1001</Index>
+                                <Name>EmptyFlags</Name>
+                                <Type>UDINT</Type>
+                                <BitSize>32</BitSize>
+                                <Flags/>
+                            </Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    auto dictionary = parser.loadString(xml);
+
+    auto [object_no_flags, entry_no_flags] = findObject(dictionary, 0x1000, 0);
+    ASSERT_NE(entry_no_flags, nullptr);
+    ASSERT_EQ(entry_no_flags->access, CoE::Access::READ);
+
+    auto [object_empty_flags, entry_empty_flags] = findObject(dictionary, 0x1001, 0);
+    ASSERT_NE(entry_empty_flags, nullptr);
+    ASSERT_EQ(entry_empty_flags->access, CoE::Access::READ);
+}
+
+TEST(ESIParser, unsigned64_default_value_above_int64_max)
+{
+    // stoll alone rejects values in [2^63, 2^64) and the whole device with it.
+    char const* xml = R"(<?xml version="1.0"?>
+        <EtherCATInfo>
+            <Vendor><Id>#x1</Id><Name>V</Name></Vendor>
+            <Descriptions><Devices><Device>
+                <Type ProductCode="#x1" RevisionNo="#x1">T</Type>
+                <Profile><ProfileNo>0</ProfileNo>
+                    <Dictionary>
+                        <DataTypes><DataType><Name>ULINT</Name><BitSize>64</BitSize></DataType></DataTypes>
+                        <Objects>
+                            <Object>
+                                <Index>#x1000</Index>
+                                <Name>Big</Name>
+                                <Type>ULINT</Type>
+                                <BitSize>64</BitSize>
+                                <Info><DefaultValue>#xFFFFFFFFFFFFFFFF</DefaultValue></Info>
+                            </Object>
+                        </Objects>
+                    </Dictionary>
+                </Profile>
+            </Device></Devices></Descriptions>
+        </EtherCATInfo>)";
+
+    ESI::Parser parser;
+    auto dictionary = parser.loadString(xml);
+
+    auto [object, entry] = findObject(dictionary, 0x1000, 0);
+    ASSERT_NE(entry, nullptr);
+    ASSERT_NE(entry->data, nullptr);
+    uint64_t value;
+    std::memcpy(&value, entry->data, sizeof(value));
+    ASSERT_EQ(UINT64_MAX, value);
+}
+
 TEST(ESIParser, throws_with_context_when_object_missing_name)
 {
     char const* xml = R"(<?xml version="1.0"?>

--- a/unit/src/ESI/SIIBuilder-t.cc
+++ b/unit/src/ESI/SIIBuilder-t.cc
@@ -72,10 +72,10 @@ TEST(SIIBuilder, maps_parsed_device_to_sii_struct)
     ASSERT_EQ(sii.info.bootstrap_recv_mbx_size,   0x0080u);
     ASSERT_EQ(sii.info.bootstrap_send_mbx_offset, 0x1010u);
     ASSERT_EQ(sii.info.bootstrap_send_mbx_size,   0x0080u);
-    // CoE/EoE/AoE/FoE/SoE present in the fixture (VoE has no protocol bit)
+    // CoE/EoE/AoE/FoE/SoE/VoE present in the fixture (VoE bit per ETG.2010 Table 4 word 0x1C)
     ASSERT_EQ(sii.info.mailbox_protocol,
               eeprom::MailboxProtocol::AoE | eeprom::MailboxProtocol::EoE | eeprom::MailboxProtocol::CoE
-            | eeprom::MailboxProtocol::FoE | eeprom::MailboxProtocol::SoE);
+            | eeprom::MailboxProtocol::FoE | eeprom::MailboxProtocol::SoE | eeprom::MailboxProtocol::VoE);
 
     // SyncManagers
     ASSERT_EQ(sii.syncManagers.size(), 4u);
@@ -180,6 +180,21 @@ TEST(SIIBuilder, round_trips_through_serialize_and_parse)
 
     // serialize() recomputed the InfoEntry CRC; it must validate after parse.
     ASSERT_EQ(eeprom::computeInfoCRC(parsed.info), parsed.info.crc);
+}
+
+TEST(SIIBuilder, serialize_clamps_string_length_to_one_byte)
+{
+    eeprom::SII sii;
+    sii.strings.push_back("");                     // reserved index 0
+    sii.strings.push_back(std::string(300, 'a'));  // would wrap the 1-byte length prefix
+    sii.strings.push_back("next");
+    auto bytes = sii.serialize();
+
+    eeprom::SII parsed;
+    parsed.parse(bytes.data(), bytes.size());
+    ASSERT_EQ(3u, parsed.strings.size());
+    ASSERT_EQ(std::string(255, 'a'), parsed.strings[1]);
+    ASSERT_EQ("next", parsed.strings[2]);
 }
 
 TEST(SIIBuilder, maps_pdo_entry_data_types_and_padding)

--- a/unit/src/EmulatedESC-t.cc
+++ b/unit/src/EmulatedESC-t.cc
@@ -353,11 +353,19 @@ TEST(EmulatedESC, ecat_fpxx_matches_station_alias)
     uint16_t alias = 0xABCD;
     esc.write(reg::STATION_ALIAS, &alias, sizeof(alias));
 
-    // FPRD addressed by the station alias is answered like the station address.
+    // Alias addressing is ignored until the master sets DL control 0x100[24].
     header.command = Command::FPRD;
     header.address = createAddress(alias, 0x0040);
     header.len = sizeof(uint64_t);
     uint64_t read_test = 0;
+    wkc = 0;
+    esc.processDatagram(&header, &read_test, &wkc);
+    ASSERT_EQ(wkc, 0);
+
+    // Once enabled, FPRD addressed by the station alias is answered like the station address.
+    uint8_t alias_enable = 0x01;
+    esc.write(reg::ESC_DL_ALIAS, &alias_enable, sizeof(alias_enable));
+    header.address = createAddress(alias, 0x0040);
     wkc = 0;
     esc.processDatagram(&header, &read_test, &wkc);
     ASSERT_EQ(wkc, 1);
@@ -714,6 +722,61 @@ TEST(EmulatedESC, watchdog)
     uint8_t counter = 0;
     esc.read(reg::WDOG_COUNTER_PDO, &counter, 1);
     EXPECT_GT(counter, 0);
+}
+
+TEST(EmulatedESC, watchdog_device_emulation_drops_to_safe_op_via_al_status)
+{
+    EmulatedESC esc;
+    // Word 0 high byte is the ESC configuration: bit 0 enables device emulation.
+    esc.loadEeprom(std::vector<uint16_t>{0x0104, 0, 0, 0, 0});
+
+    uint16_t wkc = 0;
+    DatagramHeader header{Command::NOP, 0, 0, 0, 0, 0, 0, 0};
+
+    configureOutputFmmuAndEnterSafeOP(esc, 2);
+
+    uint16_t divider = 2498;
+    esc.write(reg::WDG_DIVIDER, &divider, 2);
+    uint16_t wdg_time = 100;
+    esc.write(reg::WDG_TIME_PDO, &wdg_time, 2);
+
+    esc.processDatagram(&header, nullptr, &wkc);  // runs configureFmmus + arms the watchdog
+
+    uint8_t op = State::OPERATIONAL;
+    esc.write(reg::AL_CONTROL, &op, 1);
+    esc.processDatagram(&header, nullptr, &wkc);  // device emulation mirrors AL_CONTROL
+
+    uint8_t al_status = 0;
+    esc.read(reg::AL_STATUS, &al_status, 1);
+    ASSERT_EQ(State::OPERATIONAL, al_status);
+
+    // since_epoch() advances 1ms per call in unit tests; 30 cycles exceed the 10ms window.
+    for (int i = 0; i < 30; ++i)
+    {
+        esc.processDatagram(&header, nullptr, &wkc);
+    }
+
+    // The fallback is driven through AL_STATUS; AL_CONTROL (0x120) is master-owned
+    // and shall never be modified by the ESC.
+    esc.read(reg::AL_STATUS, &al_status, 1);
+    ASSERT_EQ(State::SAFE_OP | AL_STATUS_ERR_IND, al_status);
+    uint16_t al_status_code = 0;
+    esc.read(reg::AL_STATUS_CODE, &al_status_code, 2);
+    ASSERT_EQ(SYNC_MANAGER_WATCHDOG, al_status_code);
+    uint8_t al_control = 0;
+    esc.read(reg::AL_CONTROL, &al_control, 1);
+    ASSERT_EQ(State::OPERATIONAL, al_control);
+
+    // The error indication holds against the mirror until the master acks it.
+    esc.processDatagram(&header, nullptr, &wkc);
+    esc.read(reg::AL_STATUS, &al_status, 1);
+    ASSERT_EQ(State::SAFE_OP | AL_STATUS_ERR_IND, al_status);
+
+    uint8_t ack = State::SAFE_OP | AL_CONTROL_ERR_ACK;
+    esc.write(reg::AL_CONTROL, &ack, 1);
+    esc.processDatagram(&header, nullptr, &wkc);
+    esc.read(reg::AL_STATUS, &al_status, 1);
+    ASSERT_EQ(State::SAFE_OP, al_status);
 }
 
 TEST(EmulatedESC, watchdog_inactive_without_outputs)

--- a/unit/src/SIIParser-t.cc
+++ b/unit/src/SIIParser-t.cc
@@ -1,0 +1,147 @@
+// Malformed / truncated SII images: real partially-programmed EEPROMs declare
+// categories whose payload is shorter than the fixed structure they carry.
+#include <gtest/gtest.h>
+
+#include "kickcat/Error.h"
+#include "kickcat/SIIParser.h"
+
+using namespace kickcat;
+
+namespace
+{
+    class Image
+    {
+    public:
+        Image()
+            : bytes_(eeprom::START_CATEGORY * 2, 0)
+        {
+        }
+
+        void w8(uint8_t v)
+        {
+            bytes_.push_back(v);
+        }
+
+        void w16(uint16_t v)
+        {
+            bytes_.push_back(static_cast<uint8_t>(v & 0xFF));
+            bytes_.push_back(static_cast<uint8_t>(v >> 8));
+        }
+
+        void category(uint16_t type, std::vector<uint8_t> const& payload)
+        {
+            w16(type);
+            w16(static_cast<uint16_t>(payload.size() / 2));
+            bytes_.insert(bytes_.end(), payload.begin(), payload.end());
+        }
+
+        void end()
+        {
+            w16(eeprom::Category::End);
+            w16(0);
+        }
+
+        eeprom::SII parse()
+        {
+            eeprom::SII sii;
+            sii.parse(bytes_.data(), bytes_.size());
+            return sii;
+        }
+
+    private:
+        std::vector<uint8_t> bytes_;
+    };
+}
+
+TEST(SIIParser, truncated_general_category_is_zero_filled)
+{
+    // ETG.2010 general category is 32 bytes; declare only 4: the parser shall not
+    // read past the declared payload and the missing fields shall stay zero.
+    Image img;
+    img.category(eeprom::Category::General, {2, 3, 4, 5});
+    // The next category starts right after the 4 declared bytes: if the parser
+    // memcpys the full GeneralEntry it swallows these (non-zero) bytes instead.
+    img.category(eeprom::Category::FMMU, {0xAA, 0xBB});
+    img.end();
+
+    eeprom::SII sii = img.parse();
+    ASSERT_EQ(2, sii.general.group_info_id);
+    ASSERT_EQ(3, sii.general.image_name_id);
+    ASSERT_EQ(4, sii.general.device_order_id);
+    ASSERT_EQ(5, sii.general.device_name_id);
+    ASSERT_EQ(0, sii.general.FoE_details);
+    ASSERT_EQ(0, sii.general.EoE_details);
+    ASSERT_EQ(0, sii.general.current_on_ebus);
+    ASSERT_EQ(0, sii.general.physical_memory_address);
+
+    ASSERT_EQ(2u, sii.fmmus.size());
+    ASSERT_EQ(0xAA, sii.fmmus[0]);
+    ASSERT_EQ(0xBB, sii.fmmus[1]);
+}
+
+TEST(SIIParser, category_bigger_than_image_stops_parsing)
+{
+    Image img;
+    img.w16(eeprom::Category::Strings);
+    img.w16(0xFFFF);  // claims 128 KiB of payload: way past the image end
+    img.w16(0);
+
+    eeprom::SII sii = img.parse();
+    ASSERT_TRUE(sii.strings.empty());  // category dropped before reaching the handler
+}
+
+TEST(SIIParser, truncated_string_entry_is_dropped)
+{
+    Image img;
+    img.category(eeprom::Category::Strings, {
+        2,              // 2 strings announced
+        3, 'a', 'b', 'c',
+        200, 'x', 0,    // length runs past the category payload (+1 pad byte)
+    });
+    img.end();
+
+    eeprom::SII sii = img.parse();
+    ASSERT_EQ(2u, sii.strings.size());
+    ASSERT_EQ("abc", sii.strings[1]);
+}
+
+TEST(SIIParser, truncated_sync_manager_entry_is_dropped)
+{
+    Image img;
+    img.category(eeprom::Category::SyncM, {
+        0x00, 0x10, 0x80, 0x00, 0x26, 0x00, 0x01, 0x01,  // one full 8-byte entry
+        0x00, 0x14, 0x80, 0x00,                          // half an entry
+    });
+    img.end();
+
+    eeprom::SII sii = img.parse();
+    ASSERT_EQ(1u, sii.syncManagers.size());
+    ASSERT_EQ(0x1000, sii.syncManagers[0].start_address);
+    ASSERT_EQ(0x0080, sii.syncManagers[0].length);
+}
+
+TEST(SIIParser, truncated_pdo_entry_list_is_dropped)
+{
+    Image img;
+    img.category(eeprom::Category::TxPDO, {
+        0x00, 0x1A,     // index 0x1A00
+        2,              // announces 2 entries
+        3, 0, 0,        // sm, synchro, name
+        0x00, 0x00,     // flags
+        0x00, 0x60, 1, 0, 0x01, 1, 0x00, 0x00,  // first 8-byte entry only
+    });
+    img.end();
+
+    eeprom::SII sii = img.parse();
+    ASSERT_EQ(1u, sii.TxPDO.size());
+    ASSERT_EQ(0x1A00u, sii.TxPDO[0].index);
+    ASSERT_EQ(1u, sii.TxPDO[0].entries.size());
+    ASSERT_EQ(0x6000u, sii.TxPDO[0].entries[0].index);
+}
+
+TEST(SIIParser, image_too_small_for_info_throws)
+{
+    uint8_t bytes[4] = {0, 0, 0, 0};
+    eeprom::SII sii;
+    ASSERT_THROW(sii.parse(bytes, sizeof(bytes)), Error);
+}

--- a/unit/src/bus-t.cc
+++ b/unit/src/bus-t.cc
@@ -550,6 +550,41 @@ TEST_F(BusTest, read_SDO_emulated_complete_access_OK)
 }
 
 
+TEST_F(BusTest, read_SDO_emulated_complete_access_abort_on_size_read)
+{
+    auto& slave = bus.slaves().at(0);
+
+    // checkMailboxes: can write, nothing to read
+    mock_link->handleProcess(Command::FPRD, uint8_t{0}, 1);
+    mock_link->handleProcess(Command::FPRD, uint8_t{0}, 1);
+
+    // write to mailbox
+    mock_link->handleProcess(Command::FPWR, uint8_t{0}, 1);
+
+    // checkMailboxes: can write, something to read
+    mock_link->handleProcess(Command::FPRD, uint8_t{0}, 1);
+    mock_link->handleProcess(Command::FPRD, uint8_t{0x08}, 1);
+
+    // The subindex 0 (object size) read is aborted by the slave: the error shall
+    // be propagated instead of silently returning an empty result.
+    SDOAnswer answer;
+    answer.header.len = 10;
+    answer.header.address = 0;
+    answer.header.type = mailbox::Type::CoE;
+    answer.coe.service = CoE::Service::SDO_RESPONSE;
+    answer.sdo.command = CoE::SDO::request::ABORT;
+    answer.sdo.index = 0x1018;
+    answer.sdo.subindex = 0;
+    *reinterpret_cast<uint32_t*>(answer.payload) = CoE::SDO::abort::UNSUPPORTED_ACCESS;
+
+    mock_link->handleProcess(Command::FPRD, answer, 1);
+
+    uint32_t data[3] = {0};
+    uint32_t data_size = sizeof(data);
+    ASSERT_THROW(bus.readSDO(slave, 0x1018, 1, Bus::Access::EMULATE_COMPLETE, &data, &data_size), Error);
+}
+
+
 TEST_F(BusTest, read_SDO_buffer_too_small)
 {
     addReadEmulatedSDO<uint32_t>(0x1018, { 3, 0xCAFE0000 });

--- a/unit/src/gateway-t.cc
+++ b/unit/src/gateway-t.cc
@@ -144,3 +144,72 @@ TEST_F(GatewayTest, nominal_loop)
     ASSERT_EQ(MessageStatus::SUCCESS, msg->status());
     gateway.processPendingRequests();
 }
+
+TEST_F(GatewayTest, evict_failed_requests)
+{
+    uint16_t GEN_GATEWAY_INDEX = 2;
+    Mailbox mbx;
+    mbx.recv_size = 128;
+
+    EXPECT_CALL(*socket_, recv(_, _))
+    .WillOnce([&](void* frame, int32_t)
+    {
+        Request req;
+        req.header.type = EthercatType::MAILBOX;
+        req.mbx_header.len = 10;
+        req.mbx_header.address = 1003;
+        std::memcpy(frame, &req, sizeof(req));
+        return std::make_tuple<int32_t, uint16_t>(sizeof(req), 2);
+    });
+
+    std::shared_ptr<GatewayMessage> msg;
+    EXPECT_CALL(mockAddMessage_, Call(_, 16, GEN_GATEWAY_INDEX))
+    .WillOnce([&](uint8_t const* raw_message, int32_t raw_message_size, uint16_t gateway_index)
+    {
+        msg = mbx.createGatewayMessage(raw_message, raw_message_size, gateway_index, 2ms);
+        return msg;
+    });
+    gateway.fetchRequest();
+    ASSERT_EQ(1u, gateway.pendingRequests());
+
+    // Exhaust the message timeout (since_epoch() advances at each call in unit tests).
+    while (msg->status() == MessageStatus::RUNNING)
+    {
+    }
+    ASSERT_EQ(MessageStatus::TIMEDOUT, msg->status());
+
+    // The failed request is evicted without a reply instead of accumulating forever.
+    EXPECT_CALL(*socket_, sendTo(_, _, _)).Times(0);
+    gateway.processPendingRequests();
+    ASSERT_EQ(0u, gateway.pendingRequests());
+}
+
+TEST_F(GatewayTest, reply_bounded_to_gateway_mtu)
+{
+    uint16_t GEN_GATEWAY_INDEX = 7;
+
+    EXPECT_CALL(*socket_, recv(_, _))
+    .WillOnce([&](void* frame, int32_t)
+    {
+        Request req;
+        req.header.type = EthercatType::MAILBOX;
+        req.mbx_header.len = 10;
+        req.mbx_header.address = 1003;
+        std::memcpy(frame, &req, sizeof(req));
+        return std::make_tuple<int32_t, uint16_t>(sizeof(req), uint16_t{GEN_GATEWAY_INDEX});
+    });
+
+    // Pre-completed reply bigger than the gateway frame: the copy shall be bounded.
+    EXPECT_CALL(mockAddMessage_, Call(_, 16, GEN_GATEWAY_INDEX))
+    .WillOnce([&](uint8_t const*, int32_t, uint16_t gateway_index)
+    {
+        std::vector<uint8_t> reply(ETH_MTU_SIZE * 2, 0);
+        return std::make_shared<GatewayMessage>(std::move(reply), gateway_index);
+    });
+    gateway.fetchRequest();
+
+    EXPECT_CALL(*socket_, sendTo(_, ETH_MTU_SIZE, GEN_GATEWAY_INDEX))
+    .WillOnce(Return(ETH_MTU_SIZE));
+    gateway.processPendingRequests();
+    ASSERT_EQ(0u, gateway.pendingRequests());
+}

--- a/unit/src/link-t.cc
+++ b/unit/src/link-t.cc
@@ -1190,6 +1190,14 @@ TEST_F(LinkTest, event_callback)
 }
 
 
+TEST_F(LinkTest, event_callback_empty_is_rejected)
+{
+    // checkEcatEvents() invokes callbacks unchecked from the cyclic path: an empty
+    // std::function is a caller bug, refused at configuration time.
+    ASSERT_THROW(link.attachEcatEventCallback(EcatEvent::DL_STATUS, {}), Error);
+}
+
+
 TEST_F(LinkTest, process_datagrams_stale_frame_on_nominal_socket_keeps_current_cycle)
 {
     InSequence s;


### PR DESCRIPTION
  Master:
    - disableIRQ installs a real no-op (empty callbacks substituted)
    - readSDO complete-access propagates aborts and no longer wraps at 255 subindexes
    - Gateway evicts failed requests and bounds its reply copy

  ESI/SII:
    - missing <Flags> defaults to read access
    - unsigned defaults above 2^63 accepted
    - truncated General category no longer over-reads

  Emulator:
    - watchdog fallback drives AL_STATUS instead of the master-owned AL_CONTROL (held until error ack)
    - station alias honored only with DL control bit 24