### PR TITLE
Add a PLL mechanism to lock the master on the DC ref clock

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -60,6 +60,13 @@ authoritative source for "what works today"; the README only summarizes it.
 The ESC emulator models a DC clock with configurable drift; see
 [SIMULATION.md](SIMULATION.md). Slave-side DC is not implemented on real ESCs yet.
 
+`Bus::enableDC` lets the reference (first DC) slave clock free-run: the cyclic drift
+datagram only relays it to the other slaves (ETG-standard FRMW/ARMW relay). The master
+phase-locks its own cycle loop to that clock with a soft PLL owned by `Timer`
+(`Timer::sync_to`, driven each cycle by `Bus::sync`), rather than writing its
+software-sampled time back into the reference — doing so would inject the master's
+RT-loop jitter into the DC domain and can unlock the slaves' SYNC PLL.
+
 ## Networking and reliability
 
 | Feature                                   | Master    | Slave     |

--- a/examples/master/marvin/marvin.cc
+++ b/examples/master/marvin/marvin.cc
@@ -94,7 +94,6 @@ int main(int argc, char *argv[])
         for (int i = 0; i < MOTOR_COUNT; ++i)
         {
             Slave& slave = bus.slaves().at(i + 1); // slave 0 is the port junction
-            printf("yay %s\n", slave.name().c_str());
 
             auto drive = std::make_unique<Drive>(bus, slave);
             // This drive uses PDO objects 0x1601/0x1A01 and only accepts the INT8
@@ -163,12 +162,12 @@ int main(int argc, char *argv[])
         bus.processDataRead(false_alarm);
         bus.processDataWrite(false_alarm);
 
+        // Phase-lock the cadence to the DC reference captured by the cyclic drift datagram.
+        bus.sync(timer);
         timer.wait_next_tick();
     }
 
-    // Input image is valid now: capture typed PDO pointers and seed the setpoints.
-    // Force mode 0 until enabling at i==500 (attach() seeds the configured mode 8);
-    // the RxPDO mode byte overrides the SDO-set mode every cycle.
+    // attach() seeds mode 8; force 0 until enable at i==500 (the RxPDO mode byte overrides the SDO).
     for (auto& motor : motors)
     {
         motor.drive->attach();
@@ -207,6 +206,8 @@ int main(int argc, char *argv[])
     constexpr int64_t LOOP_NUMBER = 12 * 3600 * 1000; // 12h
     //constexpr int64_t LOOP_NUMBER = 1000 * 60 * 5; // 5min
     int64_t last_error = 0;
+    double drift_ema_ppm = 0.0;   // smoothed drift trend for the 1 Hz readout
+    bool drift_ema_init = false;
     for (int64_t i = 0; i < LOOP_NUMBER; ++i)
     {
         try
@@ -260,7 +261,29 @@ int main(int argc, char *argv[])
 
             if ((i % 1000) == 0)
             {
-                bus.isDCSynchronized(10us);
+                // ~1 Hz PLL/DC telemetry. ema is the lock metric; slavesDC is the slave-side
+                // hardware SYNC, distinct from the master soft PLL.
+                bool const dc_synced = bus.isDCSynchronized(10us);
+
+                char const* pll_state = "acquiring";
+                if (timer.locked())
+                {
+                    pll_state = "locked";
+                }
+                char const* dc_state = "no";
+                if (dc_synced)
+                {
+                    dc_state = "yes";
+                }
+                printf("PLL %-9s  phaseErr=%+8lld ns  ema=%+9.1f ns  drift=%+7.2f ppm (avg %+6.2f)  corr=%+6lld ns  samples=%9llu  slavesDC=%s\n",
+                    pll_state,
+                    static_cast<long long>(timer.pll().phase_error().count()),
+                    timer.pll().filtered_error(),
+                    timer.pll().frequency_offset_ppm(),
+                    drift_ema_ppm,
+                    static_cast<long long>(timer.pll().correction().count()),
+                    static_cast<unsigned long long>(timer.pll().samples()),
+                    dc_state);
             }
         }
         catch (kickcat::ErrorDatagram const& e)
@@ -313,6 +336,20 @@ int main(int argc, char *argv[])
                         m, sw, motors[m].drive->errorCode());
                 }
             }
+        }
+
+        bus.sync(timer);
+
+        // ~200 ms EMA so the 1 Hz readout shows the drift trend, not per-cycle jitter.
+        double const ppm_now = timer.pll().frequency_offset_ppm();
+        if (drift_ema_init)
+        {
+            drift_ema_ppm = 0.005 * ppm_now + 0.995 * drift_ema_ppm;
+        }
+        else
+        {
+            drift_ema_ppm = ppm_now;
+            drift_ema_init = true;
         }
 
         timer.wait_next_tick();

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -7,6 +7,7 @@ set(KICKCAT_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/TapSocket.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/SIIParser.cc
 
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/OS/SoftPll.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/OS/Time.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/OS/Timer.cc
 

--- a/lib/include/kickcat/OS/SoftPll.h
+++ b/lib/include/kickcat/OS/SoftPll.h
@@ -1,0 +1,118 @@
+#ifndef KICKCAT_OS_SOFT_PLL_H
+#define KICKCAT_OS_SOFT_PLL_H
+
+#include <cstdint>
+
+#include "kickcat/OS/Time.h"
+
+namespace kickcat
+{
+    /// \brief Software PLL that phase-locks a cyclic loop to a free-running reference clock.
+    /// \details Disciplines the phase of a local cadence (a Timer's deadline grid). Owned by Timer;
+    ///          feed it the reference slave's system time each cycle via Timer::sync_to.
+    ///
+    ///          Each cycle it is fed the reference clock's time and whether the previous cycle woke
+    ///          late. It computes the phase error of the wake instant inside the cycle grid, runs an
+    ///          EMA-filtered clamped PI controller (P pulls phase, I learns the ppm frequency
+    ///          offset), rejects overrun/outlier samples, and returns a slew-limited phase correction.
+    class SoftPll
+    {
+    public:
+        struct Config
+        {
+            double      ema_alpha        = 0.1;      // EMA weight on the newest phase error
+            double      kp               = 0.05;     // proportional gain (phase pull)
+            double      ki               = 0.0005;   // integral gain (learns frequency offset)
+            nanoseconds slew_limit       = 20us;     // max |correction| applied per cycle
+            nanoseconds integrator_clamp = 200us;    // anti-windup bound on the integral term
+            nanoseconds outlier_reject   = 150us;    // |phase error| above this -> coast, do not learn
+            nanoseconds lock_threshold   = 8us;      // |EMA| below this counts toward lock
+            uint32_t    lock_samples     = 500;      // consecutive in-threshold samples to declare lock
+            // Unlock hysteresis: once locked, lock is only dropped after |EMA| stays above
+            // unlock_threshold (> lock_threshold) for unlock_samples in a row. Without this the
+            // lock flaps between locked/acquiring whenever the filtered error rides the threshold.
+            nanoseconds unlock_threshold = 20us;     // |EMA| above this counts toward unlock
+            uint32_t    unlock_samples   = 200;      // consecutive over-threshold samples to drop lock
+            // consecutive post-lock outlier rejects before dropping the lock and re-acquiring
+            uint32_t    reject_escape_samples = 200;
+        };
+
+        /// \param cycle_period  the loop period; the grid the phase is measured against
+        /// \param config        gains and limits; defaults are the hardware-validated starting point
+        // Two overloads instead of a Config{} default argument: a nested struct's member
+        // initializers are not usable in the enclosing class's complete-class context.
+        explicit SoftPll(nanoseconds cycle_period);
+        SoftPll(nanoseconds cycle_period, Config const& config);
+
+        /// \brief Consume one cycle's reference-clock sample and advance the controller.
+        /// \param reference_system_time  free-running reference clock, raw ns
+        /// \param cycle_overran          previous cycle woke late; its sample is rejected as an outlier
+        /// \return the phase correction to apply to the loop deadline. Its sign is already oriented to
+        ///         shrink the phase error; a coasted cycle re-applies the last correction so the
+        ///         frequency bias is held.
+        nanoseconds update(uint64_t reference_system_time, bool cycle_overran);
+
+        /// \brief Coast one cycle with no fresh sample: re-apply the last correction, do not learn.
+        /// \return the held phase correction (same sign as update()).
+        nanoseconds coast() const { return nanoseconds{-correction_}; }
+
+        /// \return true once |EMA| has stayed below lock_threshold for lock_samples cycles in a row
+        bool locked() const { return locked_; }
+
+        /// \brief Drop the learned state (target, integrator, filter, lock). The next valid sample
+        ///        relearns the target phase.
+        void reset();
+
+        /// \return last raw (wrapped) phase error; valid once at least one sample was accepted
+        nanoseconds phase_error() const { return nanoseconds{last_error_}; }
+
+        /// \return the EMA-filtered phase error in ns (double, sub-ns resolution kept for the loop)
+        double filtered_error() const { return ema_; }
+
+        /// \return the phase correction applied to the loop deadline last cycle (ns).
+        nanoseconds correction() const { return nanoseconds{-correction_}; }
+
+        /// \return the learned frequency offset (ppm) of the local cadence vs the reference;
+        ///         positive means the reference runs ahead. Meaningful once locked.
+        double frequency_offset_ppm() const
+        {
+            if (cycle_ <= 0)
+            {
+                return 0.0;
+            }
+            return ki_ * integ_ / static_cast<double>(cycle_) * 1e6;
+        }
+
+        /// \return number of samples accepted since construction/reset
+        uint64_t samples() const { return samples_; }
+
+    private:
+        int64_t cycle_;              // loop period in ns
+        double  ema_alpha_;
+        double  kp_;
+        double  ki_;
+        int64_t slew_;               // per-cycle correction clamp, ns
+        int64_t integ_clamp_;        // anti-windup clamp, ns
+        int64_t reject_;             // outlier reject threshold, ns
+        int64_t lock_threshold_;     // ns
+        uint32_t lock_samples_;
+        int64_t  unlock_threshold_;  // ns; unlock hysteresis amplitude
+        uint32_t unlock_samples_;    // consecutive over-threshold samples to drop lock
+        uint32_t reject_escape_;     // consecutive post-lock outlier rejects before re-acquiring
+
+        int64_t target_{-1};         // learned target phase, ns; <0 means "not learned yet"
+        int64_t last_error_{0};
+        double  ema_{0.0};
+        double  integ_{0.0};
+        int64_t correction_{0};      // last PI output (sign = phase direction), ns
+        uint64_t samples_{0};
+        uint32_t lock_count_{0};
+        uint32_t unlock_count_{0};
+        uint32_t reject_streak_{0};   // consecutive post-lock outlier rejects, for the escape
+        bool    locked_{false};
+        bool    ever_locked_{false};  // gates the outlier reject: off during cold acquisition
+
+    };
+}
+
+#endif

--- a/lib/include/kickcat/OS/Time.h
+++ b/lib/include/kickcat/OS/Time.h
@@ -7,7 +7,8 @@
 namespace kickcat
 {
     using namespace std::chrono;
-    using seconds_f = std::chrono::duration<float>;
+    // double, not float despite the name: a float second count loses sub-ms resolution after ~30 min.
+    using seconds_f = std::chrono::duration<double>;
 
     void sleep(nanoseconds ns);
 

--- a/lib/include/kickcat/OS/Timer.h
+++ b/lib/include/kickcat/OS/Timer.h
@@ -3,6 +3,7 @@
 
 #include <system_error>
 
+#include "kickcat/OS/SoftPll.h"
 #include "kickcat/OS/Time.h"
 
 namespace kickcat
@@ -14,8 +15,9 @@ namespace kickcat
         Timer(Timer const &) = delete;
         void operator=(Timer const &) = delete;
 
-        /// \param  period   Interval between two timer firing
-        Timer(nanoseconds period);
+        /// \param  period      Interval between two timer firing
+        /// \param  pll_config  gains/limits for the soft PLL disciplining the cadence (see sync_to)
+        Timer(nanoseconds period, SoftPll::Config const& pll_config = {});
         ~Timer() = default;
 
         /// \brief  Start (or restart) the timer.
@@ -31,13 +33,42 @@ namespace kickcat
         /// \return timer period/interval
         nanoseconds period() const;
 
-        /// Wait until the next timer tick (blocking call)
+        /// \brief Wait until the next timer tick (blocking call).
+        /// \return an error_code carrying ETIME if the cycle woke late (see overran()).
         std::error_code wait_next_tick();
 
+        /// \return true if the last wait_next_tick() woke late (deadline already past)
+        bool overran() const { return last_overran_; }
+
+        /// \brief Feed one DC reference sample to the soft PLL and nudge the loop deadline by the
+        ///        resulting phase correction (phase only; the period is unchanged). Call once per
+        ///        cycle before wait_next_tick; prefer Bus::sync, which supplies the reference.
+        /// \param reference_system_time  reference clock, raw ns
+        void sync_to(uint64_t reference_system_time)
+        {
+            next_deadline_ += pll_.update(reference_system_time, last_overran_);
+        }
+
+        /// \brief Coast one cycle with no fresh reference: hold the PLL's bias, don't learn. Prefer
+        ///        Bus::sync, which chooses sync_to vs coast for you.
+        void coast()
+        {
+            next_deadline_ += pll_.coast();
+        }
+
+        /// \return true once the soft PLL has held phase lock (readiness gate for the application)
+        bool locked() const { return pll_.locked(); }
+
+        /// \return the soft PLL, for diagnostics (phase error, filtered error, sample count)
+        SoftPll const& pll() const { return pll_; }
+
     private:
-        nanoseconds period_;
-        nanoseconds next_deadline_{};
-        nanoseconds last_wakeup_{};
+        nanoseconds     period_;
+        nanoseconds     next_deadline_{};
+        nanoseconds     last_wakeup_{};
+        bool            last_overran_{false};
+        SoftPll::Config pll_config_;
+        SoftPll         pll_;
     };
 }
 

