### PR TITLE
simulation: out-of-band control bus for network_simulator

### DIFF
--- a/lib/include/kickcat/OS/SharedMemory.h
+++ b/lib/include/kickcat/OS/SharedMemory.h
@@ -24,6 +24,9 @@ namespace kickcat
         /// \return The address of the shm in this process.
         void* address() { return address_; }
 
+        /// Remove a named segment (no-op if absent, and on Windows).
+        static void unlink(std::string const& name);
+
     private:
         std::size_t size_{};    ///< Size in bytes of the shared memory.
         void* address_{};       ///< Address of the shared memory in this processus.

--- a/lib/include/kickcat/SimulatorControl.h
+++ b/lib/include/kickcat/SimulatorControl.h
@@ -1,0 +1,154 @@
+#ifndef KICKCAT_SIMULATOR_CONTROL_H
+#define KICKCAT_SIMULATOR_CONTROL_H
+
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+#include "kickcat/LockedRing.h"
+#include "kickcat/OS/SharedMemory.h"
+
+namespace kickcat::sim
+{
+    // Per-command payloads, decoupled from the envelope below: the message type
+    // selects which one is live in the union. POD so the message copies trivially
+    // through the ring. A new command adds a payload struct here and a union member.
+    struct SetLink
+    {
+        uint16_t node_a;
+        uint16_t node_b;
+        uint8_t  up;      // 1: heal, 0: break
+    };
+
+    union ControlPayload
+    {
+        SetLink set_link;
+    };
+
+    // Out-of-band control bus for network_simulator, off the EtherCAT wire so frame
+    // routing stays pure. The envelope carries only the type tag; the payload is
+    // command-specific.
+    struct ControlCommand
+    {
+        enum class Type : uint16_t
+        {
+            SetLink,
+        };
+
+        Type           type;
+        ControlPayload payload;
+    };
+
+    struct ControlResponse
+    {
+        ControlCommand::Type type;
+        uint8_t              ok;        // 0: command rejected (bad arguments / unknown type)
+        ControlPayload       payload;   // result, valid only when ok == 1
+    };
+
+    // The messages are byte-copied through a shared-memory ring.
+    static_assert(std::is_trivially_copyable_v<ControlCommand>);
+    static_assert(std::is_trivially_copyable_v<ControlResponse>);
+
+    // Shared-memory transport: the segment holds a small header plus the POD ring
+    // Contexts; each side wraps them with its own LockedRing whose pointers are
+    // valid only in that mapping (never copy a wrapper across the fork). The
+    // creator init()s the rings and stamps the header last; a peer attach()es and
+    // refuses a segment that is not stamped or whose layout differs (stale name,
+    // version skew, or attach-before-create).
+    class ControlChannel
+    {
+    public:
+        static constexpr uint32_t RING_SIZE = 64;   // power of two
+        using CommandRing  = LockedRing<ControlCommand,  RING_SIZE>;
+        using ResponseRing = LockedRing<ControlResponse, RING_SIZE>;
+
+        ControlChannel()                                 = default;
+        ControlChannel(ControlChannel const&)            = delete;
+        ControlChannel& operator=(ControlChannel const&) = delete;
+        ControlChannel(ControlChannel&&)                 = delete;
+        ControlChannel& operator=(ControlChannel&&)      = delete;
+
+        void create(std::string const& name) { open(name, true);  }
+        void attach(std::string const& name) { open(name, false); }
+
+        bool sendCommand(ControlCommand const& cmd) { return commands_->push(cmd); }
+        bool nextCommand(ControlCommand& out)       { return commands_->tryPop(out); }
+        bool sendResponse(ControlResponse const& r) { return responses_->push(r); }
+        bool nextResponse(ControlResponse& out)     { return responses_->tryPop(out); }
+
+        // Command and response rings are the same size and used 1:1, so room for a
+        // response guarantees the matching command's ack will fit.
+        bool responseSpaceAvailable() { return responses_->size() < RING_SIZE; }
+
+    private:
+        static constexpr uint32_t MAGIC = 0x53494d43;   // 'SIMC'
+
+        struct Storage
+        {
+            uint32_t              magic;
+            uint32_t              layout_size;
+            CommandRing::Context  commands;
+            ResponseRing::Context responses;
+        };
+
+        void open(std::string const& name, bool init)
+        {
+            if (init)
+            {
+                SharedMemory::unlink(name);   // drop a stale segment from a crashed run
+            }
+            shm_.open(name, sizeof(Storage));
+            Storage* storage = reinterpret_cast<Storage*>(shm_.address());
+            if (init)
+            {
+                std::memset(storage, 0, sizeof(Storage));
+            }
+            commands_  = std::make_unique<CommandRing>(storage->commands);
+            responses_ = std::make_unique<ResponseRing>(storage->responses);
+            if (init)
+            {
+                commands_->init();
+                responses_->init();
+                storage->layout_size = sizeof(Storage);
+                storage->magic       = MAGIC;   // stamp last: a peer only sees it once ready
+            }
+            else if (storage->magic != MAGIC or storage->layout_size != sizeof(Storage))
+            {
+                throw std::runtime_error("control channel " + name + " is not initialised or has a layout mismatch");
+            }
+        }
+
+        SharedMemory                  shm_{};
+        std::unique_ptr<CommandRing>  commands_;
+        std::unique_ptr<ResponseRing> responses_;
+    };
+
+    // Master-side producer: creates and owns the channel.
+    class SimulatorControlClient
+    {
+    public:
+        void open(std::string const& name) { channel_.create(name); }
+
+        bool breakLink(uint16_t a, uint16_t b) { return setLink(a, b, 0); }
+        bool healLink(uint16_t a, uint16_t b)  { return setLink(a, b, 1); }
+
+        bool send(ControlCommand const& cmd)     { return channel_.sendCommand(cmd); }
+        bool nextResponse(ControlResponse& out)  { return channel_.nextResponse(out); }
+
+    private:
+        bool setLink(uint16_t a, uint16_t b, uint8_t up)
+        {
+            ControlCommand cmd{};
+            cmd.type = ControlCommand::Type::SetLink;
+            cmd.payload.set_link = {a, b, up};
+            return send(cmd);
+        }
+
+        ControlChannel channel_;
+    };
+}
+
+#endif

