### PR TITLE
Use product code in eeprom to find device in ESI file in SimulatedSlave.

### DIFF
--- a/examples/slave/nuttx/lan9252/freedom-k64f/freedom-k64f.xml
+++ b/examples/slave/nuttx/lan9252/freedom-k64f/freedom-k64f.xml
@@ -16,7 +16,7 @@
     </Groups>
     <Devices>
       <Device Physics="YY">
-        <Type ProductCode="#x00000001" RevisionNo="#x00000001">Board</Type>
+        <Type ProductCode="#x00DEFEDE" RevisionNo="#x00005A01">Board</Type>
         <Name LcId="1033">Board</Name>
         <Info>
           <StateMachine>

--- a/examples/slave/nuttx/xmc4800/boards/relax/xmc4800.xml
+++ b/examples/slave/nuttx/xmc4800/boards/relax/xmc4800.xml
@@ -2,7 +2,7 @@
 <EtherCATInfo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="EtherCATInfo.xsd" Version="1.6">
 
   <Vendor>
-    <Id>#x000006a5</Id>
+    <Id>#x00001337</Id>
     <Name>XMC4800 Example</Name>
   </Vendor>
 
@@ -15,7 +15,7 @@
     </Groups>
     <Devices>
       <Device Physics="YY">
-        <Type ProductCode="#x00B0CAD0" RevisionNo="#x00000001">Relax</Type>
+        <Type ProductCode="#x00004800" RevisionNo="#x00000000">Relax</Type>
         <Name LcId="1033">Relax</Name>
         <Info>
           <StateMachine>

--- a/lib/simulation/include/kickcat/simulation/SimulatedSlave.h
+++ b/lib/simulation/include/kickcat/simulation/SimulatedSlave.h
@@ -1,6 +1,7 @@
 #ifndef KICKCAT_SIMULATION_SIMULATED_SLAVE_H
 #define KICKCAT_SIMULATION_SIMULATED_SLAVE_H
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -8,13 +9,14 @@
 #include "kickcat/CoE/OD.h"
 #include "kickcat/CoE/mailbox/response.h"
 #include "kickcat/ESC/EmulatedESC.h"
-#include "kickcat/ESI/Parser.h"
 #include "kickcat/PDO.h"
 #include "kickcat/simulation/DeviceApp.h"
 #include "kickcat/slave/Slave.h"
 
 namespace kickcat::sim
 {
+    namespace fs = std::filesystem;
+
     // One emulated slave. unique_ptr members (PDO/Slave/Mailbox hold raw pointers
     // into the ESC) and vectors (whose data() survives a move) make the aggregate
     // safe to hold in a std::vector.
@@ -35,7 +37,7 @@ namespace kickcat::sim
 
     // Build one slave from its JSON config (ESI device or raw eeprom, optional CoE).
     // Throws std::runtime_error on any failure.
-    SimulatedSlave buildSlave(std::string const& config_path, ESI::Parser& parser);
+    SimulatedSlave buildSlave(fs::path const& config_path);
 }
 
 #endif

--- a/lib/simulation/src/SimulatedSlave.cc
+++ b/lib/simulation/src/SimulatedSlave.cc
@@ -9,21 +9,43 @@
 #include <nlohmann/json.hpp>
 
 #include "kickcat/CoE/OD.h"
+#include "kickcat/ESC/EmulatedESC.h"
+#include "kickcat/ESI/Parser.h"
 #include "kickcat/ESI/SIIBuilder.h"