--- a/lib/include/kickcat/OS/math.h
+++ b/lib/include/kickcat/OS/math.h
@@ -1,0 +1,49 @@
+#ifndef KICKCAT_OS_MATH_H
+#define KICKCAT_OS_MATH_H
+
+#include <cstdint>
+
+namespace kickcat
+{
+    // Freestanding min/max/abs/round helpers that pull no <algorithm>/<cmath>/<cstdlib>. Those
+    // standard headers are broken or mutually conflicting on some embedded C++ exports (e.g. NuttX
+    // on arm-none-eabi, where cxx/cmath references an absent ::nextafterl and <cstdlib> collides with
+    // the toolchain's stdlib.h on div_t) so code compiled for those targets uses these instead.
+    // Prefer the std equivalents (std::clamp / std::abs / std::llround) in any translation unit that
+    // already compiles with those headers.
+
+    template<typename T>
+    T clamp(T v, T lo, T hi)
+    {
+        if (v < lo)
+        {
+            return lo;
+        }
+        if (v > hi)
+        {
+            return hi;
+        }
+        return v;
+    }
+
+    template<typename T>
+    T abs_value(T v)
+    {
+        if (v < 0)
+        {
+            return -v;
+        }
+        return v;
+    }
+
+    inline int64_t round_to_int(double v)
+    {
+        if (v < 0.0)
+        {
+            return static_cast<int64_t>(v - 0.5);
+        }
+        return static_cast<int64_t>(v + 0.5);
+    }
+}
+
+#endif

--- a/lib/include/kickcat/SimulatorControl.h
+++ b/lib/include/kickcat/SimulatorControl.h
@@ -22,9 +22,18 @@ namespace kickcat::sim
         uint8_t  up;      // 1: heal, 0: break
     };
 
+    // Inject zero-mean jitter on a node's reported DC system time (EmulatedESC::
+    // setClockJitter). Lets the host stress the master's soft PLL. 0 disables.
+    struct SetClockJitter
+    {
+        uint16_t node;
+        int64_t  amplitude_ns;
+    };
+
     union ControlPayload
     {
-        SetLink set_link;
+        SetLink        set_link;
+        SetClockJitter set_clock_jitter;
     };
 
     // Out-of-band control bus for network_simulator, off the EtherCAT wire so frame
@@ -35,6 +44,7 @@ namespace kickcat::sim
         enum class Type : uint16_t
         {
             SetLink,
+            SetClockJitter,
         };
 
         Type           type;
@@ -46,6 +56,12 @@ namespace kickcat::sim
     {
         SetLink link;
         uint8_t ok;    // 0: command rejected (bad arguments / unknown type)
+    };
+
+    struct SetClockJitterAck
+    {
+        SetClockJitter cmd;
+        uint8_t        ok;
     };
 
     // Frame-timing window the simulator emits unsolicited (one per N frames).
@@ -60,8 +76,9 @@ namespace kickcat::sim
 
     union EventPayload
     {
-        SetLinkAck set_link_ack;
-        SimStats   stats;
+        SetLinkAck        set_link_ack;
+        SetClockJitterAck set_clock_jitter_ack;
+        SimStats          stats;
     };
 
     // Everything the simulator sends back to the host travels on one return stream:
@@ -73,6 +90,7 @@ namespace kickcat::sim
         enum class Type : uint16_t
         {
             SetLinkAck,
+            SetClockJitterAck,
             FrameStats,
         };
 
@@ -165,6 +183,15 @@ namespace kickcat::sim
 
         bool breakLink(uint16_t a, uint16_t b) { return setLink(a, b, 0); }
         bool healLink(uint16_t a, uint16_t b)  { return setLink(a, b, 1); }
+
+        // Inject zero-mean DC-clock jitter on a node (0 disables).
+        bool setClockJitter(uint16_t node, int64_t amplitude_ns)
+        {
+            ControlCommand cmd{};
+            cmd.type = ControlCommand::Type::SetClockJitter;
+            cmd.payload.set_clock_jitter = {node, amplitude_ns};
+            return send(cmd);
+        }
 
         bool send(ControlCommand const& cmd) { return channel_.sendCommand(cmd); }
         bool nextEvent(ControlEvent& out)    { return channel_.nextEvent(out); }