--- a/lib/simulation/CMakeLists.txt
+++ b/lib/simulation/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(kickcat_simulation
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SimulatedSlave.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Topology.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/DeviceApp.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SimulatorControlServer.cc
 )
 
 target_link_libraries(kickcat_simulation PUBLIC kickcat nlohmann_json::nlohmann_json)

--- a/lib/simulation/include/kickcat/simulation/SimulatorControlServer.h
+++ b/lib/simulation/include/kickcat/simulation/SimulatorControlServer.h
@@ -1,0 +1,31 @@
+#ifndef KICKCAT_SIMULATION_SIMULATOR_CONTROL_SERVER_H
+#define KICKCAT_SIMULATION_SIMULATOR_CONTROL_SERVER_H
+
+#include <string>
+
+#include "kickcat/EmulatedNetwork.h"
+#include "kickcat/SimulatorControl.h"
+
+namespace kickcat::sim
+{
+    // Simulator-side listener: drain() applies every pending ControlCommand onto
+    // the emulated network and acks each. New command types extend apply().
+    class SimulatorControlServer
+    {
+    public:
+        SimulatorControlServer(EmulatedNetwork& network, size_t node_count);
+
+        void attach(std::string const& name);
+        void drain();   // no-op until attached
+
+    private:
+        ControlResponse apply(ControlCommand const& cmd);
+
+        ControlChannel   channel_;
+        EmulatedNetwork& network_;
+        size_t           node_count_;
+        bool             attached_{false};
+    };
+}
+
+#endif

--- a/lib/simulation/src/SimulatorControlServer.cc
+++ b/lib/simulation/src/SimulatorControlServer.cc
@@ -1,0 +1,55 @@
+#include "kickcat/simulation/SimulatorControlServer.h"
+
+namespace kickcat::sim
+{
+    SimulatorControlServer::SimulatorControlServer(EmulatedNetwork& network, size_t node_count)
+        : network_(network)
+        , node_count_(node_count)
+    {
+    }
+
+    void SimulatorControlServer::attach(std::string const& name)
+    {
+        channel_.attach(name);
+        attached_ = true;
+    }
+
+    void SimulatorControlServer::drain()
+    {
+        if (not attached_)
+        {
+            return;
+        }
+        // Stop if the response ring can't take an ack, so a command is never
+        // applied without being acknowledged (host fell behind draining responses).
+        ControlCommand cmd{};
+        while (channel_.responseSpaceAvailable() and channel_.nextCommand(cmd))
+        {
+            channel_.sendResponse(apply(cmd));
+        }
+    }
+
+    ControlResponse SimulatorControlServer::apply(ControlCommand const& cmd)
+    {
+        ControlResponse response{};
+        response.type = cmd.type;
+        response.ok   = 0;
+
+        if (cmd.type == ControlCommand::Type::SetLink)
+        {
+            SetLink const& link = cmd.payload.set_link;
+            bool const valid = (link.node_a < node_count_
+                            and link.node_b < node_count_
+                            and link.node_a != link.node_b);
+            if (valid)
+            {
+                bool const up = (link.up != 0);
+                network_.setLinkState(link.node_a, link.node_b, up);
+                response.ok               = 1;
+                response.payload.set_link = link;
+            }
+        }
+
+        return response;
+    }
+}