+#include "kickcat/SIIParser.h"
 
 namespace kickcat::sim
 {
     using json = nlohmann::json;
     namespace fs = std::filesystem;
 
-    SimulatedSlave buildSlave(std::string const& config_path, ESI::Parser& parser)
+    void configureDeviceDictionary(SimulatedSlave& sim, ESI::Device& device)
     {
-        fs::path config_dir = fs::path(config_path).parent_path();
+        if (not device.dictionary.empty())
+        {
+            sim.dictionary = std::make_unique<CoE::Dictionary>(std::move(device.dictionary));
+            sim.slave->setDictionary(sim.dictionary.get());
+
+            // A mailboxless terminal (e.g. a digital I/O like EL1004) still gets its OD,
+            // but only a device that declares a CoE mailbox is reachable by SDO.
+            const bool esi_coe_advertised = (device.mailbox and device.mailbox->coe);
+            if (esi_coe_advertised)
+            {
+                sim.mailbox = std::make_unique<mailbox::response::Mailbox>(sim.esc.get(), 1024);
+                sim.mailbox->enableCoE(*sim.dictionary);
+                sim.slave->setMailbox(sim.mailbox.get());
+            }
+        }
+    }
+
+    SimulatedSlave buildSlave(fs::path const& config_path)
+    {
+        fs::path config_dir = config_path.parent_path();
 
         std::ifstream f(config_path);
         if (not f.is_open())
         {
-            throw std::runtime_error("Failed to open config file: " + config_path);
+            throw std::runtime_error("Failed to open config file: " + config_path.string());
         }
         json config;
         try
@@ -32,12 +54,13 @@ namespace kickcat::sim
         }
         catch (const json::parse_error& e)
         {
-            throw std::runtime_error("Failed to parse JSON in " + config_path + ": " + e.what());
+            throw std::runtime_error("Failed to parse JSON in " + config_path.string() + ": " + e.what());
         }
 
         SimulatedSlave sim;
-        std::optional<CoE::Dictionary> esi_coe;  // CoE dictionary derived from the ESI device, if any
-        bool esi_coe_advertised = false;         // true => device declares a CoE mailbox (SDO on the wire)
+        sim.esc = std::make_unique<EmulatedESC>();
+        sim.pdo   = std::make_unique<PDO>(sim.esc.get());
+        sim.slave = std::make_unique<slave::Slave>(sim.esc.get(), sim.pdo.get());
 
         if (config.contains("esi"))
         {
@@ -54,19 +77,11 @@ namespace kickcat::sim
 
             try
             {
-                ESI::Device dev = parser.loadDevice(esi_full_path.string(), filter);
-                CoE::materializeStorage(dev.dictionary);
-
-                sim.esc = std::make_unique<EmulatedESC>();
-                sim.esc->loadEeprom(ESI::buildEepromImage(dev));
-
-                if (not dev.dictionary.empty())
-                {
-                    esi_coe = std::move(dev.dictionary);
-                    // A mailboxless terminal (e.g. a digital I/O like EL1004) still gets its OD,
-                    // but only a device that declares a CoE mailbox is reachable by SDO.
-                    esi_coe_advertised = (dev.mailbox and dev.mailbox->coe);
-                }
+                ESI::Parser parser;
+                ESI::Device device = parser.loadDevice(esi_full_path.string(), filter);
+                CoE::materializeStorage(device.dictionary);
+                sim.esc->loadEeprom(ESI::buildEepromImage(device));
+                configureDeviceDictionary(sim, device);
             }
             catch (std::exception const& e)
             {
@@ -80,41 +95,33 @@ namespace kickcat::sim
             {
                 throw std::runtime_error("EEPROM file not found: " + eeprom_full_path.string());
             }
-            sim.esc = std::make_unique<EmulatedESC>(eeprom_full_path.string().c_str());
+            std::vector<uint8_t> eeprom_image = loadBinaryFile(eeprom_full_path);
+            sim.esc->loadEeprom(eeprom_image);
+
+            if (config.contains("coe_xml"))
+            {
+                fs::path coe_xml_full_path = config_dir / config["coe_xml"].get<std::string>();
+                if (not fs::exists(coe_xml_full_path))
+                {
+                    throw std::runtime_error("CoE XML file not found: " + coe_xml_full_path.string());
+                }
+                eeprom::SII sii;
+                sii.parse(eeprom_image);
+                uint32_t revision_no = sii.info.revision_number;
+                uint32_t product_code = sii.info.product_code;
+
+                ESI::DeviceFilter filter;
+                filter.revision_no = revision_no;
+                filter.product_code = product_code;
+                ESI::Parser parser;
+                ESI::Device device = parser.loadDevice(coe_xml_full_path.string(), filter);
+                CoE::materializeStorage(device.dictionary);
+                configureDeviceDictionary(sim, device);
+            }
         }
         else
         {
-            throw std::runtime_error("Config file " + config_path + " missing 'eeprom' or 'esi' field");
-        }
-
-        sim.pdo   = std::make_unique<PDO>(sim.esc.get());
-        sim.slave = std::make_unique<slave::Slave>(sim.esc.get(), sim.pdo.get());
-
-        // The OD is injected into the slave always, and into a mailbox only if the
-        // device advertises CoE - so a mailboxless terminal still maps PDOs.
-        if (esi_coe)
-        {
-            sim.dictionary = std::make_unique<CoE::Dictionary>(std::move(*esi_coe));
-            sim.slave->setDictionary(sim.dictionary.get());
-            if (esi_coe_advertised)
-            {
-                sim.mailbox = std::make_unique<mailbox::response::Mailbox>(sim.esc.get(), 1024);
-                sim.mailbox->enableCoE(*sim.dictionary);
-                sim.slave->setMailbox(sim.mailbox.get());
-            }
-        }
-        else if (config.contains("coe_xml"))
-        {
-            fs::path coe_xml_full_path = config_dir / config["coe_xml"].get<std::string>();
-            if (not fs::exists(coe_xml_full_path))
-            {
-                throw std::runtime_error("CoE XML file not found: " + coe_xml_full_path.string());
-            }
-            sim.dictionary = std::make_unique<CoE::Dictionary>(parser.loadFile(coe_xml_full_path.string()));
-            sim.mailbox = std::make_unique<mailbox::response::Mailbox>(sim.esc.get(), 1024);
-            sim.mailbox->enableCoE(*sim.dictionary);
-            sim.slave->setDictionary(sim.dictionary.get());
-            sim.slave->setMailbox(sim.mailbox.get());
+            throw std::runtime_error("Config file " + config_path.string() + " missing 'eeprom' or 'esi' field");
         }
 
         sim.input.resize(PDO_MAX_SIZE);

--- a/lib/slave/include/kickcat/ESC/EmulatedESC.h
+++ b/lib/slave/include/kickcat/ESC/EmulatedESC.h
@@ -1,11 +1,15 @@
 #ifndef KICKCAT_SLAVE_ESC_EMULATED_ESC_H
 #define KICKCAT_SLAVE_ESC_EMULATED_ESC_H
 
+#include <filesystem>
+
 #include "kickcat/protocol.h"
 #include "kickcat/AbstractESC.h"
 
 namespace kickcat
 {
+    namespace fs = std::filesystem;
+
     class EmulatedESC final : public AbstractESC
     {
         // ESC access type
@@ -19,11 +23,11 @@ namespace kickcat
 
     public:
         EmulatedESC();
-        EmulatedESC(std::string const& eeprom_path);
+        EmulatedESC(fs::path const& eeprom_path);
         virtual ~EmulatedESC() = default;
 
         // Helpers to load the eeprom
-        void loadEeprom(std::string const& eeprom_path);
+        void loadEeprom(fs::path const& eeprom_path);
         void loadEeprom(std::vector<uint16_t> const& eeprom_data);
         void loadEeprom(std::vector<uint8_t> const& image);  // word-addressed; odd trailing byte zero-filled
 
@@ -269,6 +273,8 @@ namespace kickcat
         nanoseconds      clock_jitter_{0ns};
         mutable uint64_t jitter_rng_{0x2545f4914f6cdd1dull};
     };
+
+    std::vector<uint8_t> loadBinaryFile(fs::path const& path);
 }
 
 #endif

--- a/lib/slave/src/ESC/EmulatedESC.cc
+++ b/lib/slave/src/ESC/EmulatedESC.cc
@@ -43,14 +43,19 @@ namespace kickcat
         std::memset(memory_.sync_manager, 0, sizeof(memory_.sync_manager));
     }
 
-    EmulatedESC::EmulatedESC(std::string const& path)
+    EmulatedESC::EmulatedESC(fs::path const& path)
         : EmulatedESC()
     {
         loadEeprom(path);
     }
 
-    void EmulatedESC::loadEeprom(std::string const& path)
+    void EmulatedESC::loadEeprom(fs::path const& path)
     {
+        std::vector<uint8_t> image = loadBinaryFile(path);
+        loadEeprom(image);
+    }
+
+    std::vector<uint8_t> loadBinaryFile(fs::path const& path) {
         std::ifstream eeprom_file;
         eeprom_file.open(path, std::ios::binary | std::ios::ate);
         if (not eeprom_file.is_open())
@@ -62,8 +67,7 @@ namespace kickcat
         std::vector<uint8_t> image(static_cast<std::size_t>(size));
         eeprom_file.read(reinterpret_cast<char*>(image.data()), size);
         eeprom_file.close();
-
-        loadEeprom(image);
+        return image;
     }
 
     void EmulatedESC::loadEeprom(std::vector<uint16_t> const& eeprom_data)

--- a/simulation/network_simulator.cc
+++ b/simulation/network_simulator.cc
@@ -7,7 +7,6 @@
 #include <numeric>
 
 #include "kickcat/EmulatedNetwork.h"
-#include "kickcat/ESI/Parser.h"
 #include "kickcat/Frame.h"
 #include "kickcat/OS/Time.h"
 #include "kickcat/helpers.h"
@@ -237,11 +236,10 @@ int main(int argc, char* argv[])
     std::vector<sim::SimulatedSlave> slaves;
     try
     {
-        ESI::Parser parser;
         slaves.reserve(opts.slave_configs.size());
         for (auto const& config_path : opts.slave_configs)
         {
-            slaves.push_back(sim::buildSlave(config_path, parser));
+            slaves.push_back(sim::buildSlave(config_path));
         }
     }
     catch (std::exception const& e)

--- a/simulation/slave_configs/xmc4800.json
+++ b/simulation/slave_configs/xmc4800.json
@@ -1,4 +1,4 @@
 {
   "eeprom": "../../examples/slave/nuttx/xmc4800/boards/relax/eeprom_xmc4800.bin",
-  "coe_xml": "../../examples/slave/nuttx/xmc4800/xmc4800.xml"
+  "coe_xml": "../../examples/slave/nuttx/xmc4800/boards/relax/xmc4800.xml"
 }


### PR DESCRIPTION
I added a verification between eeprom and coe_xml file, such that the product code and revision number are read from the eeprom, and then the device is searched in the coe_xml file.