--- a/lib/master/include/kickcat/Bus.h
+++ b/lib/master/include/kickcat/Bus.h
@@ -10,6 +10,8 @@
 
 namespace kickcat
 {
+    class Timer;
+
     enum MailboxStatusFMMU : uint8_t
     {
         NONE        = 0,
@@ -170,6 +172,14 @@ namespace kickcat
         /// \return working counter
         uint16_t broadcastRead(uint16_t ADO, uint16_t data_size);
 
+        /// \brief Phase-lock a cyclic Timer to the DC reference clock. Call once per cycle after the
+        ///        process-data exchange (which captures the reference slave's 0x0910 via the FRMW
+        ///        drift datagram) and before Timer::wait_next_tick. A no-op until a valid reference
+        ///        has been captured (DC enabled and the drift datagram answered), so it is safe to
+        ///        call unconditionally. This is the canonical way to discipline the master cadence
+        ///        to DC.
+        void sync(Timer& timer) const;
+
         /// \return working counter
         uint16_t broadcastWrite(uint16_t ADO, void const* data, uint16_t data_size);
         void setAddresses();
@@ -260,6 +270,8 @@ namespace kickcat
         uint16_t irq_mask_{0};
 
         Slave* dc_slave_{nullptr};
+        uint64_t last_ref_system_time_{0};     // reference 0x0910 from the last cyclic FRMW
+        mutable bool last_ref_time_valid_{false};  // mutable: sync() consumes it (one sample, one use)
 
         MailboxStatusFMMU mailbox_status_fmmu_{MailboxStatusFMMU::NONE};
 

--- a/lib/master/src/dc.cc
+++ b/lib/master/src/dc.cc
@@ -5,9 +5,27 @@
 #include "debug.h"
 #include "Diagnostics.h"
 #include "helpers.h"
+#include "kickcat/OS/Timer.h"
 
 namespace kickcat
 {
+    void Bus::sync(Timer& timer) const
+    {
+        if (last_ref_time_valid_)
+        {
+            timer.sync_to(last_ref_system_time_);
+
+            // Consume it: a lost cyclic FRMW leaves this false, so a frame-less cycle coasts
+            // rather than re-feed a frozen value (which would wind the integrator through the outage).
+            last_ref_time_valid_ = false;
+        }
+        else
+        {
+            timer.coast();
+        }
+    }
+
+
     nanoseconds Bus::enableDC(nanoseconds cycle_time, nanoseconds shift_cycle, nanoseconds start_delay)
     {
         for (auto& slave : slaves_)
@@ -115,6 +133,10 @@ namespace kickcat
         // TODO: use a config in the slave to select the sync method
         uint8_t enable_dc_sync0 = 0x3;
         broadcastWrite(reg::DC_SYNC_ACTIVATION, &enable_dc_sync0, 1);
+
+        // Drop the init-frame reference: it is seconds stale, so the first sync() waits for a fresh
+        // cyclic sample rather than learn its target phase from it.
+        last_ref_time_valid_ = false;
 
         return to_unix_epoch(start_time - start_delay - shift_cycle);
     }
@@ -492,24 +514,26 @@ namespace kickcat
 
     void Bus::sendDriftCompensation(std::function<void(DatagramState const&)> const& error)
     {
-        auto process = [](DatagramHeader const*, uint8_t const*, uint16_t wkc)
-        {
-            if (wkc == 0)
-            {
-                dc_error("Invalid working counter:  %" PRIu16 "\n", wkc);
-                return DatagramState::INVALID_WKC;
-            }
-            return DatagramState::OK;
-        };
-
         nanoseconds now = since_ecat_epoch();
         uint64_t raw_now = now.count();
-        link_->addDatagram(Command::FPWR, createAddress(dc_slave_->address, reg::DC_SYSTEM_TIME), &raw_now, sizeof(uint64_t), process, error);
 
         // Slaves not matching the FRMW address write the payload to their own clock. Pre-fill it
         // with master time: slaves cut from the reference by a ring split track master time instead
-        // of being slammed to zero by the redundancy frame copy.
-        link_->addDatagram(Command::FRMW, createAddress(dc_slave_->address, reg::DC_SYSTEM_TIME), &raw_now, sizeof(uint64_t), process, error);
+        // of being slammed to zero by the redundancy frame copy. The FRMW return payload is the
+        // reference slave's live 0x0910 that the master can use to phase-lock its cycle loop.
+        auto capture_ref = [this](DatagramHeader const*, uint8_t const* data, uint16_t wkc)
+        {
+            if (wkc == 0)
+            {
+                last_ref_time_valid_ = false;
+                dc_error("Invalid working counter:  %" PRIu16 "\n", wkc);
+                return DatagramState::INVALID_WKC;
+            }
+            std::memcpy(&last_ref_system_time_, data, sizeof(uint64_t));
+            last_ref_time_valid_ = true;
+            return DatagramState::OK;
+        };
+        link_->addDatagram(Command::FRMW, createAddress(dc_slave_->address, reg::DC_SYSTEM_TIME), &raw_now, sizeof(uint64_t), capture_ref, error);
 
         // Age of the drift timestamp when the caller flushes the datagrams: the payload
         // is already this stale when it leaves the master (live ripple investigation).

--- a/lib/simulation/src/SimulatorControlServer.cc
+++ b/lib/simulation/src/SimulatorControlServer.cc
@@ -63,6 +63,19 @@ namespace kickcat::sim
                 response.payload.set_link_ack.link = link;
             }
         }
+        else if (cmd.type == ControlCommand::Type::SetClockJitter)
+        {
+            response.type                            = ControlEvent::Type::SetClockJitterAck;
+            response.payload.set_clock_jitter_ack.ok = 0;
+            SetClockJitter const& j = cmd.payload.set_clock_jitter;
+            EmulatedESC* esc = network_.esc(j.node);
+            if ((j.node < node_count_) and (esc != nullptr) and (j.amplitude_ns >= 0))
+            {
+                esc->setClockJitter(nanoseconds{j.amplitude_ns});
+                response.payload.set_clock_jitter_ack.ok  = 1;
+                response.payload.set_clock_jitter_ack.cmd = j;
+            }
+        }
 
         return response;
     }

--- a/lib/slave/include/kickcat/ESC/EmulatedESC.h
+++ b/lib/slave/include/kickcat/ESC/EmulatedESC.h
@@ -43,6 +43,11 @@ namespace kickcat
         // stays continuous across a change (accumulated drift is rebased, not dropped).
         void setClockDrift(double ppm);
 
+        // Injectable zero-mean jitter on the reported 0x910 system time: each ECAT read
+        // perturbs the value by a uniform pseudo-random offset in [-amplitude, +amplitude].
+        // Models sampling/readout jitter distinct from the steady drift above; 0 disables.
+        void setClockJitter(nanoseconds amplitude) { clock_jitter_ = amplitude; }
+
         // Local free-running clock for a given reference instant: reference time plus
         // the accumulated injected drift. No system time offset nor time-loop trim:
         // receive times latch local time, not system time (datasheet sec1 9.1.3).
@@ -258,6 +263,11 @@ namespace kickcat
         nanoseconds drift_accumulated_{0ns};
         nanoseconds dc_correction_{0ns};
         int64_t     dc_diff_filtered_{0};   // 0x92C mean-value filter state
+
+        // Injected read-time jitter (setClockJitter) and its xorshift64 state. Mutable:
+        // the RNG advances on every 0x910 read, which happens from a const-ish read path.
+        nanoseconds      clock_jitter_{0ns};
+        mutable uint64_t jitter_rng_{0x2545f4914f6cdd1dull};
     };
 }
 

--- a/lib/slave/include/kickcat/EmulatedNetwork.h
+++ b/lib/slave/include/kickcat/EmulatedNetwork.h
@@ -55,6 +55,10 @@ namespace kickcat
         size_t size()          const { return slaves_.size(); }
         bool   hasRedundancy() const { return redundancy_node_ != NO_NODE; }
 
+        // ESC at a node index, or nullptr if out of range. For runtime injection
+        // (clock drift/jitter) driven from the out-of-band control bus.
+        EmulatedESC* esc(size_t node) { if (node >= slaves_.size()) { return nullptr; } return slaves_[node]; }
+
         // True when a frame injected at the head reaches the tail injection point, so
         // the ring is closed: a frame entering one master port leaves the other. When
         // a wire is broken each half loops back to the port it came from instead.

--- a/lib/slave/src/ESC/EmulatedESC.cc
+++ b/lib/slave/src/ESC/EmulatedESC.cc
@@ -129,6 +129,19 @@ namespace kickcat
             return;
         }
         uint64_t t = static_cast<uint64_t>(localSystemTime().count());
+
+        // Zero-mean read jitter: perturb the reported system time by a uniform offset in
+        // [-amplitude, +amplitude]. Lets the host exercise the master's soft-PLL rejection.
+        if (clock_jitter_ > 0ns)
+        {
+            jitter_rng_ ^= jitter_rng_ << 13;
+            jitter_rng_ ^= jitter_rng_ >> 7;
+            jitter_rng_ ^= jitter_rng_ << 17;
+            int64_t const span  = 2 * clock_jitter_.count() + 1;
+            int64_t const noise = static_cast<int64_t>(jitter_rng_ % static_cast<uint64_t>(span)) - clock_jitter_.count();
+            t = static_cast<uint64_t>(static_cast<int64_t>(t) + noise);
+        }
+
         std::memcpy(memory_.DC + (reg::DC_SYSTEM_TIME - reg::DC_RECEIVED_TIME), &t, sizeof(t));
     }
 