--- a/lib/src/OS/Unix/SharedMemory.cc
+++ b/lib/src/OS/Unix/SharedMemory.cc
@@ -58,4 +58,9 @@ namespace kickcat
             THROW_SYSTEM_ERROR("mmap()");
         }
     }
+
+    void SharedMemory::unlink(std::string const& name)
+    {
+        shm_unlink(name.c_str());
+    }
 }

--- a/lib/src/OS/Windows/SharedMemory.cc
+++ b/lib/src/OS/Windows/SharedMemory.cc
@@ -60,4 +60,9 @@ namespace kickcat
             THROW_LAST_ERROR("MapViewOfFileEx() failed");
         }
     }
+
+    void SharedMemory::unlink(std::string const&)
+    {
+        // Reclaimed when the last handle closes; no persistent name to remove.
+    }
 }

--- a/simulation/network_simulator.cc
+++ b/simulation/network_simulator.cc
@@ -12,6 +12,7 @@
 #include "kickcat/OS/Time.h"
 #include "kickcat/helpers.h"
 #include "kickcat/simulation/SimulatedSlave.h"
+#include "kickcat/simulation/SimulatorControlServer.h"
 #include "kickcat/simulation/Topology.h"
 
 using namespace kickcat;
@@ -20,26 +21,13 @@ using json = nlohmann::json;
 static volatile std::sig_atomic_t running = 1;
 static void signalHandler(int) { running = 0; }
 
-// Example fault injection: SIGUSR1 breaks a configured wire, SIGUSR2 heals it.
-// The handler only flags the request; it is applied from the main loop where the
-// network object is in scope (setLinkState is not async-signal-safe). SIGUSR1/2 are
-// POSIX-only; on platforms without them the break/heal API is still usable directly.
-static volatile std::sig_atomic_t link_event = 0;  // 0: none, 1: break, 2: heal
-#ifdef SIGUSR1
-static void linkSignalHandler(int sig)
-{
-    if (sig == SIGUSR1) { link_event = 1; }
-    if (sig == SIGUSR2) { link_event = 2; }
-}
-#endif
-
 namespace
 {
     struct Options
     {
         std::string              interface;
         std::string              redundancy_interface;
-        std::vector<int>         break_link;
+        std::string              control_shm;       // break/heal control channel, if any
         std::string              topology_file;
         std::vector<std::string> slave_configs;   // already expanded (see --count)
     };
@@ -55,9 +43,9 @@ namespace
         program.add_argument("-r", "--redundancy")
             .help("redundancy network interface (enables cable-redundancy routing)")
             .default_value(std::string{}).store_into(opts.redundancy_interface);
-        program.add_argument("--break-link")
-            .help("two slave indices A B; SIGUSR1 breaks / SIGUSR2 heals the wire between them")
-            .nargs(2).scan<'i', int>().store_into(opts.break_link);
+        program.add_argument("--control")
+            .help("shared-memory name of a break/heal control channel (see SimulatorControl.h)")
+            .default_value(std::string{}).store_into(opts.control_shm);
         program.add_argument("--topology")
             .help("JSON topology file: master injection + slave-to-slave links (branching tree)")
             .default_value(std::string{}).store_into(opts.topology_file);
@@ -112,7 +100,7 @@ namespace
     // code (non-zero on a fatal frame-write error).
     int runSimulation(EmulatedNetwork& network, std::vector<sim::SimulatedSlave>& slaves,
                       AbstractSocket* socket, AbstractSocket* socket_redundancy,
-                      bool redundancy, size_t break_a, size_t break_b)
+                      bool redundancy, sim::SimulatorControlServer& control)
     {
         int exit_code = 0;
 
@@ -155,15 +143,7 @@ namespace
 
         while (running)
         {
-            if (link_event != 0)
-            {
-                bool up = (link_event == 2);
-                link_event = 0;
-                network.setLinkState(break_a, break_b, up);
-                char const* action = "broken";
-                if (up) { action = "healed"; }
-                printf("Link %zu-%zu %s\n", break_a, break_b, action);
-            }
+            control.drain();
 
             auto t1 = since_epoch();
 
@@ -234,10 +214,6 @@ int main(int argc, char* argv[])
 {
     std::signal(SIGINT,  signalHandler);
     std::signal(SIGTERM, signalHandler);
-#ifdef SIGUSR1
-    std::signal(SIGUSR1, linkSignalHandler);
-    std::signal(SIGUSR2, linkSignalHandler);
-#endif
 
     Options opts;
     if (not parseOptions(argc, argv, opts))
@@ -290,20 +266,25 @@ int main(int argc, char* argv[])
         network.setRedundancyInjection(slaves.size() - 1, 1);
     }
 
-    // Wire to break/heal on SIGUSR1/SIGUSR2 (defaults to the first downstream link).
-    size_t break_a = 0;
-    size_t break_b = 1;
-    if (opts.break_link.size() == 2)
+    // Optional control bus: the host creates the segment, the sim attaches.
+    sim::SimulatorControlServer control(network, slaves.size());
+    if (not opts.control_shm.empty())
     {
-        break_a = static_cast<size_t>(opts.break_link[0]);
-        break_b = static_cast<size_t>(opts.break_link[1]);
+        try
+        {
+            control.attach(opts.control_shm);
+        }
+        catch (std::exception const& e)
+        {
+            std::cerr << "Failed to attach control channel " << opts.control_shm << ": " << e.what() << std::endl;
+            return 1;
+        }
     }
 
     printf("Start EtherCAT network simulator on %s with %zu slaves\n", opts.interface.c_str(), slaves.size());
     if (redundancy)
     {
-        printf("Cable redundancy enabled on %s (SIGUSR1 breaks / SIGUSR2 heals link %zu-%zu)\n",
-               opts.redundancy_interface.c_str(), break_a, break_b);
+        printf("Cable redundancy enabled on %s\n", opts.redundancy_interface.c_str());
     }
 
     auto [socket, socket_redundancy] = createSockets(opts.interface, opts.redundancy_interface);
@@ -327,5 +308,5 @@ int main(int argc, char* argv[])
     }
 
     return runSimulation(network, slaves, socket.get(), socket_redundancy.get(),
-                         redundancy, break_a, break_b);
+                         redundancy, control);
 }

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -72,7 +72,7 @@ target_link_libraries(kickcat_unit kickcat GTest::gmock_main)
 # Simulation-support tests. lib/simulation is processed after unit/, so gate on
 # the build condition (not TARGET); the link resolves at generation time.
 if (ENABLE_ESI_PARSER AND BUILD_SIMULATION)
-    target_sources(kickcat_unit PRIVATE src/simulation-t.cc)
+    target_sources(kickcat_unit PRIVATE src/simulation-t.cc src/SimulatorControl-t.cc)
     target_link_libraries(kickcat_unit kickcat_simulation)
 endif()
 

--- a/unit/src/SimulatorControl-t.cc
+++ b/unit/src/SimulatorControl-t.cc
@@ -1,0 +1,145 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include <vector>
+
+#include "kickcat/ESC/EmulatedESC.h"
+#include "kickcat/EmulatedNetwork.h"
+#include "kickcat/Frame.h"
+#include "kickcat/OS/SharedMemory.h"
+#include "kickcat/SimulatorControl.h"
+#include "kickcat/simulation/SimulatorControlServer.h"
+
+using namespace kickcat;
+using namespace kickcat::sim;
+
+namespace
+{
+    constexpr char const* SHM_NAME = "/kickcat_simctl_test";
+
+    ControlCommand setLink(uint16_t a, uint16_t b, uint8_t up)
+    {
+        ControlCommand cmd{};
+        cmd.type = ControlCommand::Type::SetLink;
+        cmd.payload.set_link = {a, b, up};
+        return cmd;
+    }
+}
+
+class SimulatorControlTest : public ::testing::Test
+{
+protected:
+    // A leftover segment from a crashed run would keep stale ring state.
+    void SetUp() override    { SharedMemory::unlink(SHM_NAME); }
+    void TearDown() override { SharedMemory::unlink(SHM_NAME); }
+};
+
+TEST_F(SimulatorControlTest, command_and_response_round_trip)
+{
+    ControlChannel host;
+    host.create(SHM_NAME);
+    ControlChannel sim;
+    sim.attach(SHM_NAME);   // a second mapping of the same segment, as the fork would
+
+    ControlCommand drained;
+    EXPECT_FALSE(sim.nextCommand(drained));
+
+    ASSERT_TRUE(host.sendCommand(setLink(2, 3, 0)));
+    ControlCommand got;
+    ASSERT_TRUE(sim.nextCommand(got));
+    EXPECT_EQ(got.type, ControlCommand::Type::SetLink);
+    EXPECT_EQ(got.payload.set_link.node_a, 2);
+    EXPECT_EQ(got.payload.set_link.node_b, 3);
+    EXPECT_EQ(got.payload.set_link.up, 0);
+    EXPECT_FALSE(sim.nextCommand(got));
+
+    ControlResponse outgoing{};
+    outgoing.type = ControlCommand::Type::SetLink;
+    outgoing.ok   = 1;
+    outgoing.payload.set_link = {2, 3, 0};
+    ASSERT_TRUE(sim.sendResponse(outgoing));
+    ControlResponse response;
+    ASSERT_TRUE(host.nextResponse(response));
+    EXPECT_EQ(response.ok, 1);
+    EXPECT_EQ(response.payload.set_link.node_a, 2);
+    EXPECT_EQ(response.payload.set_link.node_b, 3);
+    EXPECT_FALSE(host.nextResponse(response));
+}
+
+TEST_F(SimulatorControlTest, commands_preserve_order)
+{
+    ControlChannel host;
+    host.create(SHM_NAME);
+    ControlChannel sim;
+    sim.attach(SHM_NAME);
+
+    for (uint16_t i = 0; i < 5; ++i)
+    {
+        ASSERT_TRUE(host.sendCommand(setLink(i, static_cast<uint16_t>(i + 1), 0)));
+    }
+    for (uint16_t i = 0; i < 5; ++i)
+    {
+        ControlCommand c;
+        ASSERT_TRUE(sim.nextCommand(c));
+        EXPECT_EQ(c.payload.set_link.node_a, i);
+        EXPECT_EQ(c.payload.set_link.node_b, static_cast<uint16_t>(i + 1));
+    }
+    ControlCommand c;
+    EXPECT_FALSE(sim.nextCommand(c));
+}
+
+TEST_F(SimulatorControlTest, client_drives_server_against_network)
+{
+    std::vector<std::unique_ptr<EmulatedESC>> escs;
+    std::vector<EmulatedESC*> esc_ptrs;
+    for (int i = 0; i < 3; ++i)
+    {
+        escs.push_back(std::make_unique<EmulatedESC>());
+        esc_ptrs.push_back(escs.back().get());
+    }
+    EmulatedNetwork network(std::move(esc_ptrs));
+
+    SimulatorControlClient client;
+    client.open(SHM_NAME);
+    SimulatorControlServer server(network, network.size());
+    server.attach(SHM_NAME);
+
+    // Head-injected auto-increment write: position 0xFFFF targets the second-visited
+    // slave (node 1). Returns whether it received the marker -- i.e. is still reachable.
+    auto reachesNode1 = [&](uint16_t marker)
+    {
+        Frame frame;
+        frame.addDatagram(0, Command::APWR, createAddress(0xFFFF, reg::STATION_ADDR), &marker, sizeof(marker));
+        frame.finalize();
+        network.route(frame, false);
+        uint16_t got = 0;
+        escs[1]->read(reg::STATION_ADDR, &got, sizeof(got));
+        return got == marker;
+    };
+
+    EXPECT_TRUE(reachesNode1(0x1001));
+
+    ASSERT_TRUE(client.breakLink(0, 1));
+    server.drain();
+    ControlResponse response;
+    ASSERT_TRUE(client.nextResponse(response));
+    EXPECT_EQ(response.ok, 1);
+    EXPECT_EQ(response.payload.set_link.up, 0);
+    EXPECT_FALSE(reachesNode1(0x2002));
+
+    ASSERT_TRUE(client.healLink(0, 1));
+    server.drain();
+    ASSERT_TRUE(client.nextResponse(response));
+    EXPECT_EQ(response.ok, 1);
+    EXPECT_EQ(response.payload.set_link.up, 1);
+    EXPECT_TRUE(reachesNode1(0x3003));
+
+    // Out-of-range node and a self-link are rejected, leaving the network untouched.
+    ASSERT_TRUE(client.breakLink(0, 9));
+    ASSERT_TRUE(client.breakLink(2, 2));
+    server.drain();
+    ASSERT_TRUE(client.nextResponse(response));
+    EXPECT_EQ(response.ok, 0);
+    ASSERT_TRUE(client.nextResponse(response));
+    EXPECT_EQ(response.ok, 0);
+    EXPECT_TRUE(reachesNode1(0x4004));
+}


### PR DESCRIPTION
A reusable shared-memory channel so a master-side tool can drive a running simulator. 
Useful to inject errors (break/heal a wire for instance)