--- a/lib/src/OS/SoftPll.cc
+++ b/lib/src/OS/SoftPll.cc
@@ -1,0 +1,159 @@
+#include "kickcat/OS/SoftPll.h"
+#include "kickcat/OS/math.h"
+
+namespace kickcat
+{
+    SoftPll::SoftPll(nanoseconds cycle_period)
+        : SoftPll(cycle_period, Config{})
+    {
+    }
+
+    SoftPll::SoftPll(nanoseconds cycle_period, Config const& config)
+        : cycle_(cycle_period.count())
+        , ema_alpha_(config.ema_alpha)
+        , kp_(config.kp)
+        , ki_(config.ki)
+        , slew_(config.slew_limit.count())
+        , integ_clamp_(config.integrator_clamp.count())
+        , reject_(config.outlier_reject.count())
+        , lock_threshold_(config.lock_threshold.count())
+        , lock_samples_(config.lock_samples)
+        , unlock_threshold_(config.unlock_threshold.count())
+        , unlock_samples_(config.unlock_samples)
+        , reject_escape_(config.reject_escape_samples)
+    {
+    }
+
+    void SoftPll::reset()
+    {
+        target_     = -1;
+        last_error_ = 0;
+        ema_        = 0.0;
+        integ_      = 0.0;
+        correction_  = 0;
+        samples_     = 0;
+        lock_count_  = 0;
+        unlock_count_ = 0;
+        reject_streak_ = 0;
+        locked_      = false;
+        ever_locked_ = false;
+    }
+
+    nanoseconds SoftPll::update(uint64_t reference_system_time, bool cycle_overran)
+    {
+        // Guard against a zero/garbage period: a valid cycle grid is required to measure phase.
+        if (cycle_ <= 0)
+        {
+            return nanoseconds{0};
+        }
+
+        int64_t const phase = static_cast<int64_t>(reference_system_time % static_cast<uint64_t>(cycle_));
+
+        // Learn the target phase from the first valid sample; the constant master/reference offset
+        // and propagation delays are absorbed here so only the residual jitter is disciplined.
+        if (target_ < 0)
+        {
+            target_ = phase;
+        }
+
+        // Wrap the error into (-cycle/2, +cycle/2] so a phase near the grid boundary is corrected
+        // the short way round rather than chasing a full cycle.
+        int64_t error = phase - target_;
+        if (error > cycle_ / 2)
+        {
+            error -= cycle_;
+        }
+        if (error <= -cycle_ / 2)
+        {
+            error += cycle_;
+        }
+        last_error_ = error;
+        ++samples_;
+
+        // Coast (don't learn) on an overrun or a post-lock outlier. The outlier gate is armed only
+        // after first lock: pre-lock a large error is the startup offset to slew in, not noise.
+        bool reject = cycle_overran;
+        if (ever_locked_ and abs_value(error) > reject_)
+        {
+            reject = true;
+
+            // A run of post-lock outliers means the reference moved: drop the stale lock and
+            // re-acquire rather than coast forever. A lone glitch just coasts (streak resets below).
+            ++reject_streak_;
+            if (reject_streak_ >= reject_escape_)
+            {
+                target_       = -1;
+                ema_          = 0.0;
+                integ_        = 0.0;
+                correction_   = 0;
+                lock_count_   = 0;
+                unlock_count_ = 0;
+                reject_streak_ = 0;
+                locked_       = false;
+                ever_locked_  = false;
+            }
+        }
+        else
+        {
+            reject_streak_ = 0;
+        }
+
+        if (not reject)
+        {
+            ema_   = ema_alpha_ * static_cast<double>(error) + (1.0 - ema_alpha_) * ema_;
+            integ_ = clamp(integ_ + static_cast<double>(error),
+                           -static_cast<double>(integ_clamp_), static_cast<double>(integ_clamp_));
+            double const u = kp_ * ema_ + ki_ * integ_;
+            correction_ = clamp(round_to_int(u), -slew_, slew_);
+
+            // Lock detector with hysteresis. An application gates its readiness on locked(), so it
+            // must not chatter: lock is declared once the filtered error has been predominantly in
+            // band, and dropped only after it stays above a HIGHER unlock threshold for a sustained
+            // window. The acquisition counter LEAKS rather than hard-resetting. An occasional
+            // out-of-band sample only costs one step, so jitter (a soft-RT master) merely slows lock
+            // instead of blocking it forever, while a genuinely unconverged loop still never gets
+            // there. Only accepted samples move the counters, and a rejected sample carries no fresh
+            // phase evidence, so it neither advances nor breaks the lock.
+            int64_t const abs_ema = abs_value(static_cast<int64_t>(ema_));
+            if (not locked_)
+            {
+                if (abs_ema < lock_threshold_)
+                {
+                    ++lock_count_;
+                    if (lock_count_ >= lock_samples_)
+                    {
+                        locked_       = true;
+                        ever_locked_  = true;
+                        unlock_count_ = 0;
+                    }
+                }
+                else if (lock_count_ > 0)
+                {
+                    --lock_count_;
+                }
+            }
+            else
+            {
+                if (abs_ema > unlock_threshold_)
+                {
+                    ++unlock_count_;
+                }
+                else
+                {
+                    unlock_count_ = 0;
+                }
+
+                if (unlock_count_ >= unlock_samples_)
+                {
+                    locked_     = false;
+                    lock_count_ = 0;
+                }
+            }
+        }
+
+        // error>0: reference phase is ahead of target -> the wake is late in the grid -> pull the
+        // next deadline earlier (negative delta). Sign validated on hardware: an injected positive
+        // offset must decay, not grow. A coasted cycle re-applies the last correction to hold bias.
+        return nanoseconds{-correction_};
+    }
+}

--- a/lib/src/OS/Timer.cc
+++ b/lib/src/OS/Timer.cc
@@ -3,8 +3,10 @@
 
 namespace kickcat
 {
-    Timer::Timer(nanoseconds period)
+    Timer::Timer(nanoseconds period, SoftPll::Config const& pll_config)
         : period_{period}
+        , pll_config_{pll_config}
+        , pll_{period, pll_config}
     {
     }
 
@@ -29,5 +31,7 @@ namespace kickcat
     void Timer::update_period(nanoseconds period)
     {
         period_ = period;
+        // The grid changed, so the PLL's learned target phase is stale: rebuild on the new cycle.
+        pll_ = SoftPll{period, pll_config_};
     }
 }

--- a/lib/src/OS/Unix/Timer.cc
+++ b/lib/src/OS/Unix/Timer.cc
@@ -28,10 +28,12 @@ namespace kickcat
         next_deadline_ += period_;
 
         std::error_code ret{};
+        last_overran_ = false;
         if (next_deadline_ < last_wakeup_)
         {
             dc_error("!!! LATE !!!\n");
             ret = std::error_code{ETIME, std::system_category()};
+            last_overran_ = true;
         }
         while (next_deadline_ < last_wakeup_)
         {

--- a/lib/src/OS/Windows/Timer.cc
+++ b/lib/src/OS/Windows/Timer.cc
@@ -16,9 +16,11 @@ namespace kickcat
         last_wakeup_ = since_epoch();
 
         next_deadline_ += period_;
+        last_overran_ = false;
         if (next_deadline_ < last_wakeup_)
         {
             printf("!!! LATE !!!\n");
+            last_overran_ = true;
         }
         while (next_deadline_ < last_wakeup_)
         {

--- a/tools/kickui/BusProtocol.h
+++ b/tools/kickui/BusProtocol.h
@@ -200,6 +200,21 @@ namespace kickcat::kickui
         SlaveErrorStats stats;
     };
 
+    // Distributed-clock discipline telemetry: the state of the master's soft PLL
+    // (Timer::sync_to) locking the RT cadence to the DC reference clock, plus the
+    // currently injected master-side jitter. Published only while cyclic + DC on.
+    struct DcStats
+    {
+        bool     active          = false;  // DC on and the loop is disciplining
+        bool     locked          = false;  // PLL has held phase lock
+        int64_t  phase_error_ns  = 0;      // last raw wrapped phase error
+        int64_t  phase_peak_ns   = 0;      // decaying peak |phase error| (RT-tracked, ~1s fade)
+        int64_t  filtered_error_ns = 0;    // EMA-filtered phase error
+        uint64_t samples         = 0;      // PLL samples since bring-up
+        bool     overran         = false;  // last cycle woke late
+        int64_t  master_jitter_ns = 0;     // injected master-side jitter amplitude
+    };
+
     struct BusSnapshot
     {
         bool        redundancy_active = false;
@@ -207,6 +222,7 @@ namespace kickcat::kickui
         std::string error;
         TopologyInfo topology;
         std::vector<SlaveSnapshot> slaves;   // index-aligned with the device list
+        DcStats     dc;
     };
 }
 

--- a/tools/kickui/BusSession.cc
+++ b/tools/kickui/BusSession.cc
@@ -420,6 +420,14 @@ namespace kickcat::kickui
                 }
             }
         }
+        snap->dc.active            = dc_active_;
+        snap->dc.locked            = dc_locked_;
+        snap->dc.phase_error_ns    = dc_phase_error_ns_;
+        snap->dc.phase_peak_ns     = dc_phase_peak_ns_;
+        snap->dc.filtered_error_ns = dc_filtered_error_ns_;
+        snap->dc.samples           = dc_pll_samples_;
+        snap->dc.overran           = dc_overran_;
+        snap->dc.master_jitter_ns  = master_jitter_ns_;
         {
             LockGuard lock(snap_mtx_);
             snapshot_ = snap;
@@ -1214,7 +1222,23 @@ namespace kickcat::kickui
                 setSlaveState(r.control->slave_index_, static_cast<uint8_t>(State::PRE_OP));
             }
 
-            Timer timer{milliseconds(cycle_ms)};
+            // Soft-PLL tuning for KickUI. The bus loop runs on a kickcat Thread at SCHED_FIFO 80
+            // when the process has cap_sys_nice, else it falls back to SCHED_OTHER (see
+            // startBusThread). Either way its residual jitter is larger than a lean hardware
+            // master's: it does more per cycle (GUI actor, mailbox stepping, snapshot publish,
+            // multi-slave) over the tap transport, and an unprivileged run is not real-time at all.
+            // Loosen the lock criteria and outlier reject so a lock can actually accumulate;
+            // Marvin keeps the tight SoftPll defaults.
+            SoftPll::Config pll_cfg;
+            pll_cfg.ema_alpha        = 0.05;    // heavier smoothing -> lower filtered-error noise floor
+            pll_cfg.slew_limit       = 30us;
+            pll_cfg.integrator_clamp = 500us;
+            pll_cfg.outlier_reject   = 500us;   // soft-RT stalls spike well past the hardware 150us
+            pll_cfg.lock_threshold   = 30us;
+            pll_cfg.unlock_threshold = 80us;
+            pll_cfg.lock_samples     = 200;
+            pll_cfg.unlock_samples   = 100;
+            Timer timer{milliseconds(cycle_ms), pll_cfg};
             timer.start();
             double const dt = cycle_ms * 1.0e-3;
 
@@ -1237,11 +1261,32 @@ namespace kickcat::kickui
             // unmapped slave's mailbox actually advances. Reset right after the command.
             bool service_unmapped = false;
 
+            uint64_t jitter_rng = 0x9e3779b97f4a7c15ull ^ static_cast<uint64_t>(cycle_ms);  // xorshift64 state
+
             // One full cyclic tick: compute + apply each drive's setpoint, exchange
             // all PDOs together, advance one mailbox step, publish per-drive feedback.
             auto rt_cyclic = [&]
             {
+                // Phase-lock the RT cadence to the DC reference captured by the previous cycle's
+                // drift datagram. No-op until a valid reference exists; the timer remembers its own
+                // overrun, so a late wake rejects its own suspect sample.
+                bus->sync(timer);
                 timer.wait_next_tick();
+
+                // Optional master-side jitter: busy-wait a bounded pseudo-random delay before
+                // sending the frame so the sampled DC phase is perturbed -- exercises the PLL.
+                int64_t jitter = master_jitter_ns_.load();
+                if (jitter > 0)
+                {
+                    int64_t const cap = milliseconds(cycle_ms).count() / 4;
+                    if (jitter > cap) { jitter = cap; }
+                    jitter_rng ^= jitter_rng << 13;
+                    jitter_rng ^= jitter_rng >> 7;
+                    jitter_rng ^= jitter_rng << 17;
+                    nanoseconds const until = since_epoch()
+                        + nanoseconds{static_cast<int64_t>(jitter_rng % static_cast<uint64_t>(jitter + 1))};
+                    while (since_epoch() < until) { /* burn the injected jitter */ }
+                }
 
                 for (auto& r : rts)
                 {
@@ -1453,6 +1498,27 @@ namespace kickcat::kickui
                     r.control->fb_.faulted           = drive.isFaulted();
                     r.control->fb_.operational       = (r.current_state == static_cast<int>(State::OPERATIONAL));
                 }
+
+                // Publish soft-PLL telemetry for the UI (DC lock panel).
+                dc_active_.store(dc_enabled_.load());
+                if (dc_enabled_)
+                {
+                    int64_t const pe = timer.pll().phase_error().count();
+                    dc_locked_.store(timer.locked());
+                    dc_phase_error_ns_.store(pe);
+                    dc_filtered_error_ns_.store(static_cast<int64_t>(std::llround(timer.pll().filtered_error())));
+                    dc_pll_samples_.store(timer.pll().samples());
+                    dc_overran_.store(timer.overran());
+
+                    // Decaying peak-hold of |phase error|, tracked on the RT thread so it catches
+                    // every cycle's spike (the UI samples far slower). Fades over ~1 s so a spike
+                    // stays visible long enough to read, then relaxes back toward the live error.
+                    int64_t peak = dc_phase_peak_ns_.load();
+                    int64_t const abs_pe = std::llabs(pe);
+                    peak -= peak / 1024;
+                    if (abs_pe > peak) { peak = abs_pe; }
+                    dc_phase_peak_ns_.store(peak);
+                }
             };
 
             // Apply one queued motor/units command to its DriveRuntime (latest-wins).
@@ -1635,6 +1701,9 @@ namespace kickcat::kickui
                     service_unmapped = false;
                 }
             }
+
+            dc_active_.store(false);   // left the cyclic phase: PLL no longer disciplining
+            dc_phase_peak_ns_.store(0);
 
             try { bus->disableIRQ(EcatEvent::AL_STATUS); } catch (std::exception const&) {}
 

--- a/tools/kickui/BusSession.h
+++ b/tools/kickui/BusSession.h
@@ -208,6 +208,13 @@ namespace kickcat::kickui
         // Bus-wide distributed-clock setting; applied during connect (PRE-OP).
         void setDcConfig(bool enable, int cycle_ms);
 
+        // Inject master-side timing jitter: each cyclic tick the RT thread busy-waits
+        // a pseudo-random delay in [0, amplitude] before sending the frame, perturbing
+        // the sampled DC phase so the soft PLL has to correct it. 0 disables. Bounded
+        // to a quarter cycle by the loop. UI thread; effective on the next tick.
+        void setMasterJitter(int64_t amplitude_ns) { master_jitter_ns_ = amplitude_ns; }
+        int64_t masterJitter() const { return master_jitter_ns_; }
+
         // Cable redundancy: a non-empty redundant interface makes connect open a
         // second socket and probe the ring (Link::checkRedundancyNeeded). Set on
         // the UI thread before connect(). redundancyActive() reflects the live
@@ -371,6 +378,17 @@ namespace kickcat::kickui
 
         std::atomic<bool>    dc_enabled_{false};
         std::atomic<int>     cycle_ms_{1};
+
+        // Soft-PLL telemetry, written by the RT thread each tick, copied into the
+        // snapshot by publishSnapshot. master_jitter_ns_ is UI-set (see setMasterJitter).
+        std::atomic<bool>     dc_active_{false};
+        std::atomic<bool>     dc_locked_{false};
+        std::atomic<int64_t>  dc_phase_error_ns_{0};
+        std::atomic<int64_t>  dc_phase_peak_ns_{0};
+        std::atomic<int64_t>  dc_filtered_error_ns_{0};
+        std::atomic<uint64_t> dc_pll_samples_{0};
+        std::atomic<bool>     dc_overran_{false};
+        std::atomic<int64_t>  master_jitter_ns_{0};
 
         std::string          redundancy_interface_;   // UI-thread; read at connect()
         std::atomic<bool>    redundancy_active_{false};

--- a/tools/kickui/Simulator.cc
+++ b/tools/kickui/Simulator.cc
@@ -41,10 +41,10 @@ namespace kickcat::kickui
         return ports;
     }
 
-    void SimScene::save(char const* path, std::string& message) const
+    bool SimScene::save(char const* path, std::string& message) const
     {
         std::ofstream f(path);
-        if (not f) { message = std::string("cannot write ") + path; return; }
+        if (not f) { message = std::string("cannot write ") + path; return false; }
         int red = 0;
         if (redundancy) { red = 1; }
         f << "# kickui sim scene\n";
@@ -56,15 +56,16 @@ namespace kickcat::kickui
         if (not f)
         {
             message = std::string("write error on ") + path;
-            return;
+            return false;
         }
         message = std::string("saved ") + path;
+        return true;
     }
 
-    void SimScene::load(char const* path, std::string& message)
+    bool SimScene::load(char const* path, std::string& message)
     {
         std::ifstream f(path);
-        if (not f) { message = std::string("cannot open ") + path; return; }
+        if (not f) { message = std::string("cannot open ") + path; return false; }
         std::vector<SimSlave> loaded;
         bool red = false;
         std::string tok;
@@ -92,7 +93,7 @@ namespace kickcat::kickui
                 std::getline(f, rest);
             }
         }
-        if (loaded.empty()) { message = std::string("no slaves in ") + path; return; }
+        if (loaded.empty()) { message = std::string("no slaves in ") + path; return false; }
         // Keep the tree acyclic: a parent must reference an earlier slave.
         for (int i = 0; i < static_cast<int>(loaded.size()); ++i)
         {
@@ -101,6 +102,7 @@ namespace kickcat::kickui
         slaves     = std::move(loaded);
         redundancy = red;
         message    = std::string("loaded ") + path;
+        return true;
     }
 
     bool SimScene::writeTopologyFile(std::string const& path, std::string& error) const
@@ -382,6 +384,12 @@ namespace kickcat::kickui
         auto key = std::make_pair(std::min(a, b), std::max(a, b));
         if (broken) { broken_links_.insert(key); }
         else        { broken_links_.erase(key); }
+    }
+
+    void SimulatorProcess::setClockJitter(int node, int64_t amplitude_ns)
+    {
+        if ((not control_) or (node < 0) or (amplitude_ns < 0)) { return; }
+        control_->setClockJitter(static_cast<uint16_t>(node), amplitude_ns);
     }
 #endif
 }

--- a/tools/kickui/Simulator.h
+++ b/tools/kickui/Simulator.h
@@ -32,9 +32,9 @@ namespace kickcat::kickui
         std::vector<int> assignedPorts() const;
 
         // Save/load the editor scene as a small text file, so a topology is easy
-        // to reproduce and share.
-        void save(char const* path, std::string& message) const;
-        void load(char const* path, std::string& message);
+        // to reproduce and share. Return false (and set message) on failure.
+        bool save(char const* path, std::string& message) const;
+        bool load(char const* path, std::string& message);
 
         // Serialize into a network_simulator --topology file: a master injection
         // point on the root + one connect() edge per non-root slave. False (and
@@ -68,6 +68,10 @@ namespace kickcat::kickui
         // the link draws broken until healed. No-op without a running simulator.
         void setLinkBroken(int a, int b, bool broken);
         std::set<std::pair<int, int>> const& brokenLinks() const { return broken_links_; }
+
+        // Inject zero-mean DC-clock jitter (ns amplitude) on a SIM slave index; 0 disables.
+        // No-op without a running simulator.
+        void setClockJitter(int node, int64_t amplitude_ns);
 
         // Pop one message from the simulator's return stream (acks + events).
         // False when nothing is pending (or when not running). The caller drains

--- a/tools/kickui/main.cc
+++ b/tools/kickui/main.cc
@@ -440,6 +440,7 @@ namespace kickcat::kickui
             // editor from the running sim, so it is gated like the rest.
             // The text field holds the path; "Browse..." fills it via a dialog,
             // and Save/Load act on whatever it holds.
+            bool const load_gated = (running or session_.isConnected() or session_.isConnecting());
             ImGui::SetNextItemWidth(px(170.0f));
             ImGui::InputText("scene", sim_scene_path_, sizeof(sim_scene_path_));
             ImGui::SameLine();
@@ -451,17 +452,27 @@ namespace kickcat::kickui
                 {
                     std::string chosen = relativeToCwd(sel[0]);
                     std::snprintf(sim_scene_path_, sizeof(sim_scene_path_), "%s", chosen.c_str());
+                    // Picking a scene means you want it loaded -- do it now (unless a live
+                    // sim/session would desync). The Load button stays for a typed/edited path.
+                    if (not load_gated) { sim_scene_ok_ = scene_.load(sim_scene_path_, sim_scene_msg_); }
                 }
             }
             ImGui::SameLine();
-            if (ImGui::Button("Save")) { scene_.save(sim_scene_path_, sim_scene_msg_); }
+            if (ImGui::Button("Save")) { sim_scene_ok_ = scene_.save(sim_scene_path_, sim_scene_msg_); }
             ImGui::SameLine();
-            ImGui::BeginDisabled(running or session_.isConnected() or session_.isConnecting());
-            if (ImGui::Button("Load")) { scene_.load(sim_scene_path_, sim_scene_msg_); }
+            ImGui::BeginDisabled(load_gated);
+            if (ImGui::Button("Load")) { sim_scene_ok_ = scene_.load(sim_scene_path_, sim_scene_msg_); }
             ImGui::EndDisabled();
+            if (load_gated and ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+            {
+                ImGui::SetTooltip("Load is disabled while a simulator is running or a bus is\n"
+                                  "connected (it would desync the editor). Stop/disconnect first.");
+            }
             if (not sim_scene_msg_.empty())
             {
-                ImGui::TextDisabled("%s", sim_scene_msg_.c_str());
+                ImVec4 col = COLOR_GREEN;
+                if (not sim_scene_ok_) { col = COLOR_RED; }
+                ImGui::TextColored(col, "%s", sim_scene_msg_.c_str());
             }
 
             if (running)
@@ -878,6 +889,11 @@ namespace kickcat::kickui
                     renderDeviceDetail();
                     ImGui::EndTabItem();
                 }
+                if (ImGui::BeginTabItem("Distributed Clocks"))
+                {
+                    renderDcPanel();
+                    ImGui::EndTabItem();
+                }
                 // The "###diag" suffix fixes the tab's ImGui ID, so the visible count
                 // can change (or the banner ack fire) WITHOUT the tab losing selection.
                 char diag_label[40] = "Diagnostics###diag";
@@ -893,6 +909,136 @@ namespace kickcat::kickui
                 }
                 ImGui::EndTabBar();
             }
+        }
+
+        // Distributed-clock discipline: shows the master soft-PLL locking the RT
+        // cadence to the DC reference, with a live phase-error plot, plus jitter
+        // injection knobs (master-side and simulator reference clock) to exercise it.
+        void renderDcPanel()
+        {
+            auto snap = session_.snapshot();
+            if ((not snap) or (not snap->dc.active))
+            {
+                ImGui::TextDisabled("Distributed clocks are not disciplining.");
+                ImGui::TextWrapped("Enable DC before connecting and operate the bus: the master "
+                                   "phase-locks its cycle to the reference clock (soft PLL).");
+                dc_phase_history_.clear();
+                dc_filt_history_.clear();
+                return;
+            }
+
+            DcStats const& dc = snap->dc;
+
+            if (dc.locked) { ImGui::TextColored(COLOR_GREEN, "\xe2\x97\x8f PLL LOCKED"); }
+            else           { ImGui::TextColored(COLOR_YELLOW, "\xe2\x97\x8f PLL acquiring..."); }
+            if (dc.overran)
+            {
+                ImGui::SameLine();
+                ImGui::TextColored(COLOR_RED, "  cycle overrun");
+            }
+
+            ImGui::TextWrapped("The master's cycle is phase-locked to the DC reference clock. "
+                               "Phase error is how far each wake-up lands from the target instant; "
+                               "the PLL drives it to zero and reports LOCKED once it stays small.");
+
+            // The RT loop updates far faster than we render, so downsample to a fixed cadence:
+            // the numbers and the plot advance ~10x/s, slow enough to read and stable to compare.
+            constexpr size_t MAX_SAMPLES = 480;   // ~48 s of history at 10 Hz
+            double const t = ImGui::GetTime();
+            if (t >= dc_next_sample_t_)
+            {
+                dc_next_sample_t_ = t + 0.1;   // 10 Hz
+                dc_disp_phase_ns_ = dc.phase_error_ns;
+                dc_disp_filt_ns_  = dc.filtered_error_ns;
+                dc_phase_history_.push_back(static_cast<float>(dc.phase_error_ns) / 1000.0f);
+                dc_filt_history_.push_back(static_cast<float>(dc.filtered_error_ns) / 1000.0f);
+                if (dc_phase_history_.size() > MAX_SAMPLES)
+                {
+                    dc_phase_history_.erase(dc_phase_history_.begin(), dc_phase_history_.end() - MAX_SAMPLES);
+                }
+                if (dc_filt_history_.size() > MAX_SAMPLES)
+                {
+                    dc_filt_history_.erase(dc_filt_history_.begin(), dc_filt_history_.end() - MAX_SAMPLES);
+                }
+            }
+
+            ImGui::Separator();
+            // Explanation first, value last: the label stays put while only the trailing number
+            // changes width (a value-first layout makes the text jump around as the digits change).
+            ImGui::Text("phase error, raw this cycle: %+lld ns", static_cast<long long>(dc_disp_phase_ns_));
+            ImGui::Text("filtered error, EMA the lock test watches: %+lld ns",
+                        static_cast<long long>(dc_disp_filt_ns_));
+            ImGui::Text("peak |phase|, recent spikes (~1s fade): %lld ns",
+                        static_cast<long long>(dc.phase_peak_ns));
+            ImGui::Text("samples since bring-up: %llu", static_cast<unsigned long long>(dc.samples));
+
+            // Live plot: raw phase error (noisy) and the filtered EMA overlaid on one graph,
+            // sharing a scale so the smoothing is visible against the raw jitter. Units: µs.
+            ImVec4 const raw_col = ImGui::GetStyleColorVec4(ImGuiCol_PlotLines);
+            ImGui::TextColored(raw_col, "raw"); ImGui::SameLine();
+            ImGui::TextColored(COLOR_GREEN, "filtered (EMA)"); ImGui::SameLine();
+            ImGui::TextDisabled("\xc2\xb5s");
+
+            float lo = 0.0f, hi = 0.0f;   // include zero so the target line is always on screen
+            for (float v : dc_phase_history_) { if (v < lo) { lo = v; } if (v > hi) { hi = v; } }
+            for (float v : dc_filt_history_)  { if (v < lo) { lo = v; } if (v > hi) { hi = v; } }
+            float span = hi - lo;
+            if (span < 0.001f) { span = 1.0f; }
+            lo -= span * 0.1f;
+            hi += span * 0.1f;
+
+            ImVec2 const plot_size(px(360.0f), px(90.0f));
+            ImGui::PlotLines("##dc_phase", dc_phase_history_.data(),
+                             static_cast<int>(dc_phase_history_.size()),
+                             0, nullptr, lo, hi, plot_size);
+            // Overlay the filtered series on the exact graph area PlotLines just used.
+            if (dc_filt_history_.size() >= 2)
+            {
+                ImVec2 const rmin = ImGui::GetItemRectMin();
+                ImVec2 const rmax = ImGui::GetItemRectMax();
+                ImGuiStyle const& style = ImGui::GetStyle();
+                float const gx0 = rmin.x + style.FramePadding.x;
+                float const gy0 = rmin.y + style.FramePadding.y;
+                float const gw  = (rmax.x - style.FramePadding.x) - gx0;
+                float const gh  = (rmax.y - style.FramePadding.y) - gy0;
+                ImDrawList* dl = ImGui::GetWindowDrawList();
+                ImU32 const col = ImGui::GetColorU32(COLOR_GREEN);
+                size_t const m = dc_filt_history_.size();
+                float const dx = gw / static_cast<float>(m - 1);
+                for (size_t i = 1; i < m; ++i)
+                {
+                    float const ya = gy0 + gh * (1.0f - (dc_filt_history_[i - 1] - lo) / (hi - lo));
+                    float const yb = gy0 + gh * (1.0f - (dc_filt_history_[i]     - lo) / (hi - lo));
+                    dl->AddLine(ImVec2(gx0 + dx * (i - 1), ya), ImVec2(gx0 + dx * i, yb), col, 1.4f);
+                }
+            }
+
+            ImGui::Separator();
+            ImGui::TextDisabled("Jitter injection (to exercise the PLL)");
+
+            if (ImGui::SliderInt("master jitter (\xc2\xb5s)", &dc_master_jitter_us_, 0, 200))
+            {
+                session_.setMasterJitter(static_cast<int64_t>(dc_master_jitter_us_) * 1000);
+            }
+            if (ImGui::IsItemHovered())
+            {
+                ImGui::SetTooltip("Delays each cyclic frame by a random 0..N \xc2\xb5s so the sampled\n"
+                                  "DC phase is perturbed and the PLL must correct it.");
+            }
+
+#ifdef __linux__
+            ImGui::BeginDisabled(not sim_proc_.running());
+            if (ImGui::SliderInt("sim ref-clock jitter (\xc2\xb5s)", &dc_sim_jitter_us_, 0, 200))
+            {
+                sim_proc_.setClockJitter(0, static_cast<int64_t>(dc_sim_jitter_us_) * 1000);
+            }
+            ImGui::EndDisabled();
+            if (ImGui::IsItemHovered())
+            {
+                ImGui::SetTooltip("Adds zero-mean noise to the simulated reference slave's\n"
+                                  "reported DC system time (node 0).");
+            }
+#endif
         }
 
         void renderDeviceDetail()
@@ -1258,12 +1404,23 @@ namespace kickcat::kickui
         std::string sim_error_;
         char        sim_scene_path_[256] = "sim_scene.txt";  // save/load the editor scene
         std::string sim_scene_msg_;
+        bool        sim_scene_ok_ = true;   // last save/load outcome (colors the message)
 #ifdef __linux__
         SimulatorProcess sim_proc_;
         sim::SimStats      sim_last_stats_{};       // most recent window drained
         bool               sim_has_stats_ = false;
         std::vector<float> sim_avg_history_;        // per-window avg (µs), for the sparkline
 #endif
+
+        // DC / soft-PLL panel state (UI thread only). Displayed values are downsampled
+        // (~10 Hz) off the RT loop so they are readable; histories feed the overlaid plot.
+        std::vector<float> dc_phase_history_;      // recent raw phase error (µs)
+        std::vector<float> dc_filt_history_;       // recent filtered (EMA) error (µs)
+        double             dc_next_sample_t_ = 0.0;  // next ImGui::GetTime() to sample at
+        int64_t            dc_disp_phase_ns_ = 0;   // held raw value shown as text
+        int64_t            dc_disp_filt_ns_  = 0;   // held filtered value shown as text
+        int                dc_master_jitter_us_ = 0;  // injected master-side jitter slider
+        int                dc_sim_jitter_us_    = 0;  // injected simulator ref-clock jitter slider
 
         EventLog     event_log_;
         TopologyView topo_view_;

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(kickcat_unit src/adler32_sum-t.cc
                             src/AbstractSPI-t.cc
                             src/bus-t.cc
+                            src/SoftPll-t.cc
                             src/dc-t.cc
                             src/debughelpers-t.cc
                             src/diagnostics-t.cc
@@ -26,6 +27,7 @@ add_executable(kickcat_unit src/adler32_sum-t.cc
                             src/ESMStatePreOP-t.cc
                             src/ESMStateSafeOP-t.cc
                             src/Units-t.cc
+                            src/Timer-t.cc
                             src/CoE/protocol-t.cc
                             src/CoE/OD-t.cc
                             src/ESI/Parser-t.cc

--- a/unit/src/SimulatorControl-t.cc
+++ b/unit/src/SimulatorControl-t.cc
@@ -202,3 +202,40 @@ TEST_F(SimulatorControlTest, client_drives_server_against_network)
     EXPECT_EQ(response.payload.set_link_ack.ok, 0);
     EXPECT_TRUE(reachesNode1(0x4004));
 }
+
+
+TEST_F(SimulatorControlTest, set_clock_jitter_command_round_trip)
+{
+    std::vector<std::unique_ptr<EmulatedESC>> escs;
+    std::vector<EmulatedESC*> esc_ptrs;
+    for (int i = 0; i < 3; ++i)
+    {
+        escs.push_back(std::make_unique<EmulatedESC>());
+        esc_ptrs.push_back(escs.back().get());
+    }
+    EmulatedNetwork network(std::move(esc_ptrs));
+
+    SimulatorControlClient client;
+    client.open(SHM_NAME);
+    SimulatorControlServer server(network, network.size());
+    server.attach(SHM_NAME);
+
+    // Valid node: acked ok with the echoed amplitude.
+    ASSERT_TRUE(client.setClockJitter(0, 50000));
+    server.drain();
+    ControlEvent response;
+    ASSERT_TRUE(client.nextEvent(response));
+    EXPECT_EQ(response.type, ControlEvent::Type::SetClockJitterAck);
+    EXPECT_EQ(response.payload.set_clock_jitter_ack.ok, 1);
+    EXPECT_EQ(response.payload.set_clock_jitter_ack.cmd.node, 0);
+    EXPECT_EQ(response.payload.set_clock_jitter_ack.cmd.amplitude_ns, 50000);
+
+    // Out-of-range node and a negative amplitude are rejected.
+    ASSERT_TRUE(client.setClockJitter(9, 1000));
+    ASSERT_TRUE(client.setClockJitter(1, -1));
+    server.drain();
+    ASSERT_TRUE(client.nextEvent(response));
+    EXPECT_EQ(response.payload.set_clock_jitter_ack.ok, 0);
+    ASSERT_TRUE(client.nextEvent(response));
+    EXPECT_EQ(response.payload.set_clock_jitter_ack.ok, 0);
+}

--- a/unit/src/SoftPll-t.cc
+++ b/unit/src/SoftPll-t.cc
@@ -1,0 +1,342 @@
+// SoftPll: closed-loop convergence and sign of the phase correction.
+//
+// Plant model. The reference clock free-runs; the master wakes at t_k and samples it. Nudging the
+// deadline by delta shifts the next wake, so with ref_ns = t_k + phi:
+//     phase_{k+1} = (phase_k + delta_k) mod cycle
+// The controller must drive an injected phase step back to zero. delta carries the opposite sign of
+// the error, so this also verifies the correction sign (a positive offset must decay, not grow).
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+
+#include "kickcat/OS/SoftPll.h"
+
+using namespace kickcat;
+
+namespace
+{
+    // Advance the plant one cycle: feed the current reference sample, apply the returned
+    // correction to the wake time, and return the raw wrapped phase error the loop measured.
+    int64_t stepPlant(SoftPll& disc, int64_t& wake_ns, int64_t injected_ns, int64_t cycle_ns)
+    {
+        uint64_t const ref = static_cast<uint64_t>(wake_ns + injected_ns);
+        nanoseconds const delta = disc.update(ref, false);
+        wake_ns += cycle_ns + delta.count();
+        return disc.phase_error().count();
+    }
+}
+
+
+TEST(SoftPllTest, learns_target_and_holds_zero_when_undisturbed)
+{
+    int64_t const cycle = 1000000; // 1 ms
+    SoftPll disc{nanoseconds{cycle}};
+
+    int64_t wake = 5000000;
+    for (int i = 0; i < 10; ++i)
+    {
+        int64_t const err = stepPlant(disc, wake, 0, cycle);
+        EXPECT_EQ(0, err); // no disturbance -> error stays at the learned target
+    }
+}
+
+
+TEST(SoftPllTest, positive_offset_decays_and_locks)
+{
+    int64_t const cycle = 1000000; // 1 ms
+    SoftPll disc{nanoseconds{cycle}};
+
+    // Cycle 0 establishes the target phase (error 0).
+    int64_t wake = 5000000;
+    stepPlant(disc, wake, 0, cycle);
+
+    // Inject a +50 us phase step, held for the rest of the run.
+    int64_t const injected = 50000;
+
+    // First disturbed cycle: error must be positive and the correction must pull the wake earlier
+    // (negative delta) -- the sign check.
+    uint64_t const ref = static_cast<uint64_t>(wake + injected);
+    nanoseconds const first_delta = disc.update(ref, false);
+    EXPECT_GT(disc.phase_error().count(), 0);      // +offset shows up as +error
+    EXPECT_LT(first_delta.count(), 0);            // correction opposes it
+    wake += cycle + first_delta.count();
+
+    int64_t const initial_err = disc.phase_error().count();
+
+    // Run the loop closed; the step must decay toward zero.
+    int64_t last_err = initial_err;
+    for (int i = 0; i < 4000; ++i)
+    {
+        last_err = stepPlant(disc, wake, injected, cycle);
+    }
+
+    EXPECT_LT(std::llabs(last_err), std::llabs(initial_err)); // it shrank
+    EXPECT_LT(std::llabs(last_err), 1000);                    // to well under 1 us
+    EXPECT_TRUE(disc.locked());                               // sustained small error asserts lock
+}
+
+
+TEST(SoftPllTest, negative_offset_decays_with_opposite_sign_correction)
+{
+    int64_t const cycle = 1000000;
+    SoftPll disc{nanoseconds{cycle}};
+
+    int64_t wake = 5000000;
+    stepPlant(disc, wake, 0, cycle);
+
+    int64_t const injected = -50000; // -50 us
+
+    uint64_t const ref = static_cast<uint64_t>(wake + injected);
+    nanoseconds const first_delta = disc.update(ref, false);
+    EXPECT_LT(disc.phase_error().count(), 0);
+    EXPECT_GT(first_delta.count(), 0); // correction opposes the negative error
+    wake += cycle + first_delta.count();
+
+    int64_t last_err = disc.phase_error().count();
+    for (int i = 0; i < 4000; ++i)
+    {
+        last_err = stepPlant(disc, wake, injected, cycle);
+    }
+    EXPECT_LT(std::llabs(last_err), 1000);
+    EXPECT_TRUE(disc.locked());
+}
+
+
+TEST(SoftPllTest, learns_frequency_offset_ppm)
+{
+    int64_t const cycle = 1000000; // 1 ms
+    SoftPll disc{nanoseconds{cycle}};
+
+    // Reference runs faster than the master cadence by a constant rate: model it as an offset
+    // proportional to elapsed time. The loop must learn this bias, and frequency_offset_ppm() must
+    // report it (this is the drift figure a soak test watches).
+    double const ppm = 20.0;
+    int64_t wake = 5000000;
+    for (int i = 0; i < 60000; ++i)
+    {
+        int64_t const ref = wake + static_cast<int64_t>(wake * ppm * 1e-6);
+        nanoseconds const delta = disc.update(static_cast<uint64_t>(ref), false);
+        wake += cycle + delta.count();
+    }
+
+    EXPECT_TRUE(disc.locked());
+    EXPECT_NEAR(disc.frequency_offset_ppm(), ppm, 3.0); // learned bias tracks the injected drift
+    EXPECT_LT(std::fabs(disc.filtered_error()), 1000.0); // residual phase error sub-us
+}
+
+
+TEST(SoftPllTest, cold_start_beyond_reject_window_still_locks)
+{
+    int64_t const cycle = 1000000; // 1 ms
+    SoftPll disc{nanoseconds{cycle}};
+
+    int64_t wake = 5000000;
+    stepPlant(disc, wake, 0, cycle); // cycle 0 learns the target at error 0
+
+    // A cold-start phase offset far beyond the 150 us outlier-reject window. Before the staged
+    // reject this was discarded every cycle and the loop never engaged; now it must slew in and
+    // lock within a bounded, sub-second window (slew-limited pull-in + lock_samples).
+    int64_t const injected = 400000; // 400 us > outlier_reject (150 us)
+    int locked_at = -1;
+    for (int i = 0; i < 1000; ++i)
+    {
+        stepPlant(disc, wake, injected, cycle);
+        if (disc.locked())
+        {
+            locked_at = i;
+            break;
+        }
+    }
+    EXPECT_GE(locked_at, 0);   // it locked at all (old behavior: never)
+    EXPECT_LT(locked_at, 800); // within slew-in (~20) + lock_samples (500) + margin
+}
+
+
+TEST(SoftPllTest, outlier_reject_still_guards_once_locked)
+{
+    int64_t const cycle = 1000000;
+    SoftPll disc{nanoseconds{cycle}};
+
+    // Drive it to lock first, so the outlier gate is armed.
+    int64_t wake = 5000000;
+    stepPlant(disc, wake, 0, cycle);
+    for (int i = 0; i < 1000 and not disc.locked(); ++i)
+    {
+        stepPlant(disc, wake, 0, cycle);
+    }
+    ASSERT_TRUE(disc.locked());
+
+    // A single outlier beyond the reject window must now coast (correction unchanged), proving the
+    // gate re-engages after lock rather than being disabled outright.
+    nanoseconds const d_outlier = disc.update(static_cast<uint64_t>(wake + 300000), false);
+    EXPECT_EQ(0, d_outlier.count());
+    EXPECT_TRUE(disc.locked());
+}
+
+
+TEST(SoftPllTest, sustained_post_lock_outlier_re_acquires)
+{
+    int64_t const cycle = 1000000; // 1 ms
+    SoftPll disc{nanoseconds{cycle}};
+
+    // Lock first.
+    int64_t wake = 5000000;
+    stepPlant(disc, wake, 0, cycle);
+    for (int i = 0; i < 1000 and not disc.locked(); ++i)
+    {
+        stepPlant(disc, wake, 0, cycle);
+    }
+    ASSERT_TRUE(disc.locked());
+
+    // The reference jumps 300 us (beyond the 150 us reject window) and stays there. The loop must
+    // not reject forever with locked() stuck true: after the escape streak it abandons the stale
+    // lock and re-acquires to the new phase.
+    int64_t const jump = 300000;
+    bool dropped  = false;
+    bool relocked = false;
+    for (int i = 0; i < 3000; ++i)
+    {
+        stepPlant(disc, wake, jump, cycle);
+        if (not disc.locked())        { dropped  = true; }
+        if (dropped and disc.locked()) { relocked = true; break; }
+    }
+    EXPECT_TRUE(dropped);   // stale lock abandoned (old behavior: never)
+    EXPECT_TRUE(relocked);  // re-acquired to the moved reference
+}
+
+
+TEST(SoftPllTest, coast_holds_bias_without_learning)
+{
+    int64_t const cycle = 1000000;
+    SoftPll disc{nanoseconds{cycle}};
+
+    int64_t wake = 5000000;
+    stepPlant(disc, wake, 0, cycle);
+    for (int i = 0; i < 30; ++i) { stepPlant(disc, wake, 50000, cycle); } // build a nonzero correction
+
+    uint64_t const samples_before = disc.samples();
+    nanoseconds const held  = disc.coast();
+    nanoseconds const held2 = disc.coast();
+    EXPECT_EQ(held.count(), held2.count());      // stable: re-applies the same held correction
+    EXPECT_EQ(samples_before, disc.samples());   // coast does not consume/learn a sample
+}
+
+
+TEST(SoftPllTest, overrun_samples_are_rejected)
+{
+    int64_t const cycle = 1000000;
+    SoftPll disc{nanoseconds{cycle}};
+
+    int64_t wake = 5000000;
+    stepPlant(disc, wake, 0, cycle);
+
+    // A cycle flagged as overran must coast unconditionally, even before lock: a late wake yields a
+    // bogus phase sample. Correction unchanged (0 here), so no phase nudge. (The |error| outlier
+    // gate is staged on lock instead -- see cold_start_* and outlier_reject_still_guards_once_locked.)
+    nanoseconds const d_overrun = disc.update(static_cast<uint64_t>(wake + 50000), true);
+    EXPECT_EQ(0, d_overrun.count());
+}
+
+
+TEST(SoftPllTest, coast_holds_the_last_nonzero_correction)
+{
+    int64_t const cycle = 1000000;
+    SoftPll disc{nanoseconds{cycle}};
+
+    int64_t wake = 5000000;
+    stepPlant(disc, wake, 0, cycle);
+
+    // Build up a non-zero correction with a sustained offset.
+    int64_t const injected = 60000; // 60 us, under the reject threshold
+    nanoseconds last_delta{0};
+    for (int i = 0; i < 5; ++i)
+    {
+        last_delta = disc.update(static_cast<uint64_t>(wake + injected), false);
+        wake += cycle + last_delta.count();
+    }
+    ASSERT_NE(0, last_delta.count()); // precondition: correction is non-zero
+
+    // An overrun must re-apply that same correction (hold the frequency bias), not fall back to 0.
+    nanoseconds const d_overrun = disc.update(static_cast<uint64_t>(wake + injected), true);
+    EXPECT_EQ(last_delta.count(), d_overrun.count());
+}
+
+
+TEST(SoftPllTest, per_cycle_correction_respects_slew_limit)
+{
+    int64_t const cycle = 1000000;
+    SoftPll::Config cfg; // default slew 20 us
+    SoftPll disc{nanoseconds{cycle}, cfg};
+
+    int64_t wake = 5000000;
+    stepPlant(disc, wake, 0, cycle);
+
+    // A large (but not rejected) step: the correction must be clamped to +/- slew each cycle.
+    int64_t const injected = 140000; // under the 150 us reject threshold
+    for (int i = 0; i < 50; ++i)
+    {
+        nanoseconds const delta = disc.update(static_cast<uint64_t>(wake + injected), false);
+        EXPECT_LE(std::llabs(delta.count()), cfg.slew_limit.count());
+        wake += cycle + delta.count();
+    }
+}
+
+
+TEST(SoftPllTest, lock_has_hysteresis_and_does_not_chatter)
+{
+    int64_t const cycle = 1000000; // 1 ms
+    SoftPll::Config cfg;
+    cfg.ema_alpha        = 1.0;    // ema == last error: deterministic detector test
+    cfg.lock_threshold   = 8us;
+    cfg.lock_samples     = 5;
+    cfg.unlock_threshold = 20us;
+    cfg.unlock_samples   = 3;
+    SoftPll disc{nanoseconds{cycle}, cfg};
+
+    // Feed a phase directly (open loop): reference % cycle == phase, target learned as 0.
+    auto feed = [&](int64_t phase) { disc.update(static_cast<uint64_t>(phase), false); };
+
+    for (int i = 0; i < 6; ++i) { feed(0); }
+    EXPECT_TRUE(disc.locked());
+
+    // Excursion above the unlock threshold but shorter than unlock_samples: lock holds.
+    feed(30000);
+    feed(30000);
+    EXPECT_TRUE(disc.locked());
+    feed(0);                       // back in band resets the unlock debounce
+    EXPECT_TRUE(disc.locked());
+
+    // Sustained excursion beyond unlock_samples in a row: lock finally drops.
+    feed(30000);
+    feed(30000);
+    feed(30000);
+    EXPECT_FALSE(disc.locked());
+}
+
+
+TEST(SoftPllTest, acquisition_tolerates_occasional_jitter)
+{
+    int64_t const cycle = 1000000;
+    SoftPll::Config cfg;
+    cfg.ema_alpha        = 1.0;   // ema == error: deterministic
+    cfg.lock_threshold   = 8us;
+    cfg.lock_samples     = 5;
+    cfg.unlock_threshold = 20us;
+    cfg.unlock_samples   = 3;
+    SoftPll disc{nanoseconds{cycle}, cfg};
+
+    auto feed = [&](int64_t phase) { disc.update(static_cast<uint64_t>(phase), false); };
+
+    feed(0);            // learns target 0, lock_count -> 1
+    feed(0);            // 2
+    feed(0);            // 3
+    feed(0);            // 4
+    EXPECT_FALSE(disc.locked());
+    feed(30000);        // out of band: leaky counter steps back to 3 (a hard reset would go to 0)
+    EXPECT_FALSE(disc.locked());
+    feed(0);            // 4
+    feed(0);            // 5 -> lock reached despite the excursion
+    EXPECT_TRUE(disc.locked());
+}

--- a/unit/src/Timer-t.cc
+++ b/unit/src/Timer-t.cc
@@ -1,0 +1,46 @@
+// Timer owning the soft PLL: verify it drives the owned SoftPll and exposes lock/diagnostics.
+// The control loop itself is covered by SoftPll-t.cc; here we only check the wiring, so no real
+// sleeping is needed -- sync_to advances the PLL without touching wait_next_tick.
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "kickcat/OS/Timer.h"
+
+using namespace kickcat;
+
+
+TEST(TimerPllTest, sync_to_advances_the_owned_pll)
+{
+    int64_t const cycle = 1000000; // 1 ms
+    Timer timer{nanoseconds{cycle}};
+
+    EXPECT_EQ(0u, timer.pll().samples());
+
+    // A constant reference phase keeps the measured error at the learned target: the PLL stays
+    // quiet and eventually declares lock after lock_samples in-threshold cycles.
+    int64_t ref = 5000000;
+    for (uint32_t i = 0; i < SoftPll::Config{}.lock_samples; ++i)
+    {
+        timer.sync_to(static_cast<uint64_t>(ref));
+        ref += cycle;
+    }
+
+    EXPECT_EQ(SoftPll::Config{}.lock_samples, timer.pll().samples());
+    EXPECT_EQ(0, timer.pll().phase_error().count());
+    EXPECT_TRUE(timer.locked());
+}
+
+
+TEST(TimerPllTest, update_period_rebuilds_the_pll_on_the_new_grid)
+{
+    Timer timer{1ms};
+
+    timer.sync_to(5000000);
+    ASSERT_EQ(1u, timer.pll().samples());
+
+    // Changing the period invalidates the learned target phase: the PLL must start fresh.
+    timer.update_period(2ms);
+    EXPECT_EQ(0u, timer.pll().samples());
+    EXPECT_FALSE(timer.locked());
+}


### PR DESCRIPTION
* OS/Time: make seconds_f a double to avoid long-run precision loss
* marvin: 1 Hz PLL/DC telemetry with smoothed drift